### PR TITLE
Fix crash on iPad

### DIFF
--- a/StepicAdaptiveCourse/CongratulationViewController.swift
+++ b/StepicAdaptiveCourse/CongratulationViewController.swift
@@ -57,6 +57,7 @@ class CongratulationViewController: UIViewController {
         AnalyticsReporter.reportEvent(AnalyticsEvents.Adaptive.Achievement.shareClicked)
         let activityVC = UIActivityViewController(activityItems: [congratulationType.shareText, url], applicationActivities: nil)
         activityVC.excludedActivityTypes = [UIActivityType.airDrop]
+        activityVC.popoverPresentationController?.sourceView = shareButton
         present(activityVC, animated: true)
     }
     


### PR DESCRIPTION
# Fix crash on iPad
Фикс краша на айпадах из-за незаданного popoverPresentationController.sourceView у UIActivityViewController в диалоге о достижении уровня.