### PR TITLE
Perl to Code Quiz & unsupported language enhancements

### DIFF
--- a/Stepic/CodeLanguages.swift
+++ b/Stepic/CodeLanguages.swift
@@ -32,7 +32,7 @@ enum CodeLanguage: String {
     case kotlin = "kotlin"
     case go = "go"
     case pascal = "pascalabc"
-    case unsupported = "UNSUPPORTED_LANGUAGE"
+    case perl = "perl"
 
     var highlightr: String {
         switch self {
@@ -70,8 +70,8 @@ enum CodeLanguage: String {
             return "go"
         case .pascal:
             return "delphi"
-        case .unsupported:
-            return "cpp"
+        case .perl:
+            return "perl"
         }
     }
 

--- a/Stepic/CodeLimit.swift
+++ b/Stepic/CodeLimit.swift
@@ -12,8 +12,8 @@ import SwiftyJSON
 
 class CodeLimit: NSManagedObject {
 
-    var language: CodeLanguage {
-        return CodeLanguage(rawValue: languageString) ?? CodeLanguage.unsupported
+    var language: CodeLanguage? {
+        return CodeLanguage(rawValue: languageString)
     }
 
     convenience required init(language: String, json: JSON) {

--- a/Stepic/CodeQuizViewController.swift
+++ b/Stepic/CodeQuizViewController.swift
@@ -68,7 +68,7 @@ class CodeQuizViewController: QuizViewController {
         codeTextView.reloadInputViews()
     }
 
-    var language: CodeLanguage = CodeLanguage.unsupported {
+    var language: CodeLanguage! {
         didSet {
             textStorage.language = language.highlightr
             if let limit = step.options?.limit(language: language) {
@@ -240,10 +240,29 @@ class CodeQuizViewController: QuizViewController {
             setQuizControls(enabled: true)
         }
 
-        language = reply.language
-        codeTextView.text = reply.code
-        currentCode = reply.code
+        if let l = reply.language {
+            language = l
+            codeTextView.text = reply.code
+            currentCode = reply.code
+        } else {
+            setUnsupportedQuizView()
+        }
         hidePicker()
+    }
+
+    func setUnsupportedQuizView() {
+        let v = UIView()
+        v.backgroundColor = UIColor.groupTableViewBackground
+        let unsupportedLabel = UILabel()
+        unsupportedLabel.text = NSLocalizedString("NotSupportedLanguage", comment: "")
+        unsupportedLabel.textAlignment = .center
+        unsupportedLabel.numberOfLines = 0
+        unsupportedLabel.font = UIFont.systemFont(ofSize: 15)
+        unsupportedLabel.textColor = UIColor.gray
+        v.addSubview(unsupportedLabel)
+        unsupportedLabel.align(to: v)
+        self.containerView.addSubview(v)
+        v.align(to: self.containerView)
     }
 
     fileprivate func setQuizControls(enabled: Bool) {

--- a/Stepic/CodeReply.swift
+++ b/Stepic/CodeReply.swift
@@ -12,19 +12,22 @@ import SwiftyJSON
 class CodeReply: Reply {
 
     var code: String
-    var language: CodeLanguage
+    var language: CodeLanguage?
+    var languageName: String
 
     init(code: String, language: CodeLanguage) {
         self.code = code
         self.language = language
+        self.languageName = language.rawValue
     }
 
     required init(json: JSON) {
         code = json["code"].stringValue
-        language = CodeLanguage(rawValue: json["language"].stringValue) ?? .unsupported
+        languageName = json["language"].stringValue
+        language = CodeLanguage(rawValue: languageName)
     }
 
     var dictValue: [String : Any] {
-        return ["code": code, "language": language.rawValue]
+        return ["code": code, "language": languageName]
     }
 }

--- a/Stepic/CodeTemplate.swift
+++ b/Stepic/CodeTemplate.swift
@@ -12,8 +12,8 @@ import SwiftyJSON
 
 class CodeTemplate: NSManagedObject {
 
-    var language: CodeLanguage {
-        return CodeLanguage(rawValue: languageString) ?? CodeLanguage.unsupported
+    var language: CodeLanguage? {
+        return CodeLanguage(rawValue: languageString)
     }
 
     convenience required init(language: CodeLanguage, template: String) {

--- a/Stepic/FullscreenCodeQuizViewController.swift
+++ b/Stepic/FullscreenCodeQuizViewController.swift
@@ -68,7 +68,7 @@ class FullscreenCodeQuizViewController: UIViewController {
         codeTextView.reloadInputViews()
     }
 
-    var language: CodeLanguage = .unsupported {
+    var language: CodeLanguage! {
         didSet {
             textStorage.language = language.highlightr
 

--- a/Stepic/en.lproj/Localizable.strings
+++ b/Stepic/en.lproj/Localizable.strings
@@ -259,3 +259,4 @@ RetentionNotificationYesterdayZero = "You didn't score any points for yesterday.
 RetentionNotificationYesterdayStreak = "You have been learning %@ in a row. Go back and keep learning!";
 RetentionNotificationWeekly = "You haven't done it for a long time. Go back and keep learning!";
 SocialSignupWithExistingEmail = "This email is already used. To log in using this social account you have to log in via email and password";
+NotSupportedLanguage = "The language is not supported in the application yet";

--- a/Stepic/ru.lproj/Localizable.strings
+++ b/Stepic/ru.lproj/Localizable.strings
@@ -260,3 +260,5 @@ RetentionNotificationYesterdayZero = "За вчерашний день Вы ни
 RetentionNotificationYesterdayStreak = "Вы занимаетесь уже %@ подряд. Возвращайтесь и продолжайте учиться!";
 RetentionNotificationWeekly = "Вы давно не занимались. Возвращайтесь и продолжайте учиться!";
 SocialSignupWithExistingEmail = "Указанный email привязан к другому аккаунту. Чтобы входить через эту социальную сеть, необходимо войти, используя email и пароль";
+NotSupportedLanguage = "Язык не поддерживается в приложении";
+


### PR DESCRIPTION
**Задача**: [#1377](https://vyahhi.myjetbrains.com/youtrack/issue/1377) и [#1404](https://vyahhi.myjetbrains.com/youtrack/issue/1404)

**Коротко для Release Notes, в формате «Сделали/Добавили/Исправили N»**: 
Добавили Perl в Code Quiz, а так же неподдерживаемые языки теперь не отображаются (раньше отображался треш)

**Описание**:
Убрал `.unsupported` кейс из `CodeLanguage` и не отображаю неподдерживаемые языки в принципе (их нельзя выбрать в пикере или просмотреть submission). В дальнейшем можно придумать что-нибудь поумнее, но пока выглядит так. 
![simulator screen shot 17 2017 18 25 10](https://user-images.githubusercontent.com/6818370/29420305-45cedfde-837a-11e7-9d94-6214dc7a1131.png)
