### PR TITLE
Section progress update after solved step

### DIFF
--- a/Stepic/SectionsViewController.swift
+++ b/Stepic/SectionsViewController.swift
@@ -84,6 +84,12 @@ class SectionsViewController: UIViewController, ShareableController, UIViewContr
             self.refreshControl.beginRefreshing()
             self.tableView.contentOffset = offset
         }
+        if didRefresh {
+            course.loadProgressesForSections(sections: course.sections, success: {
+                [weak self] in
+                self?.tableView.reloadData()
+            }, error: {})
+        }
     }
 
     var emptyDatasetState: EmptyDatasetState = .empty {


### PR DESCRIPTION
**Задача**: [#APPS-1332](https://vyahhi.myjetbrains.com/youtrack/issue/APPS-1332)

**Коротко для Release Notes, в формате «Сделали/Добавили/Исправили N»**: 
Обновляем прогресс по секции после решения задания

**Описание**:
Просто делаю `loadProgressesForSections()` по `viewWillAppear`, если список секций уже прогружен
![section progress update](https://user-images.githubusercontent.com/6818370/29422102-d02015ea-837f-11e7-9b52-faa7ed39d198.gif)
