### PR TITLE
Fixed annoying selection of initial step with bad connection

### DIFF
--- a/Stepic/LessonPresenter.swift
+++ b/Stepic/LessonPresenter.swift
@@ -30,6 +30,9 @@ class LessonPresenter {
     fileprivate var unitId: Int?
     fileprivate var context: StepsControllerPresentationContext = .unit
 
+    var stepsAPI = ApiDataDownloader.steps
+    var lessonsAPI = ApiDataDownloader.lessons
+
     var shouldNavigateToPrev: Bool = false
     var shouldNavigateToNext: Bool = false
 
@@ -38,7 +41,7 @@ class LessonPresenter {
 
     fileprivate var canSendViews: Bool = false
 
-    init(objects: LessonInitObjects?, ids: LessonInitIds?) {
+    init(objects: LessonInitObjects?, ids: LessonInitIds?, stepsAPI: StepsAPI = ApiDataDownloader.steps, lessonsAPI: LessonsAPI = ApiDataDownloader.lessons) {
         if let objects = objects {
             self.lesson = objects.lesson
             self.startStepId = objects.startStepId
@@ -50,6 +53,8 @@ class LessonPresenter {
             self.context = .unit
         }
         LastStepGlobalContext.context.unitId = unitId
+        self.stepsAPI = stepsAPI
+        self.lessonsAPI = lessonsAPI
     }
 
     var url: String {
@@ -76,7 +81,8 @@ class LessonPresenter {
             }
         }
 
-        _ = ApiDataDownloader.steps.retrieve(ids: [stepId], existing: (step != nil) ? [step!] : [], refreshMode: .update, success: {
+        _ = stepsAPI.retrieve(ids: [stepId], existing: (step != nil) ? [step!] : [], refreshMode: .update, success: {
+            [weak self]
             steps in
 
             guard let step = steps.first else {
@@ -86,7 +92,7 @@ class LessonPresenter {
             var localLesson: Lesson? = nil
             localLesson = Lesson.getLesson(step.lessonId)
 
-            _ = ApiDataDownloader.lessons.retrieve(ids: [step.lessonId], existing: (localLesson != nil) ? [localLesson!] : [], refreshMode: .update, success: {
+            _ = self?.lessonsAPI.retrieve(ids: [step.lessonId], existing: (localLesson != nil) ? [localLesson!] : [], refreshMode: .update, success: {
                 [weak self]
                 lessons in
                 guard let lesson = lessons.first else {
@@ -242,7 +248,6 @@ class LessonPresenter {
             stepController.lessonSlug = lesson.slug
             stepController.nItem = self.view?.nItem
             stepController.nController = self.view?.nController
-
             if let assignments = lesson.unit?.assignments {
                 if index < assignments.count {
                     stepController.assignment = assignments[index]
@@ -252,6 +257,7 @@ class LessonPresenter {
             stepController.startStepBlock = {
                 [weak self] in
                 self?.canSendViews = true
+                self?.didSelectTab = true
             }
             stepController.shouldSendViewsBlock = {
                 [weak self] in
@@ -294,6 +300,7 @@ class LessonPresenter {
             stepController.startStepBlock = {
                 [weak self] in
                 self?.canSendViews = true
+                self?.didSelectTab = true
             }
             stepController.shouldSendViewsBlock = {
                 [weak self] in

--- a/Stepic/LessonPresenter.swift
+++ b/Stepic/LessonPresenter.swift
@@ -30,8 +30,8 @@ class LessonPresenter {
     fileprivate var unitId: Int?
     fileprivate var context: StepsControllerPresentationContext = .unit
 
-    var stepsAPI = ApiDataDownloader.steps
-    var lessonsAPI = ApiDataDownloader.lessons
+    var stepsAPI: StepsAPI
+    var lessonsAPI: LessonsAPI
 
     var shouldNavigateToPrev: Bool = false
     var shouldNavigateToNext: Bool = false
@@ -41,7 +41,7 @@ class LessonPresenter {
 
     fileprivate var canSendViews: Bool = false
 
-    init(objects: LessonInitObjects?, ids: LessonInitIds?, stepsAPI: StepsAPI = ApiDataDownloader.steps, lessonsAPI: LessonsAPI = ApiDataDownloader.lessons) {
+    init(objects: LessonInitObjects?, ids: LessonInitIds?, stepsAPI: StepsAPI, lessonsAPI: LessonsAPI) {
         if let objects = objects {
             self.lesson = objects.lesson
             self.startStepId = objects.startStepId

--- a/Stepic/LessonViewController.swift
+++ b/Stepic/LessonViewController.swift
@@ -95,7 +95,7 @@ class LessonViewController: PagerController, ShareableController, LessonView {
         navigationController?.navigationBar.shadowImage = UIImage()
         self.navigationItem.backBarButtonItem?.title = " "
 
-        presenter = LessonPresenter(objects: initObjects, ids: initIds)
+        presenter = LessonPresenter(objects: initObjects, ids: initIds, stepsAPI: ApiDataDownloader.steps, lessonsAPI: ApiDataDownloader.lessons)
         presenter?.view = self
         presenter?.sectionNavigationDelegate = sectionNavigationDelegate
         if let rules = navigationRules {

--- a/Stepic/QuizPresenter.swift
+++ b/Stepic/QuizPresenter.swift
@@ -15,9 +15,9 @@ class QuizPresenter {
     weak var view: QuizView?
 
     var step: Step
-    var submissionsAPI: SubmissionsAPI = ApiDataDownloader.submissions
-    var attemptsAPI: AttemptsAPI = ApiDataDownloader.attempts
-    var userActivitiesAPI: UserActivitiesAPI = ApiDataDownloader.userActivities
+    var submissionsAPI: SubmissionsAPI
+    var attemptsAPI: AttemptsAPI
+    var userActivitiesAPI: UserActivitiesAPI
     var alwaysCreateNewAttemptOnRefresh: Bool
 
     var state: QuizState = .nothing {
@@ -33,7 +33,7 @@ class QuizPresenter {
         return "\(StepicApplicationsInfo.stepicURL)/lesson/\(lesson.slug)/step/\(step.position)?from_mobile_app=true"
     }
 
-    init(view: QuizView, step: Step, dataSource: QuizControllerDataSource, alwaysCreateNewAttemptOnRefresh: Bool, submissionsAPI: SubmissionsAPI = ApiDataDownloader.submissions, attemptsAPI: AttemptsAPI = ApiDataDownloader.attempts, userActivitiesAPI: UserActivitiesAPI = ApiDataDownloader.userActivities) {
+    init(view: QuizView, step: Step, dataSource: QuizControllerDataSource, alwaysCreateNewAttemptOnRefresh: Bool, submissionsAPI: SubmissionsAPI, attemptsAPI: AttemptsAPI, userActivitiesAPI: UserActivitiesAPI) {
         self.view = view
         self.step = step
         self.dataSource = dataSource

--- a/Stepic/QuizViewController.swift
+++ b/Stepic/QuizViewController.swift
@@ -162,7 +162,7 @@ class QuizViewController: UIViewController, QuizView, QuizControllerDataSource {
         NotificationCenter.default.addObserver(self, selector: #selector(QuizViewController.becameActive), name:
             NSNotification.Name.UIApplicationWillEnterForeground, object: nil)
 
-        self.presenter = QuizPresenter(view: self, step: step, dataSource: self, alwaysCreateNewAttemptOnRefresh: needNewAttempt)
+        self.presenter = QuizPresenter(view: self, step: step, dataSource: self, alwaysCreateNewAttemptOnRefresh: needNewAttempt, submissionsAPI: ApiDataDownloader.submissions, attemptsAPI: ApiDataDownloader.attempts, userActivitiesAPI: ApiDataDownloader.userActivities)
         presenter?.delegate = self.delegate
         presenter?.refreshAttempt()
     }


### PR DESCRIPTION
**Задача**: [#APPS-1405](https://vyahhi.myjetbrains.com/youtrack/issue/APPS-1405)

**Коротко для Release Notes, в формате «Сделали/Добавили/Исправили N»**: 
При медленном соединении после обновления урока пользователь не перекидывается на первый таб.

**Описание**:
Добавил немного зависимостей в `LessonPresenter`, а так же исправил эту ошибку. Возможно, мы также этим пофиксим львиную долю крашей, которые приходятся на несвоевременный выбор таба.