### PR TITLE
Fix protocol-relative URLs

### DIFF
--- a/Stepic/HTMLBuilder.swift
+++ b/Stepic/HTMLBuilder.swift
@@ -89,6 +89,9 @@ class HTMLBuilder: NSObject {
     }
 
     func addStepikURLWhereNeeded(body: String) -> String {
+        var body = body
+        body = fixProtocolRelativeURLs(html: body)
+
         var links = HTMLParsingUtil.getAllLinksWithText(body).map({return $0.link})
         links += HTMLParsingUtil.getImageSrcLinks(body)
         var linkMap = [String: String]()
@@ -105,5 +108,9 @@ class HTMLBuilder: NSObject {
         }
 
         return newBody
+    }
+
+    func fixProtocolRelativeURLs(html: String) -> String {
+        return html.replacingOccurrences(of: "src=\"//", with: "src=\"http://")
     }
 }

--- a/Stepic/WebStepViewController.swift
+++ b/Stepic/WebStepViewController.swift
@@ -158,8 +158,6 @@ class WebStepViewController: UIViewController {
             return
         }
 
-        htmlText = htmlText.replacingOccurrences(of: "audio controls src=\"//", with: "audio controls src=\"http://")
-
         if step.block.name == "code" {
             for (index, sample) in (step.options?.samples ?? []).enumerated() {
                 htmlText += "<h4>Sample input \(index + 1)</h4>\(sample.input)<h4>Sample output \(index + 1)</h4>\(sample.output)"


### PR DESCRIPTION
**Задача**: [#APPS-1409](https://vyahhi.myjetbrains.com/youtrack/issue/APPS-1409)

**Коротко для Release Notes, в формате «Сделали/Добавили/Исправили N»**: 
Исправлен баг с картинками, которые загружаются по protocol-relative ссылкам

**Описание**:
Фикс из #78 немного изменен (теперь меняем все `src="//`) и перемещен в функцию которую юзают оба приложения.