### PR TITLE
Removed setting a label with plain text while LaTeX rendering

### DIFF
--- a/Stepic/ChoiceQuizTableViewCell.swift
+++ b/Stepic/ChoiceQuizTableViewCell.swift
@@ -71,24 +71,22 @@ extension ChoiceQuizTableViewCell {
 
     //All optimization logics is now encapsulated here
     func setHTMLText(_ text: String, width: CGFloat, finishedBlock: @escaping (CGFloat) -> Void) {
-        initLabel()
-        optionLabel?.isHidden = false
-        optionLabel?.setTextWithHTMLString(text)
         if TagDetectionUtil.isWebViewSupportNeeded(text) {
             initWebView()
-            optionWebView?.isHidden = true
+            optionWebView?.isHidden = false
             webViewHelper?.mathJaxFinishedBlock = {
                 [weak self] in
                 self?.layoutIfNeeded()
                 if let webView = self?.optionWebView {
                     webView.invalidateIntrinsicContentSize()
-                    self?.optionLabel?.isHidden = true
-                    self?.optionWebView?.isHidden = false
                     finishedBlock(17 + webView.contentHeight)
                 }
             }
             webViewHelper?.setTextWithTeX(text)
         } else {
+            initLabel()
+            optionLabel?.setTextWithHTMLString(text)
+            optionLabel?.isHidden = false
             let height = ChoiceQuizTableViewCell.getHeightForText(text: text, width: width)
             finishedBlock(height)
         }

--- a/Stepic/SortingQuizTableViewCell.swift
+++ b/Stepic/SortingQuizTableViewCell.swift
@@ -71,24 +71,22 @@ extension SortingQuizTableViewCell {
 
     //All optimization logics is now encapsulated here
     func setHTMLText(_ text: String, width: CGFloat, finishedBlock: @escaping (CGFloat) -> Void) {
-        initLabel()
-        optionLabel?.isHidden = false
-        optionLabel?.setTextWithHTMLString(text)
         if TagDetectionUtil.isWebViewSupportNeeded(text) {
             initWebView()
-            optionWebView?.isHidden = true
+            optionWebView?.isHidden = false
             webViewHelper?.mathJaxFinishedBlock = {
                 [weak self] in
                 self?.layoutIfNeeded()
                 if let webView = self?.optionWebView {
                     webView.invalidateIntrinsicContentSize()
-                    self?.optionLabel?.isHidden = true
-                    self?.optionWebView?.isHidden = false
                     finishedBlock(17 + webView.contentHeight)
                 }
             }
             webViewHelper?.setTextWithTeX(text)
         } else {
+            initLabel()
+            optionLabel?.setTextWithHTMLString(text)
+            optionLabel?.isHidden = false
             let height = SortingQuizTableViewCell.getHeightForText(text: text, width: width, sortable: self.sortable)
             finishedBlock(height)
         }


### PR DESCRIPTION
**Задача**: [#APPS-1415](https://vyahhi.myjetbrains.com/youtrack/issue/APPS-1415)

**Коротко для Release Notes, в формате «Сделали/Добавили/Исправили N»**: 
Возможно, пофиксили самый популярный краш из crashlytics 🎉 

**Описание**:
Убрали UILabel во время рендеринга LaTeX для Choice, Sorting и Matching квизов
