### PR TITLE
Fixed limited submissions long button text bug

### DIFF
--- a/Stepic/QuizViewController.swift
+++ b/Stepic/QuizViewController.swift
@@ -324,8 +324,8 @@ class QuizViewController: UIViewController, QuizView, QuizControllerDataSource {
     }
 
     func update(limit: SubmissionLimitation?) {
+        updateSendButtonWithoutLimit()
         guard let limit = limit else {
-            updateSendButtonWithoutLimit()
             return
         }
 


### PR DESCRIPTION
**Задача**: [#APPS-1406](https://vyahhi.myjetbrains.com/youtrack/issue/APPS-1406)

**Коротко для Release Notes, в формате «Сделали/Добавили/Исправили N»**: 
Для шагов с ограничением попыток после рефакторинга текст не всегда влезал в кнопку. Теперь влезает.

**Описание**:
Send button title сбрасывается теперь каждый раз в `update(limit:)`, а не только в случае, если `limit == nil`