### PR TITLE
Adaptive rate dialog

### DIFF
--- a/Stepic/QuizViewController.swift
+++ b/Stepic/QuizViewController.swift
@@ -379,9 +379,9 @@ class QuizViewController: UIViewController, QuizView, QuizControllerDataSource {
     }
 
     func showRateAlert() {
+        Alerts.rate.present(alert: Alerts.rate.construct(lessonProgress: positionPercentageString), inController: self)
         if let cnt = step.lesson?.stepsArray.count {
             let positionPercentageString = String(format: "%.02f", cnt != 0 ? Double(step.position) / Double(cnt) : -1)
-            Alerts.rate.present(alert: Alerts.rate.construct(lessonProgress: positionPercentageString), inController: self)
         }
     }
 

--- a/Stepic/QuizViewController.swift
+++ b/Stepic/QuizViewController.swift
@@ -379,10 +379,11 @@ class QuizViewController: UIViewController, QuizView, QuizControllerDataSource {
     }
 
     func showRateAlert() {
-        Alerts.rate.present(alert: Alerts.rate.construct(lessonProgress: positionPercentageString), inController: self)
+        var positionPercentageString: String? = nil
         if let cnt = step.lesson?.stepsArray.count {
-            let positionPercentageString = String(format: "%.02f", cnt != 0 ? Double(step.position) / Double(cnt) : -1)
+            positionPercentageString = String(format: "%.02f", cnt != 0 ? Double(step.position) / Double(cnt) : -1)
         }
+        Alerts.rate.present(alert: Alerts.rate.construct(lessonProgress: positionPercentageString), inController: self)
     }
 
     func logout(onClose: (() -> Void)?) {


### PR DESCRIPTION
**Задача**: [#APPS-1447](https://vyahhi.myjetbrains.com/youtrack/issue/APPS-1447)

**Коротко для Release Notes, в формате «Сделали/Добавили/Исправили N»**: 
Теперь rate app диалог появляется, как и должен был.

**Описание**:
Из-за аналитики сломалось. У step-ов в адаптивных аппах нет загруженного lesson-а, поэтому алерт не мог понять, какое отношение `step.position / step.lesson.stepsArray.count`