### PR TITLE
Fixed getReply() crash in Code Quiz

### DIFF
--- a/Stepic/CodeQuizViewController.swift
+++ b/Stepic/CodeQuizViewController.swift
@@ -289,7 +289,10 @@ class CodeQuizViewController: QuizViewController {
     }
 
     override func getReply() -> Reply? {
-        return CodeReply(code: codeTextView.text ?? "", language: language)
+        guard let language = language, let code = codeTextView.text else {
+            return nil
+        }
+        return CodeReply(code: code, language: language)
     }
 
     override func didReceiveMemoryWarning() {


### PR DESCRIPTION
**Задача**: [#APPS-1450](https://vyahhi.myjetbrains.com/youtrack/issue/APPS-1450)

**Коротко для Release Notes, в формате «Сделали/Добавили/Исправили N»**: 
Исправили ошибку, иногда приводящую к вылету приложения в Code Quiz. 

**Описание**:
Там был force unwrapped optional, пришлось его хорошо обрабатывать в `getReply()`
Ссылка на баг в крашлитикс: https://fabric.io/alexander-karpovs-projects3/ios/apps/com.alexkarpov.stepic/issues/59a82718be077a4dcce4c5e1?time=last-seven-days