### PR TITLE
Fixed URL autocorrection bug

### DIFF
--- a/Stepic/HTMLBuilder.swift
+++ b/Stepic/HTMLBuilder.swift
@@ -104,7 +104,7 @@ class HTMLBuilder: NSObject {
 
         var newBody = body
         for (key, val) in linkMap {
-            newBody = newBody.replacingOccurrences(of: key, with: val)
+            newBody = newBody.replacingOccurrences(of: "\"\(key)", with: "\"\(val)")
         }
 
         return newBody


### PR DESCRIPTION
**Задача**: [#APPS-1542](https://vyahhi.myjetbrains.com/youtrack/issue/#APPS-1542)

**Коротко для Release Notes, в формате «Сделали/Добавили/Исправили N»**: 
Исправили баг при автокоррекции URL

**Описание**:
Раньше исправляли все вхождения URL-а, начинающегося с `/` на URL с `https://stepik.org`. Это приводило к тому, что исправлялся URL не только в `href=` и прочих тегах, но и в тексте. Теперь исправляем только вхождения, начинающиеся с кавычки.