### PR TITLE
Code Quiz iOS 11 fixes

### DIFF
--- a/Stepic/CodePlaygroundManager.swift
+++ b/Stepic/CodePlaygroundManager.swift
@@ -309,8 +309,12 @@ class CodePlaygroundManager {
 
             let analyzed = analyze(currentText: textView.text, previousText: previousText, cursorPosition: cursorPosition, language: language, tabSize: tabSize)
 
-            textView.text = analyzed.text
-            textView.selectedTextRange = textRangeFrom(position: analyzed.position, textView: textView)
+            if textView.text != analyzed.text {
+                textView.text = analyzed.text
+            }
+            if textView.selectedTextRange != textRangeFrom(position: analyzed.position, textView: textView) {
+                textView.selectedTextRange = textRangeFrom(position: analyzed.position, textView: textView)
+            }
             if let autocomplete = analyzed.autocomplete {
                 if autocomplete.suggestions.count == 0 {
                     hideSuggestions()

--- a/Stepic/CodeQuizViewController.swift
+++ b/Stepic/CodeQuizViewController.swift
@@ -70,7 +70,9 @@ class CodeQuizViewController: QuizViewController {
 
     var language: CodeLanguage! {
         didSet {
-            textStorage.language = language.highlightr
+            if language != oldValue {
+                textStorage.language = language.highlightr
+            }
             if let limit = step.options?.limit(language: language) {
                 setLimits(time: limit.time, memory: limit.memory)
             }
@@ -84,12 +86,16 @@ class CodeQuizViewController: QuizViewController {
             setupAccessoryView(editable: submissionStatus != .correct)
 
             if let userTemplate = step.options?.template(language: language, userGenerated: true) {
-                codeTextView.text = userTemplate.templateString
+                if codeTextView.text != userTemplate.templateString {
+                    codeTextView.text = userTemplate.templateString
+                }
                 currentCode = userTemplate.templateString
                 return
             }
             if let template = step.options?.template(language: language, userGenerated: false) {
-                codeTextView.text = template.templateString
+                if codeTextView.text != template.templateString {
+                    codeTextView.text = template.templateString
+                }
                 currentCode = template.templateString
                 return
             }
@@ -177,6 +183,11 @@ class CodeQuizViewController: QuizViewController {
         }
     }
 
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        toolbarView.layoutSubviews()
+    }
+
     func hidePicker() {
         languagePicker.removeFromParentViewController()
         languagePicker.view.removeFromSuperview()
@@ -214,6 +225,8 @@ class CodeQuizViewController: QuizViewController {
             return
         }
 
+        self.submissionStatus = nil
+
         setQuizControls(enabled: true)
 
         if options.languages.count > 1 {
@@ -232,8 +245,8 @@ class CodeQuizViewController: QuizViewController {
         }
 
         self.reply = reply
-        display(reply: reply)
         self.submissionStatus = status
+        display(reply: reply)
 
         if status == .correct {
             setQuizControls(enabled: false)
@@ -250,7 +263,9 @@ class CodeQuizViewController: QuizViewController {
 
         if let l = reply.language {
             language = l
-            codeTextView.text = reply.code
+            if codeTextView.text != reply.code {
+                codeTextView.text = reply.code
+            }
             currentCode = reply.code
         } else {
             setUnsupportedQuizView()

--- a/Stepic/CodeQuizViewController.swift
+++ b/Stepic/CodeQuizViewController.swift
@@ -151,6 +151,7 @@ class CodeQuizViewController: QuizViewController {
         codeTextView.autoresizingMask = [.flexibleHeight, .flexibleWidth]
         codeTextView.autocorrectionType = UITextAutocorrectionType.no
         codeTextView.autocapitalizationType = UITextAutocapitalizationType.none
+        codeTextView.keyboardType = UIKeyboardType.asciiCapable
         codeTextView.textColor = UIColor(white: 0.8, alpha: 1.0)
         highlightr = textStorage.highlightr
         highlightr.setTheme(to: "Androidstudio")

--- a/Stepic/FullscreenCodeQuizViewController.swift
+++ b/Stepic/FullscreenCodeQuizViewController.swift
@@ -109,6 +109,7 @@ class FullscreenCodeQuizViewController: UIViewController {
         codeTextView.autoresizingMask = [.flexibleHeight, .flexibleWidth]
         codeTextView.autocorrectionType = UITextAutocorrectionType.no
         codeTextView.autocapitalizationType = UITextAutocapitalizationType.none
+        codeTextView.keyboardType = UIKeyboardType.asciiCapable
         codeTextView.textColor = UIColor(white: 0.8, alpha: 1.0)
         highlightr = textStorage.highlightr
         highlightr.setTheme(to: "Androidstudio")

--- a/Stepic/SocialAuthPresenter.swift
+++ b/Stepic/SocialAuthPresenter.swift
@@ -126,7 +126,7 @@ class SocialAuthPresenter {
                 self.view?.update(with: .success)
             }, error: { _ in
                 print("social auth: successfully signed in, but could not get user")
-                
+
                 AnalyticsReporter.reportEvent(AnalyticsEvents.Login.success, parameters: ["provider": "social"])
                 self.view?.update(with: .success)
             })


### PR DESCRIPTION
**Задача**: [#APPS-1496](https://vyahhi.myjetbrains.com/youtrack/issue/APPS-1496)

**Коротко для Release Notes, в формате «Сделали/Добавили/Исправили N»**: 
Убрали автозамену кавычек и ускорили рендеринг

**Описание**:
Теперь не заменяем текст (и не перерендериваем TextView) когда присваивается тот же текст, который был.
Также UITextView теперь не заменяет кавычки. 