### PR TITLE
Fix hint text color

### DIFF
--- a/Stepic/CellWebViewHelper.swift
+++ b/Stepic/CellWebViewHelper.swift
@@ -32,7 +32,7 @@ class CellWebViewHelper: NSObject {
     func setTextWithTeX(_ text: String, color: UIColor = UIColor.black) {
         let scriptsString = "\(Scripts.localTexScript)\(Scripts.mathJaxFinishedScript)"
         let textColorHex = "#\(color.hexString)"
-        let html = HTMLBuilder.sharedBuilder.buildHTMLStringWith(head: scriptsString, body: text, addStyle: true, textColorHex: textColorHex)
+        let html = HTMLBuilder.sharedBuilder.buildHTMLStringWith(head: scriptsString, body: text, textColor: UIColor.white)
         webView?.delegate = self
         webView?.loadHTMLString(html, baseURL: URL(fileURLWithPath: Bundle.main.bundlePath))
     }

--- a/Stepic/HTMLBuilder.swift
+++ b/Stepic/HTMLBuilder.swift
@@ -12,9 +12,9 @@ class HTMLBuilder: NSObject {
     fileprivate override init() {}
     static var sharedBuilder = HTMLBuilder()
 
-    fileprivate var stepicStyleString: String {
+    private func stepicStyleString(textColor: UIColor) -> String {
         var res: String = ""
-        let colorHexString = UIColor.mainText.hexString
+        let colorHexString = textColor.hexString
         res += "<style>"
         res += "\nhtml{-webkit-text-size-adjust: 100%;}"
         res += "\nbody{font-size: 12pt; font-family:Arial, Helvetica, sans-serif; line-height:1.6em; color: #\(colorHexString); }"
@@ -52,11 +52,16 @@ class HTMLBuilder: NSObject {
 
     fileprivate var stepicBaseURLString: String = ""//"<base href=\"\(StepicApplicationsInfo.stepicURL)\">"
 
-    func buildHTMLStringWith(head: String, body: String, addStepicFont: Bool = true, width: Int) -> String {
+    func buildHTMLStringWith(head: String, body: String, width: Int? = nil, textColor: UIColor = UIColor.mainText) -> String {
         var res = "<html>\n"
 
-        res += "<head>\n\(stepicStyleString + stepicBaseURLString + head)\n</head>\n"
-        res += "<body style=\"width:\(width))px;\">\n\(addStepikURLWhereNeeded(body: body))\n</body>\n"
+        res += "<head>\n\(stepicStyleString(textColor: textColor) + stepicBaseURLString + head)\n</head>\n"
+
+        if let width = width {
+            res += "<body style=\"width:\(width))px;\">\n\(addStepikURLWhereNeeded(body: body))\n</body>\n"
+        } else {
+            res += "<body>\n\(addStepikURLWhereNeeded(body: body))\n</body>\n"
+        }
 
         res += "</html>"
         return res
@@ -68,21 +73,6 @@ class HTMLBuilder: NSObject {
         res += "<head>\n\(stepicCommentStyleString + head)\n</head>\n"
 
         let bodyOpenTag = "<body>"
-        res += "\(bodyOpenTag)\n\(addStepikURLWhereNeeded(body: body))\n</body>\n"
-
-        res += "</html>"
-        return res
-    }
-
-    func buildHTMLStringWith(head: String, body: String, addStyle: Bool = false, textColorHex: String = "#000000") -> String {
-        var res = "<html>\n"
-
-        if addStyle {
-            res += "<head>\n\(stepicStyleString + head)\n</head>\n"
-        } else {
-            res += "<head>\n\(head)\n</head>\n"
-        }
-        let bodyOpenTag = "<body text=\"\(textColorHex)\">"
         res += "\(bodyOpenTag)\n\(addStepikURLWhereNeeded(body: body))\n</body>\n"
 
         res += "</html>"


### PR DESCRIPTION
**Коротко для Release Notes, в формате «Сделали/Добавили/Исправили N»**: 
После изменения цветов те хинты, для отображения которых требуется UIWebView, перестали правильно работать. Теперь работают хорошо.

**Описание**:
Отрефакторил немного `HTMLBuilder`, проблема была в нем.
Теперь стало на один странный `build()` метод меньше.