### PR TITLE
Fixed download button in video step

### DIFF
--- a/Stepic/VideoStepViewController.swift
+++ b/Stepic/VideoStepViewController.swift
@@ -10,6 +10,7 @@ import UIKit
 import MediaPlayer
 import SVProgressHUD
 import DownloadButton
+import FLKAutoLayout
 
 class VideoStepViewController: UIViewController {
 
@@ -154,13 +155,16 @@ class VideoStepViewController: UIViewController {
     }
 
     var itemView: VideoDownloadView!
-
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
 
-        itemView = VideoDownloadView(frame: CGRect(x: 0, y: 0, width: 100, height: 30), video: video, buttonDelegate: self, downloadDelegate: self)
+        itemView = VideoDownloadView(frame: CGRect(x: 0, y: 0, width: 100, height: 40), video: video, buttonDelegate: self, downloadDelegate: self)
+        
+        itemView.constrainHeight("40")
+        itemView.constrainWidth("100")
+        let downloadItem = UIBarButtonItem(customView: itemView)
         let shareBarButtonItem = UIBarButtonItem(barButtonSystemItem: UIBarButtonSystemItem.action, target: self, action: #selector(VideoStepViewController.sharePressed(_:)))
-        nItem.rightBarButtonItems = [shareBarButtonItem, UIBarButtonItem(customView: itemView)]
+        nItem.rightBarButtonItems = [shareBarButtonItem, downloadItem]
     }
 
     override func didReceiveMemoryWarning() {

--- a/Stepic/VideoStepViewController.swift
+++ b/Stepic/VideoStepViewController.swift
@@ -159,7 +159,7 @@ class VideoStepViewController: UIViewController {
         super.viewWillAppear(animated)
 
         itemView = VideoDownloadView(frame: CGRect(x: 0, y: 0, width: 100, height: 40), video: video, buttonDelegate: self, downloadDelegate: self)
-        
+
         itemView.constrainHeight("40")
         itemView.constrainWidth("100")
         let downloadItem = UIBarButtonItem(customView: itemView)


### PR DESCRIPTION
**Задача**: [#APPS-1501](https://vyahhi.myjetbrains.com/youtrack/issue/APPS-1501)

**Коротко для Release Notes, в формате «Сделали/Добавили/Исправили N»**: 
Теперь можно нажать на кнопку загрузки в видео степе

**Описание**:
Выяснилось, что теперь `UINavigationBar` использует AutoLayout. Добавил констрейнты на ширину и высоту вьюшки и все заработало.