### PR TITLE
Fixed iOS 11 AppStore rate bug

### DIFF
--- a/Stepic/RateAppViewController.swift
+++ b/Stepic/RateAppViewController.swift
@@ -10,6 +10,7 @@ import UIKit
 import MessageUI
 import Presentr
 import FLKAutoLayout
+import StoreKit
 
 class RateAppViewController: UIViewController {
 
@@ -143,11 +144,16 @@ class RateAppViewController: UIViewController {
 
     func showAppStore() {
         AnalyticsReporter.reportEvent(AnalyticsEvents.Rate.Positive.appstore, parameters: defaultAnalyticsParams)
-        guard let appStoreURL = StepicApplicationsInfo.RateApp.appStoreURL else {
-            return
-        }
-        UIApplication.shared.openURL(appStoreURL)
-        self.dismiss(animated: true, completion: nil)
+        self.dismiss(animated: true, completion: {
+            if #available(iOS 11, *) {
+                SKStoreReviewController.requestReview()
+            } else {
+                guard let appStoreURL = StepicApplicationsInfo.RateApp.appStoreURL else {
+                    return
+                }
+                UIApplication.shared.openURL(appStoreURL)
+            }
+        })
     }
 
     override func didReceiveMemoryWarning() {


### PR DESCRIPTION
**Задача**: [#APPS-1510](https://vyahhi.myjetbrains.com/youtrack/issue/APPS-1510)

**Коротко для Release Notes, в формате «Сделали/Добавили/Исправили N»**: 
Теперь можно оценить приложение в AppStore по предложению внутри приложения и на iOS 11.

**Описание**:
Теперь используем `StoreKit` для iOS 11, чтобы показывать рейт диалог.