### PR TITLE
Send submission_created to analytics

### DIFF
--- a/Stepic/AnalyticsEvents.swift
+++ b/Stepic/AnalyticsEvents.swift
@@ -87,6 +87,7 @@ struct AnalyticsEvents {
             static let submit = "clicked_submit"
             static let newAttempt = "clicked_generate_new_attempt"
             static let solveInWebPressed = "clicked_solve_in_web"
+            static let created = "submission_created"
         }
 
         static let hasRestrictions = "step_with_submission_restriction"

--- a/Stepic/Block+CoreDataProperties.swift
+++ b/Stepic/Block+CoreDataProperties.swift
@@ -32,7 +32,7 @@ extension Block {
 
     var name: String {
         get {
-            return managedName ?? "no name"
+            return managedName ?? "undefined"
         }
         set(value) {
             managedName = value

--- a/Stepic/QuizPresenter.swift
+++ b/Stepic/QuizPresenter.swift
@@ -318,6 +318,9 @@ class QuizPresenter {
                 [weak self]
                 submission in
                 guard let s = self else { return }
+
+                AnalyticsReporter.reportEvent(AnalyticsEvents.Step.Submission.created, parameters: ["type": s.step.block.name])
+
                 s.submission = submission
                 s.checkSubmission(submission.id!, time: 0, completion: completion)
             }, error: {


### PR DESCRIPTION
**Задача**: [#APPS-1492](https://vyahhi.myjetbrains.com/youtrack/issue/APPS-1492)

**Коротко для Release Notes, в формате «Сделали/Добавили/Исправили N»**: 
Событие submission_created для аналитики.

**Описание**:
Шлём submission_created, когда POST /api/submissions создан.