### PR TITLE
HTML in UILabel

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -39,7 +39,7 @@ def all_pods
     
     pod 'SVGKit', :git => 'https://github.com/SVGKit/SVGKit.git', :branch => '2.x'
     
-    pod 'Presentr'
+    pod 'Presentr', '1.2.3'
     
     pod 'Agrume', :git => 'https://github.com/Ostrenkiy/Agrume.git', :branch => 'feature/single-horizontal-dismiss'
     pod 'Highlightr'

--- a/Podfile
+++ b/Podfile
@@ -44,6 +44,7 @@ def all_pods
     pod 'Agrume', :git => 'https://github.com/Ostrenkiy/Agrume.git', :branch => 'feature/single-horizontal-dismiss'
     pod 'Highlightr'
     pod "RFKeyboardToolbar", "~> 1.3"
+    pod 'Atributika', '~> 3.0' # update after migration to Swift 4
 end
 
 def testing_pods

--- a/Stepic/HTMLParsingUtil.swift
+++ b/Stepic/HTMLParsingUtil.swift
@@ -95,4 +95,14 @@ class HTMLParsingUtil {
             return []
         }
     }
+    
+    static func getAllHTMLTags(_ htmlString: String) -> [String] {
+        if let doc = Kanna.HTML(html: htmlString, encoding: String.Encoding.utf8) {
+            let nodes = doc.css("*")
+            // Drop 2 first tags: html & body added by Kanna
+            return Array(nodes.flatMap { $0.tagName }.dropFirst(2))
+        } else {
+            return []
+        }
+    }
 }

--- a/Stepic/LabelExtension.swift
+++ b/Stepic/LabelExtension.swift
@@ -7,20 +7,21 @@
 //
 
 import UIKit
+import Atributika
 
 extension UILabel {
     func setTextWithHTMLString(_ htmlText: String) {
-        guard let encodedData = htmlText.data(using: .unicode) else {
-            self.text = ""
-            return
-        }
+        let currentFontSize = self.font.pointSize
 
-        guard let attributedDescription = try? NSMutableAttributedString(data: encodedData, options: [NSDocumentTypeDocumentAttribute: NSHTMLTextDocumentType], documentAttributes: nil) else {
-            self.text = ""
-            return
-        }
+        let attributedString = htmlText.style(tags: [
+            Style("b").font(.boldSystemFont(ofSize: currentFontSize)),
+            Style("strong").font(.boldSystemFont(ofSize: currentFontSize)),
+            Style("i").font(.italicSystemFont(ofSize: currentFontSize)),
+            Style("em").font(.italicSystemFont(ofSize: currentFontSize)),
+            Style("strike").strikethroughStyle(.styleSingle)
+        ]).attributedString
 
-        self.text = attributedDescription.string
+        self.attributedText = attributedString
     }
 
     class func heightForLabelWithText(_ text: String, lines: Int, fontName: String, fontSize: CGFloat, width: CGFloat, html: Bool = false, alignment: NSTextAlignment = NSTextAlignment.natural) -> CGFloat {

--- a/Stepic/TagDetectionUtil.swift
+++ b/Stepic/TagDetectionUtil.swift
@@ -8,26 +8,27 @@
 
 import Foundation
 
-/*
- Utility class for detecting tags in html string
- */
 class TagDetectionUtil {
-    fileprivate init() {}
-
+    static let supportedHtmlTagsForLabel = ["b", "strong", "i", "em", "strike"]
+    
     static func isWebViewSupportNeeded(_ htmlString: String) -> Bool {
-        return detectLaTeX(htmlString) || detectImage(htmlString) || detectCode(htmlString)
+        return detectLaTeX(htmlString) || detectUnsupportedTags(htmlString)
     }
 
-    //POSSIBLY detects LaTeX in html string
+    // POSSIBLY detects LaTeX in html string
     static func detectLaTeX(_ htmlString: String) -> Bool {
         return htmlString.characters.filter({$0 == "$"}).count >= 2 || (htmlString.range(of: "\\[") != nil && htmlString.range(of: "\\]") != nil)
     }
 
     static func detectImage(_ htmlString: String) -> Bool {
-        return  HTMLParsingUtil.getImageSrcLinks(htmlString).count > 0
+        return HTMLParsingUtil.getImageSrcLinks(htmlString).count > 0
     }
 
     static func detectCode(_ htmlString: String) -> Bool {
         return HTMLParsingUtil.getCodeStrings(htmlString).count > 0
+    }
+    
+    static func detectUnsupportedTags(_ htmlString: String) -> Bool {
+        return HTMLParsingUtil.getAllHTMLTags(htmlString).filter { !supportedHtmlTagsForLabel.contains($0) }.count > 0
     }
 }


### PR DESCRIPTION
**Задача**: [#APPS-1526](https://vyahhi.myjetbrains.com/youtrack/issue/APPS-1526)

**Коротко для Release Notes, в формате «Сделали/Добавили/Исправили N»**: 
Отображаем в UILabel html

**Описание**:
До этого html в UILabel не отображался в принципе (при этом, рендерился в NSAttributedString и постоянно крашился). Теперь отображаем некоторое множество тегов для форматирования текста.
Ещё подробнее в [APPS-1482](https://vyahhi.myjetbrains.com/youtrack/issue/APPS-1482).