### PR TITLE
Bump fastlane version

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -11,7 +11,7 @@
 
 # This is the minimum version number required.
 # Update this, if you use features of a newer version
-fastlane_version "2.23.0"
+fastlane_version "2.61.0"
 
 default_platform :ios
 


### PR DESCRIPTION
**Коротко для Release Notes, в формате «Сделали/Добавили/Исправили N»**: 
Исправили падающие тесты

**Описание**:
При добавлении новых подов с актуальными версиями, тесты падают из-за того, что fastlane запускает pod install без обновления репов. В fastlane 2.61.0 в экшн *cocoapods* добавили опцию `try_repo_update_on_error` (*true* по дефолту)  – кажется, это то, что нам нужно.