### PR TITLE
Fix tags detection

### DIFF
--- a/Stepic/HTMLParsingUtil.swift
+++ b/Stepic/HTMLParsingUtil.swift
@@ -97,10 +97,11 @@ class HTMLParsingUtil {
     }
     
     static func getAllHTMLTags(_ htmlString: String) -> [String] {
-        if let doc = Kanna.HTML(html: htmlString, encoding: String.Encoding.utf8) {
+        if let doc = Kanna.HTML(html: "<html><body>\(htmlString)</body></html>", encoding: String.Encoding.utf8) {
             let nodes = doc.css("*")
-            // Drop 2 first tags: html & body added by Kanna
-            return Array(nodes.flatMap { $0.tagName }.dropFirst(2))
+            // Drop 2 first tags: html, body
+            let tags = Array(nodes.flatMap { $0.tagName }.dropFirst(2))
+            return tags
         } else {
             return []
         }


### PR DESCRIPTION
**Коротко для Release Notes, в формате «Сделали/Добавили/Исправили N»**: 
Хотфикс детекта html тегов

**Описание**:
В TagDetectionUtil неверно детектились html теги: Kanna добавляет тег `<p>` в некоторых случаях. Из-за этого всегда отображалась WebView, а не Label.