### PR TITLE
Remove 'opened' state for notification

### DIFF
--- a/Stepic/Notification.swift
+++ b/Stepic/Notification.swift
@@ -25,7 +25,7 @@ class Notification: NSManagedObject, JSONInitializable {
         isMuted = json["is_muted"].boolValue
         isFavorite = json["is_favorite"].boolValue
 
-        managedStatus = json["is_unread"].boolValue ? NotificationStatus.unread.rawValue : NotificationStatus.opened.rawValue
+        managedStatus = json["is_unread"].boolValue ? NotificationStatus.unread.rawValue : NotificationStatus.read.rawValue
         managedType = json["type"].stringValue
         managedAction = json["action"].stringValue
 
@@ -60,7 +60,6 @@ class Notification: NSManagedObject, JSONInitializable {
 enum NotificationStatus: String {
     case unread = "unread"
     case read = "read"
-    case opened = "opened"
 }
 
 enum NotificationType: String {

--- a/Stepic/NotificationStatusButton.swift
+++ b/Stepic/NotificationStatusButton.swift
@@ -12,7 +12,7 @@ class NotificationStatusButton: UIButton {
     var unreadMark: UIView?
 
     enum Status {
-        case unread, opened, read
+        case unread, read
     }
 
     var status: Status = .read
@@ -60,15 +60,10 @@ class NotificationStatusButton: UIButton {
                 self.unreadMark?.alpha = 1.0
             })
         case .read:
-            self.setImage(#imageLiteral(resourceName: "notifications-letter-sign"), for: .normal)
-            if status == .unread {
-                // unread -> read: hide mark
-                unreadMarkAnimation()
-            }
-        case .opened:
             self.setImage(#imageLiteral(resourceName: "notifications-check-sign"), for: .normal)
             self.isEnabled = false
             if status == .unread {
+                // unread -> read: hide mark
                 unreadMarkAnimation()
             }
         }

--- a/Stepic/NotificationsAPI.swift
+++ b/Stepic/NotificationsAPI.swift
@@ -64,15 +64,7 @@ class NotificationsAPI {
                     newNotifications.append(Notification(json: objectJSON))
                 default:
                     let obj = existing[0]
-
-                    let oldStatus = obj.status
-                    let isUnreadFetched = objectJSON["is_unread"].boolValue
                     obj.update(json: objectJSON)
-
-                    // Save read status
-                    if oldStatus == .read && isUnreadFetched {
-                        obj.status = .read
-                    }
                     newNotifications.append(obj)
                 }
             }
@@ -111,7 +103,6 @@ class NotificationsAPI {
                 return
             }
 
-            // Update notification, but save read status
             notification.update(json: json["notifications"].arrayValue[0])
             success(notification)
 

--- a/Stepic/NotificationsPresenter.swift
+++ b/Stepic/NotificationsPresenter.swift
@@ -239,39 +239,35 @@ class NotificationsPresenter {
             return
         }
 
-        if status == .opened {
-            // TODO: ugly performRequest() call
-            performRequest({
-                self.notificationsAPI.update(notification, success: { _ in
-                    notification.status = status
-                    CoreDataHelper.instance.save()
-                }, error: { err in
-                    print("notifications: unable to update notification with id = \(id), error = \(err)")
-                })
+        notification.status = status
+        // TODO: ugly performRequest() call
+        performRequest({
+            self.notificationsAPI.update(notification, success: { _ in
+                CoreDataHelper.instance.save()
+            }, error: { err in
+                print("notifications: unable to update notification with id = \(id), error = \(err)")
             })
-        } else {
-            notification.status = status
-            CoreDataHelper.instance.save()
-        }
+        })
     }
 
     func markAllAsRead() {
         view?.updateMarkAllAsReadButton(with: .loading)
 
-        DispatchQueue.global().async {
+        notificationsAPI.markAllAsRead(success: {
             Notification.markAllAsRead()
             self.displayedNotifications = self.displayedNotifications.map { arg -> (date: Date, notifications: [NotificationViewData]) in
                 let (date, notifications) = arg
                 return (date: date, notifications: notifications.map { notification in
                     var openedNotification = notification
-                    openedNotification.status = .opened
+                    openedNotification.status = .read
                     return openedNotification
                 })
             }
-            DispatchQueue.main.async {
-                self.view?.set(notifications: self.displayedNotifications)
-                self.view?.updateMarkAllAsReadButton(with: .normal)
-            }
-        }
+            self.view?.set(notifications: self.displayedNotifications)
+            self.view?.updateMarkAllAsReadButton(with: .normal)
+        }, error: { err in
+            print("notifications: unable to mark all notifications as read, error = \(err)")
+            self.view?.updateMarkAllAsReadButton(with: .error)
+        })
     }
 }

--- a/Stepic/NotificationsTableViewCell.swift
+++ b/Stepic/NotificationsTableViewCell.swift
@@ -39,8 +39,6 @@ class NotificationsTableViewCell: UITableViewCell {
             switch status {
             case .read:
                 statusButton.update(with: .read)
-            case .opened:
-                statusButton.update(with: .opened)
             case .unread:
                 statusButton.update(with: .unread)
             }

--- a/Stepic/NotificationsViewController.swift
+++ b/Stepic/NotificationsViewController.swift
@@ -178,21 +178,17 @@ extension NotificationsViewController: UITableViewDelegate, UITableViewDataSourc
 
 extension NotificationsViewController: NotificationsTableViewCellDelegate {
     func statusButtonClicked(inCell cell: NotificationsTableViewCell, withNotificationId id: Int) {
-        if cell.status == .unread {
-            presenter?.updateNotification(with: id, status: .read)
-            cell.status = .read
-        }
+        presenter?.updateNotification(with: id, status: .read)
+        cell.status = .read
     }
 
     func linkClicked(inCell cell: NotificationsTableViewCell, url: URL, withNotificationId id: Int) {
         let deepLinkingUrlString = "https://stepik.org" + url.absoluteString
         if let deepLinkingUrl = URL(string: deepLinkingUrlString) {
             DeepLinkRouter.routeFromDeepLink(url: deepLinkingUrl, showAlertForUnsupported: false)
-        }
 
-        if cell.status != .opened {
-            presenter?.updateNotification(with: id, status: .opened)
-            cell.status = .opened
+            presenter?.updateNotification(with: id, status: .read)
+            cell.status = .read
         }
     }
 }


### PR DESCRIPTION
**Коротко для Release Notes, в формате «Сделали/Добавили/Исправили N»**: 
Оставляем только два состояния для уведомлений: прочитано/непрочитано.

**Описание**:
Удалил состояние 'opened' и всё, что с ним связано. Переделал поведение кнопки "отметить прочитанным всё".