### PR TITLE
Fix analytics events

### DIFF
--- a/Stepic/AnalyticsEvents.swift
+++ b/Stepic/AnalyticsEvents.swift
@@ -142,7 +142,7 @@ struct AnalyticsEvents {
 
         struct LocalNotification {
             static let shown = "streak_local_notification_shown"
-            static let clicked = "streak_local_notification_clicked"
+            static let opened = "streak_local_notification_opened"
         }
         struct ImproveAlert {
             static let notificationOffered = "streak_improve_alert_notifications_offered"

--- a/Stepic/AnalyticsEvents.swift
+++ b/Stepic/AnalyticsEvents.swift
@@ -15,7 +15,7 @@ struct AnalyticsEvents {
     }
 
     struct SignIn {
-        static let onSocialAuth = "clicked_SignIn_on_social_auth_screen"
+        static let onSocialAuth = "clicked_SignIn_on_launch_screen"
         static let onEmailAuth = "clicked_SignIn_on_email_auth_screen"
         static let onSignInScreen = "click_sign_in_with_interaction_type"
         static let nextButton = "click_sign_in_next_sign_in_screen"
@@ -30,7 +30,7 @@ struct AnalyticsEvents {
     }
 
     struct SignUp {
-        static let onSocialAuth = "clicked_SignUp_on_social_auth_screen"
+        static let onSocialAuth = "clicked_SignUp_on_launch_screen"
         static let onEmailAuth = "clicked_SignUp_on_email_auth_screen"
         static let onSignUpScreen = "click_registration_with_interaction_type"
         static let nextButton = "click_registration_send_ime"

--- a/Stepic/AnalyticsEvents.swift
+++ b/Stepic/AnalyticsEvents.swift
@@ -80,6 +80,10 @@ struct AnalyticsEvents {
             static let anonymous = "join_course_anonymous"
             static let signed = "join_course_signed"
         }
+        struct Video {
+            static let clicked = "course_detail_video_clicked"
+            static let shown = "course_detail_video_shown"
+        }
     }
 
     struct Step {

--- a/Stepic/AppDelegate.swift
+++ b/Stepic/AppDelegate.swift
@@ -100,7 +100,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func presentStreaks(userActivity: UserActivity) {
 
-        AnalyticsReporter.reportEvent(AnalyticsEvents.Streaks.LocalNotification.shown, parameters: [
+        AnalyticsReporter.reportEvent(AnalyticsEvents.Streaks.LocalNotification.opened, parameters: [
             "current": userActivity.currentStreak,
             "longest": userActivity.longestStreak,
             "percentage": String(format: "%.02f", Double(userActivity.currentStreak) / Double(userActivity.longestStreak))

--- a/Stepic/CoursePreviewViewController.swift
+++ b/Stepic/CoursePreviewViewController.swift
@@ -109,6 +109,8 @@ class CoursePreviewViewController: UIViewController, ShareableController {
             tableView.reloadData()
             resetHeightConstraints()
             if let introVideo = c.introVideo {
+                // Intro presented, send to analytics
+                AnalyticsReporter.reportEvent(AnalyticsEvents.CourseOverview.Video.shown)
                 setIntroMode(fromVideo: true)
                 setupPlayerWithVideo(introVideo)
             } else {
@@ -334,6 +336,7 @@ class CoursePreviewViewController: UIViewController, ShareableController {
         if ConnectionHelper.shared.reachability.isReachableViaWiFi() || ConnectionHelper.shared.reachability.isReachableViaWWAN() {
             setControls(playing: true)
             self.moviePlayer?.play()
+            AnalyticsReporter.reportEvent(AnalyticsEvents.CourseOverview.Video.clicked)
         }
     }
 


### PR DESCRIPTION
**Задача**: [#APPS-1077](https://vyahhi.myjetbrains.com/youtrack/issue/APPS-1077), [#APPS-1076](https://vyahhi.myjetbrains.com/youtrack/issue/APPS-1076), [#APPS-1560](https://vyahhi.myjetbrains.com/youtrack/issue/APPS-1560), [#APPS-1561](https://vyahhi.myjetbrains.com/youtrack/issue/APPS-1561)

**Коротко для Release Notes, в формате «Сделали/Добавили/Исправили N»**: 
Пофиксили неотправляющиеся событий в аналитику и добавили события на интро видео в курсе

**Описание**:
* Переименованы события на экране авторизации и регистрации
* События в CourseOverview, связанные с интро видео
* Фикс события при тапе на уведомлении о стрике
