### PR TITLE
Fix insets when keyboard did show

### DIFF
--- a/Stepic/FullscreenCodeQuizViewController.swift
+++ b/Stepic/FullscreenCodeQuizViewController.swift
@@ -161,7 +161,7 @@ class FullscreenCodeQuizViewController: UIViewController {
 
     @objc fileprivate func keyboardWasShown(aNotification: NSNotification) {
         let info = aNotification.userInfo
-        let infoNSValue = info![UIKeyboardFrameBeginUserInfoKey] as! NSValue
+        let infoNSValue = info![UIKeyboardFrameEndUserInfoKey] as! NSValue
         let kbSize = infoNSValue.cgRectValue.size
         let contentInsets = UIEdgeInsets(top: 0.0, left: 0.0, bottom: kbSize.height, right: 0.0)
         codeTextView.contentInset = contentInsets


### PR DESCRIPTION
**Задача**: [#APPS-1551](https://vyahhi.myjetbrains.com/youtrack/issue/APPS-1551)

**Коротко для Release Notes, в формате «Сделали/Добавили/Исправили N»**: 
Исправили скролл полноэкранного редактора Code Quiz

**Описание**:
Неправильно получались размеры клавиатуры (`UIKeyboardFrameBeginUserInfoKey` вместо `UIKeyboardFrameEndUserInfoKey`), из-за этого неверно рассчитывались `contentInsets` у текстовой вьюшки.