### PR TITLE
Support font style tags in profile

### DIFF
--- a/Stepic/TitleContentExpandableMenuBlockTableViewCell.swift
+++ b/Stepic/TitleContentExpandableMenuBlockTableViewCell.swift
@@ -74,10 +74,15 @@ class TitleContentExpandableMenuBlockTableViewCell: MenuBlockTableViewCell {
 
     private func buildLabel(type: LabelType, text: String) -> StepikLabel {
         let label = StepikLabel(frame: CGRect.zero)
-        label.text = text
         label.font = type.font
         if let titleColor = block?.titleColor {
             label.textColor = titleColor
+        }
+
+        if type == .title {
+            label.text = text
+        } else {
+            label.setTextWithHTMLString(text)
         }
 
         return label


### PR DESCRIPTION
**Задача**: [#APPS-1451](https://vyahhi.myjetbrains.com/youtrack/issue/APPS-1451)

**Коротко для Release Notes, в формате «Сделали/Добавили/Исправили N»**: 
Добавили поддержку html в профиле

**Описание**:
Поле с информацией о пользователе в профиле теперь задается с помощью `setTextWithHTMLString`, которая рендерит NSAttributedString с некоторыми поддерживаемыми тегами.