### PR TITLE
Tab bar titles

### DIFF
--- a/Stepic/StyledTabBarViewController.swift
+++ b/Stepic/StyledTabBarViewController.swift
@@ -23,6 +23,7 @@ class StyledTabBarViewController: UITabBarController {
             vc.tabBarItem = $0.buildItem()
             return vc
         }, animated: false)
+        self.updateTitlesForTabBarItems()
 
         delegate = self
 
@@ -36,6 +37,46 @@ class StyledTabBarViewController: UITabBarController {
             return nil
         }
         return items[index].clickEventName
+    }
+
+    private func updateTitlesForTabBarItems() {
+        func hideTitle(for item: UITabBarItem) {
+            let inset: CGFloat = UIDevice.current.userInterfaceIdiom == .pad ? 8.0 : 6.0
+            item.imageInsets = UIEdgeInsets(top: inset, left: 0, bottom: -inset, right: 0)
+            item.titlePositionAdjustment = UIOffset(horizontal: 0, vertical: CGFloat.greatestFiniteMagnitude)
+        }
+
+        func showDefaultTitle(for item: UITabBarItem) {
+            item.imageInsets = UIEdgeInsets.zero
+            item.titlePositionAdjustment = UIOffset.zero
+        }
+
+        self.tabBar.items?.forEach { item in
+            if #available(iOS 11.0, *) {
+                // For new tabbar in iOS 11.0+
+                switch UIDevice.current.orientation {
+                case .landscapeLeft, .landscapeRight:
+                    // Using default tabbar in landscape
+                    showDefaultTitle(for: item)
+                default:
+                    if UIDevice.current.userInterfaceIdiom == .pad {
+                        // Using default tabbar on iPads in both orientations
+                        showDefaultTitle(for: item)
+                    } else {
+                        // Using tabbar w/o titles in other cases
+                        hideTitle(for: item)
+                    }
+                }
+            } else {
+                // Using tabbar w/o titles if iOS version < 11.0
+                hideTitle(for: item)
+            }
+        }
+    }
+
+    override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
+        super.viewWillTransition(to: size, with: coordinator)
+        self.updateTitlesForTabBarItems()
     }
 }
 
@@ -53,10 +94,7 @@ struct TabBarItemInfo {
     }
 
     func buildItem() -> UITabBarItem {
-        let item = UITabBarItem(title: title, image: image, tag: 0)
-        item.imageInsets = UIEdgeInsets(top: 6, left: 0, bottom: -6, right: 0)
-        item.titlePositionAdjustment = UIOffset(horizontal: 0, vertical: CGFloat.greatestFiniteMagnitude)
-        return item
+        return UITabBarItem(title: title, image: image, tag: 0)
     }
 }
 


### PR DESCRIPTION
**Коротко для Release Notes, в формате «Сделали/Добавили/Исправили N»**: 
Исправлен таб бар в некоторых ориентациях/размерах

**Описание**:
В iOS 11 изменили отображение подписей у иконок таб бара для некоторых размеров экрана. Исходя из этого, настраиваем таб бар по-разному:
* iOS < 11.0: убираем подписи
* iOS 11.0+: оставляем подписи для лендскейпа и для планшетов  

iPad (iOS 9):
<img width="778" alt="ipad9" src="https://user-images.githubusercontent.com/1695403/32228982-cb68839a-be60-11e7-9242-71eee8f45561.png">
iPad (iOS 11):
<img width="781" alt="ipad11" src="https://user-images.githubusercontent.com/1695403/32229037-eb47fb1e-be60-11e7-8090-58c092bfa17f.png">
iPhone (iOS 9, portrait):
<img width="331" alt="iphone9_p" src="https://user-images.githubusercontent.com/1695403/32229065-fd5fb422-be60-11e7-8738-631cbc1538ae.png">
iPhone (iOS 11, portrait):
<img width="331" alt="iphone11_p" src="https://user-images.githubusercontent.com/1695403/32229080-09922f18-be61-11e7-830d-d0506f72ea63.png">
iPhone (iOS 9, landscape):
<img width="581" alt="iphone9_l" src="https://user-images.githubusercontent.com/1695403/32229105-1c5ab480-be61-11e7-9f18-06b00f2b8605.png">
iPhone (iOS 11, landscape):
<img width="585" alt="iphone11_l" src="https://user-images.githubusercontent.com/1695403/32229125-2e8c0ab4-be61-11e7-9673-8f2ad0498a7a.png">

