### PR TITLE
performRequest race condition fix

### DIFF
--- a/Stepic/AppDelegate.swift
+++ b/Stepic/AppDelegate.swift
@@ -25,9 +25,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
 
-//        let token = StepicToken(accessToken: "q0FPaRDvITg0DiltK98zvbMhsORUBc", refreshToken: "G5G98oDqA4HiiME74xQLtz4KINCaFV", tokenType: "Bearer", expireDate: Date(timeIntervalSince1970: 1509532200))
-//        AuthInfo.shared.token = token
-
         AnalyticsHelper.sharedHelper.setupAnalytics()
 
         WatchSessionManager.sharedManager.startSession()

--- a/Stepic/AppDelegate.swift
+++ b/Stepic/AppDelegate.swift
@@ -25,6 +25,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
 
+//        let token = StepicToken(accessToken: "q0FPaRDvITg0DiltK98zvbMhsORUBc", refreshToken: "G5G98oDqA4HiiME74xQLtz4KINCaFV", tokenType: "Bearer", expireDate: Date(timeIntervalSince1970: 1509532200))
+//        AuthInfo.shared.token = token
+
         AnalyticsHelper.sharedHelper.setupAnalytics()
 
         WatchSessionManager.sharedManager.startSession()


### PR DESCRIPTION
**Коротко для Release Notes, в формате «Сделали/Добавили/Исправили N»**: 
Исправили race condition в performRequest

**Описание**:
Добавил диспатч в отдельную очередь и семафоры на проверку токена на валидность.
Возникает проблема, если сразу попытаться рефрешнуть контроллер: несколько CourseList-ов на одном экране пытались одновременно асинхронно рефрешнуть токен и чуда не происходило.
