### PR TITLE
Fix play/pause crash

### DIFF
--- a/Stepic/StepicVideoPlayerViewController.swift
+++ b/Stepic/StepicVideoPlayerViewController.swift
@@ -288,6 +288,7 @@ class StepicVideoPlayerViewController: UIViewController {
     deinit {
         WatchSessionSender.sendPlaybackStatus(.noVideo)
         WatchSessionManager.sharedManager.removeObserver(self)
+        MPRemoteCommandCenter.shared().togglePlayPauseCommand.removeTarget(self)
         print("did deinit")
         saveCurrentPlayerTime()
     }


### PR DESCRIPTION
**Задача**: [#APPS-1616](https://vyahhi.myjetbrains.com/youtrack/issue/APPS-1616)

**Коротко для Release Notes, в формате «Сделали/Добавили/Исправили N»**: 
Исправили краш при нажатии кнопки play/pause на гарнитуре

**Описание**:
Если нажать на кнопку play/pause на гарнитуре после закрытия полноэкранного плеера в степе с видео, приложение крашилось из-за того, что в `deinit` блоке не удаляли таргет на селектор из MPRemoteCommandCenter. 