### PR TITLE
Fix comment time

### DIFF
--- a/Stepic/DiscussionTableViewCell.swift
+++ b/Stepic/DiscussionTableViewCell.swift
@@ -73,7 +73,7 @@ class DiscussionTableViewCell: UITableViewCell {
         self.comment = comment
         self.separatorType = separatorType
         labelContainerView.backgroundColor = UIColor.clear
-        timeLabel.text = comment.lastTime.getStepicFormatString(withTime: true)
+        timeLabel.text = comment.time.getStepicFormatString(withTime: true)
         setLiked(comment.vote.value == .Epic, likesCount: comment.epicCount)
         loadLabel(comment.text)
         if comment.isDeleted {

--- a/Stepic/DiscussionWebTableViewCell.swift
+++ b/Stepic/DiscussionWebTableViewCell.swift
@@ -93,7 +93,7 @@ class DiscussionWebTableViewCell: UITableViewCell {
         self.comment = comment
         self.separatorType = separatorType
 
-        timeLabel.text = comment.lastTime.getStepicFormatString()
+        timeLabel.text = comment.time.getStepicFormatString()
         loadWebView(comment.text)
     }
 


### PR DESCRIPTION
**Задача**: [#APPS-1414](https://vyahhi.myjetbrains.com/youtrack/issue/APPS-1414)

**Коротко для Release Notes, в формате «Сделали/Добавили/Исправили N»**: 
Исправили время комментариев

**Описание**:
Для комментария отображалось время из `last_time`, из-за этого родительский комментарий имел время последнего комментария в своей ветке.