### PR TITLE
Fix crash when navigate to prev/next lesson

### DIFF
--- a/Stepic/UnitsViewController.swift
+++ b/Stepic/UnitsViewController.swift
@@ -287,8 +287,11 @@ class UnitsViewController: UIViewController, ShareableController, UIViewControll
                     let isPrevSectionReachable = sectionBefore?.isReachable ?? false
                     let isNextSectionReachable = sectionAfter?.isReachable ?? false
 
-                    let canPrev = (!isSectionFirstInCourse && isPrevSectionReachable) || !isUnitFirstInSection
-                    let canNext = (!isSectionLastInCourse && isNextSectionReachable) || !isUnitLastInSection
+                    let isPrevSectionEmpty = sectionBefore?.unitsArray.isEmpty ?? true
+                    let isNextSectionEmpty = sectionAfter?.unitsArray.isEmpty ?? true
+
+                    let canPrev = (!isSectionFirstInCourse && isPrevSectionReachable && !isPrevSectionEmpty) || !isUnitFirstInSection
+                    let canNext = (!isSectionLastInCourse && isNextSectionReachable && !isNextSectionEmpty) || !isUnitLastInSection
                     dvc.navigationRules = (prev: canPrev, next: canNext)
                 } else {
                     dvc.navigationRules = (prev: !isUnitFirstInSection, next: !isUnitLastInSection)
@@ -349,7 +352,7 @@ class UnitsViewController: UIViewController, ShareableController, UIViewControll
         self.section = prevSection
         self.refreshUnits {
             [weak self] in
-            self?.selectUnitAtIndex(prevSection.units.count - 1, replace: true)
+            self?.selectUnitAtIndex(prevSection.unitsArray.count - 1, replace: true)
         }
     }
 

--- a/Stepic/UnitsViewController.swift
+++ b/Stepic/UnitsViewController.swift
@@ -315,6 +315,7 @@ class UnitsViewController: UIViewController, ShareableController, UIViewControll
 
                     let isPrevSectionEmpty = sectionBefore?.units.isEmpty ?? true
                     let isNextSectionEmpty = sectionAfter?.units.isEmpty ?? true
+                    print("DEBUGG", isNextSectionEmpty)
 
                     let canPrev = (!isSectionFirstInCourse && isPrevSectionReachable && !isPrevSectionEmpty) || !isUnitFirstInSection
                     let canNext = (!isSectionLastInCourse && isNextSectionReachable && !isNextSectionEmpty) || !isUnitLastInSection

--- a/Stepic/UnitsViewController.swift
+++ b/Stepic/UnitsViewController.swift
@@ -316,6 +316,12 @@ class UnitsViewController: UIViewController, ShareableController, UIViewControll
             return
         }
 
+        // Exam
+        guard !nextSection.isExam else {
+            showExamAlert { }
+            return
+        }
+
         self.section = nextSection
         self.refreshUnits {
             [weak self] in
@@ -335,10 +341,41 @@ class UnitsViewController: UIViewController, ShareableController, UIViewControll
         }
 
         self.section = prevSection
+
+        // Exam
+        guard !prevSection.isExam else {
+            showExamAlert { }
+            return
+        }
+
         self.refreshUnits {
             [weak self] in
             self?.selectUnitAtIndex(prevSection.units.count - 1, replace: true)
         }
+    }
+
+    func showExamAlert(seccancel cancelAction: @escaping (() -> Void)) {
+        var sUrl = ""
+        if let slug = section?.course?.slug {
+            sUrl = StepicApplicationsInfo.stepicURL + "/course/" + slug + "/syllabus/"
+        }
+
+        let alert = UIAlertController(title: NSLocalizedString("ExamTitle", comment: ""), message: NSLocalizedString("ShowExamInWeb", comment: ""), preferredStyle: .alert)
+
+        alert.addAction(UIAlertAction(title: NSLocalizedString("Open", comment: ""), style: .default, handler: {
+            [weak self]
+            _ in
+            if let s = self {
+                WebControllerManager.sharedManager.presentWebControllerWithURLString(sUrl + "?from_mobile_app=true", inController: s, withKey: "exam", allowsSafari: true, backButtonStyle: .close)
+            }
+        }))
+
+        alert.addAction(UIAlertAction(title: NSLocalizedString("Cancel", comment: ""), style: .cancel, handler: {
+            _ in
+            cancelAction()
+        }))
+
+        self.present(alert, animated: true, completion: {})
     }
 
     func clearAllSelection() {

--- a/Stepic/UnitsViewController.swift
+++ b/Stepic/UnitsViewController.swift
@@ -340,14 +340,13 @@ class UnitsViewController: UIViewController, ShareableController, UIViewControll
             return
         }
 
-        self.section = prevSection
-
         // Exam
         guard !prevSection.isExam else {
             showExamAlert { }
             return
         }
 
+        self.section = prevSection
         self.refreshUnits {
             [weak self] in
             self?.selectUnitAtIndex(prevSection.units.count - 1, replace: true)

--- a/Stepic/UnitsViewController.swift
+++ b/Stepic/UnitsViewController.swift
@@ -315,7 +315,6 @@ class UnitsViewController: UIViewController, ShareableController, UIViewControll
 
                     let isPrevSectionEmpty = sectionBefore?.units.isEmpty ?? true
                     let isNextSectionEmpty = sectionAfter?.units.isEmpty ?? true
-                    print("DEBUGG", isNextSectionEmpty)
 
                     let canPrev = (!isSectionFirstInCourse && isPrevSectionReachable && !isPrevSectionEmpty) || !isUnitFirstInSection
                     let canNext = (!isSectionLastInCourse && isNextSectionReachable && !isNextSectionEmpty) || !isUnitLastInSection

--- a/Stepic/UnitsViewController.swift
+++ b/Stepic/UnitsViewController.swift
@@ -222,8 +222,15 @@ class UnitsViewController: UIViewController, ShareableController, UIViewControll
 
         updateTitle()
 
-        didRefresh = false
-        section?.loadUnits(success: {
+        let failureHandler = {
+            UIThread.performUI({
+                self.refreshControl.endRefreshing()
+                self.emptyDatasetState = EmptyDatasetState.connectionError
+            })
+            self.didRefresh = true
+        }
+
+        let successHandler = {
             UIThread.performUI({
                 self.refreshControl.endRefreshing()
                 self.tableView.reloadData()
@@ -231,13 +238,32 @@ class UnitsViewController: UIViewController, ShareableController, UIViewControll
             })
             self.didRefresh = true
             success?()
-        }, error: {
-            UIThread.performUI({
-                self.refreshControl.endRefreshing()
-                self.emptyDatasetState = EmptyDatasetState.connectionError
-            })
-            self.didRefresh = true
-        })
+        }
+
+        didRefresh = false
+        section?.loadUnits(success: {
+            if let course = self.section?.course,
+               let section = self.section {
+                let sectionBefore = course.getSection(before: section)
+                let sectionAfter = course.getSection(after: section)
+
+                if sectionBefore == nil {
+                    if sectionAfter == nil {
+                        successHandler()
+                    } else {
+                        sectionAfter?.loadUnits(success: { successHandler() }, error: { failureHandler() })
+                    }
+                } else if sectionAfter == nil {
+                    sectionBefore?.loadUnits(success: { successHandler() }, error: { failureHandler() })
+                } else {
+                    sectionAfter?.loadUnits(success: {
+                        sectionBefore?.loadUnits(success: { successHandler() }, error: { failureHandler() })
+                    }, error: { failureHandler() })
+                }
+            } else {
+                failureHandler()
+            }
+        }, error: { failureHandler() })
     }
 
     override func didReceiveMemoryWarning() {
@@ -287,8 +313,12 @@ class UnitsViewController: UIViewController, ShareableController, UIViewControll
                     let isPrevSectionReachable = sectionBefore?.isReachable ?? false
                     let isNextSectionReachable = sectionAfter?.isReachable ?? false
 
-                    let canPrev = (!isSectionFirstInCourse && isPrevSectionReachable) || !isUnitFirstInSection
-                    let canNext = (!isSectionLastInCourse && isNextSectionReachable) || !isUnitLastInSection
+                    let isPrevSectionEmpty = sectionBefore?.units.isEmpty ?? true
+                    let isNextSectionEmpty = sectionAfter?.units.isEmpty ?? true
+                    print("DEBUGG", isNextSectionEmpty)
+
+                    let canPrev = (!isSectionFirstInCourse && isPrevSectionReachable && !isPrevSectionEmpty) || !isUnitFirstInSection
+                    let canNext = (!isSectionLastInCourse && isNextSectionReachable && !isNextSectionEmpty) || !isUnitLastInSection
                     dvc.navigationRules = (prev: canPrev, next: canNext)
                 } else {
                     dvc.navigationRules = (prev: !isUnitFirstInSection, next: !isUnitLastInSection)


### PR DESCRIPTION
**Задача**: [#APPS-1629](https://vyahhi.myjetbrains.com/youtrack/issue/APPS-1629), [#APPS-1647](https://vyahhi.myjetbrains.com/youtrack/issue/APPS-1647)

**Коротко для Release Notes, в формате «Сделали/Добавили/Исправили N»**: 
Исправили краш при переходе к экзамену и к пустому модулю с кнопки "Следующий урок"

**Описание**:
* При переходе к экзамену: добавили проверку на то, что следующая секция имеет `isExam == true` и показываем алерт (как в силлабусе).
* При переходе к пустому модулю: смотрим на кол-во юнитов в следующей секции