### PR TITLE
Explore screen

### DIFF
--- a/Stepic.xcodeproj/project.pbxproj
+++ b/Stepic.xcodeproj/project.pbxproj
@@ -551,6 +551,30 @@
 		087039311CD7413D00B6571B /* NotificationAlertConstructor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0870392F1CD7413D00B6571B /* NotificationAlertConstructor.swift */; };
 		087387D81BB9A4BD003CFAD1 /* CoreDataHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 087387D71BB9A4BD003CFAD1 /* CoreDataHelper.swift */; };
 		087387DA1BB9B768003CFAD1 /* ErrorEnums.swift in Sources */ = {isa = PBXBuildFile; fileRef = 087387D91BB9B768003CFAD1 /* ErrorEnums.swift */; };
+		087585A31FB50D640047A269 /* CourseListsAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 087585A21FB50D640047A269 /* CourseListsAPI.swift */; };
+		087585A41FB50D640047A269 /* CourseListsAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 087585A21FB50D640047A269 /* CourseListsAPI.swift */; };
+		087585A51FB50D640047A269 /* CourseListsAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 087585A21FB50D640047A269 /* CourseListsAPI.swift */; };
+		087585A61FB50D640047A269 /* CourseListsAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 087585A21FB50D640047A269 /* CourseListsAPI.swift */; };
+		087585A71FB50D640047A269 /* CourseListsAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 087585A21FB50D640047A269 /* CourseListsAPI.swift */; };
+		087585A81FB50D640047A269 /* CourseListsAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 087585A21FB50D640047A269 /* CourseListsAPI.swift */; };
+		087585A91FB50D640047A269 /* CourseListsAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 087585A21FB50D640047A269 /* CourseListsAPI.swift */; };
+		087585AA1FB50D640047A269 /* CourseListsAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 087585A21FB50D640047A269 /* CourseListsAPI.swift */; };
+		087585AE1FB51D720047A269 /* CourseList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 087585AD1FB51D720047A269 /* CourseList.swift */; };
+		087585AF1FB51D720047A269 /* CourseList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 087585AD1FB51D720047A269 /* CourseList.swift */; };
+		087585B01FB51D720047A269 /* CourseList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 087585AD1FB51D720047A269 /* CourseList.swift */; };
+		087585B11FB51D720047A269 /* CourseList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 087585AD1FB51D720047A269 /* CourseList.swift */; };
+		087585B21FB51D720047A269 /* CourseList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 087585AD1FB51D720047A269 /* CourseList.swift */; };
+		087585B31FB51D720047A269 /* CourseList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 087585AD1FB51D720047A269 /* CourseList.swift */; };
+		087585B41FB51D720047A269 /* CourseList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 087585AD1FB51D720047A269 /* CourseList.swift */; };
+		087585B51FB51D720047A269 /* CourseList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 087585AD1FB51D720047A269 /* CourseList.swift */; };
+		087585B71FB51D840047A269 /* CourseList+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 087585B61FB51D840047A269 /* CourseList+CoreDataProperties.swift */; };
+		087585B81FB51D840047A269 /* CourseList+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 087585B61FB51D840047A269 /* CourseList+CoreDataProperties.swift */; };
+		087585B91FB51D840047A269 /* CourseList+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 087585B61FB51D840047A269 /* CourseList+CoreDataProperties.swift */; };
+		087585BA1FB51D840047A269 /* CourseList+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 087585B61FB51D840047A269 /* CourseList+CoreDataProperties.swift */; };
+		087585BB1FB51D840047A269 /* CourseList+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 087585B61FB51D840047A269 /* CourseList+CoreDataProperties.swift */; };
+		087585BC1FB51D840047A269 /* CourseList+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 087585B61FB51D840047A269 /* CourseList+CoreDataProperties.swift */; };
+		087585BD1FB51D840047A269 /* CourseList+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 087585B61FB51D840047A269 /* CourseList+CoreDataProperties.swift */; };
+		087585BE1FB51D840047A269 /* CourseList+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 087585B61FB51D840047A269 /* CourseList+CoreDataProperties.swift */; };
 		08758A9B1CDB99C400159233 /* DevicesAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08AEC3A21CCA69C700FFF29E /* DevicesAPI.swift */; };
 		08758A9C1CDB99C700159233 /* APIDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08AEC3A61CCA75F400FFF29E /* APIDefaults.swift */; };
 		08758A9D1CDB99CF00159233 /* Device.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08AEC3A41CCA69F300FFF29E /* Device.swift */; };
@@ -4588,6 +4612,10 @@
 		0870392F1CD7413D00B6571B /* NotificationAlertConstructor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NotificationAlertConstructor.swift; sourceTree = "<group>"; };
 		087387D71BB9A4BD003CFAD1 /* CoreDataHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CoreDataHelper.swift; sourceTree = "<group>"; };
 		087387D91BB9B768003CFAD1 /* ErrorEnums.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ErrorEnums.swift; sourceTree = "<group>"; };
+		087585A21FB50D640047A269 /* CourseListsAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseListsAPI.swift; sourceTree = "<group>"; };
+		087585AB1FB50E220047A269 /* Model_courselists_v21.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = Model_courselists_v21.xcdatamodel; sourceTree = "<group>"; };
+		087585AD1FB51D720047A269 /* CourseList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseList.swift; sourceTree = "<group>"; };
+		087585B61FB51D840047A269 /* CourseList+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CourseList+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		087854F41DF6EE0D00368A50 /* wysiwyg.css */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.css; path = wysiwyg.css; sourceTree = "<group>"; };
 		087D96B81EBB7C7700059408 /* Tokens.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Tokens.plist; sourceTree = "<group>"; };
 		087D96BA1EBB7F5500059408 /* Tokens.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Tokens.swift; sourceTree = "<group>"; };
@@ -5495,6 +5523,7 @@
 		0828FF701BC5D181000AFEA7 /* Entities */ = {
 			isa = PBXGroup;
 			children = (
+				087585AC1FB51D590047A269 /* CourseList */,
 				2C9E3F381F7A7B2D00DDF1AA /* Notification */,
 				2CD8463D1F25F7AF00E8153C /* Profile */,
 				0846B1131EDDF05F00D64D77 /* CodeTemplates */,
@@ -5884,6 +5913,7 @@
 				0829B8341E9D025C009B4A84 /* CertificatesAPI.swift */,
 				2CD8464A1F25FE8B00E8153C /* ProfilesAPI.swift */,
 				08D5F57F1F7DBA70007C1634 /* CourseReviewSummariesAPI.swift */,
+				087585A21FB50D640047A269 /* CourseListsAPI.swift */,
 			);
 			name = "API Endpoints";
 			sourceTree = "<group>";
@@ -6077,6 +6107,15 @@
 				08EDB8B91F7C3D100028A9AE /* CourseWidgetView */,
 			);
 			name = Views;
+			sourceTree = "<group>";
+		};
+		087585AC1FB51D590047A269 /* CourseList */ = {
+			isa = PBXGroup;
+			children = (
+				087585AD1FB51D720047A269 /* CourseList.swift */,
+				087585B61FB51D840047A269 /* CourseList+CoreDataProperties.swift */,
+			);
+			name = CourseList;
 			sourceTree = "<group>";
 		};
 		0885F8491BA8374000F2A188 /* Model */ = {
@@ -11034,6 +11073,7 @@
 				086953101D747DC0003857A2 /* RequestChain.swift in Sources */,
 				088E58BE1DE33B410009B9CE /* AuthAPI.swift in Sources */,
 				08E59AC01E433057008EEECE /* FillBlanksDataset.swift in Sources */,
+				087585AF1FB51D720047A269 /* CourseList.swift in Sources */,
 				086BE2861F901CCF00B4BE56 /* LastStepRouter.swift in Sources */,
 				08BC47151CDA3E99009A1D25 /* ExecutableTaskTypes.swift in Sources */,
 				08D120821C937B2200A54ABC /* VideoURL+CoreDataProperties.swift in Sources */,
@@ -11104,6 +11144,7 @@
 				0829B8361E9D025C009B4A84 /* CertificatesAPI.swift in Sources */,
 				08D120991C937B2200A54ABC /* StringExtensions.swift in Sources */,
 				08D1209A1C937B2200A54ABC /* Attempt.swift in Sources */,
+				087585A41FB50D640047A269 /* CourseListsAPI.swift in Sources */,
 				08EDD6191F7C607A005203E4 /* CourseWidgetTableViewCell.swift in Sources */,
 				0869F6D31CE216B600F8A6DB /* PersistentQueueRecoveryManager.swift in Sources */,
 				08BC47071CD9F424009A1D25 /* DeleteDeviceExecutableTask.swift in Sources */,
@@ -11145,6 +11186,7 @@
 				08F476231E82C1480018E82C /* StreaksView.swift in Sources */,
 				0868C17F1F375A1200D77C5F /* SearchQueriesPersistentManager.swift in Sources */,
 				0899842D1ECDE194005C0B27 /* LessonPresenter.swift in Sources */,
+				087585B81FB51D840047A269 /* CourseList+CoreDataProperties.swift in Sources */,
 				0899842A1ECDE188005C0B27 /* LessonViewController.swift in Sources */,
 				08AF59E91E6D9BE800423EFF /* RGTabView.swift in Sources */,
 				2CD846401F25F7F300E8153C /* Profile.swift in Sources */,
@@ -11523,6 +11565,7 @@
 				083D64AF1C19BDB2003222F0 /* ControllerHelper.swift in Sources */,
 				08AF59E41E6D9BE800423EFF /* RGPageViewController.swift in Sources */,
 				083AABE81BE8D63D005E1E96 /* Progress+CoreDataProperties.swift in Sources */,
+				087585B71FB51D840047A269 /* CourseList+CoreDataProperties.swift in Sources */,
 				0805FE441F0D390B001226B4 /* CodePlaygroundManager.swift in Sources */,
 				08E8F9741F34E3D5008CF4A1 /* SearchQueriesViewController.swift in Sources */,
 				08D035211D65A252003515C6 /* AnalyticsEvents.swift in Sources */,
@@ -11586,6 +11629,7 @@
 				08F485B31C58EC33000165AA /* SortingQuizViewController.swift in Sources */,
 				08019A851DEED8B900691F0B /* QuizDataManager.swift in Sources */,
 				0885F8561BA9F18900F2A188 /* Parser.swift in Sources */,
+				087585A31FB50D640047A269 /* CourseListsAPI.swift in Sources */,
 				082EDED31D881562006B51DC /* StepsControllerRouter.swift in Sources */,
 				0889FEB21BFB864B00C6417E /* DownloadTableViewCell.swift in Sources */,
 				089B370F1BFA210F003DC593 /* CacheManager.swift in Sources */,
@@ -11642,6 +11686,7 @@
 				08F5555C1C4FB1E300C877E8 /* ChoiceReply.swift in Sources */,
 				08AEC3A31CCA69C800FFF29E /* DevicesAPI.swift in Sources */,
 				087D96BB1EBB7F5500059408 /* Tokens.swift in Sources */,
+				087585AE1FB51D720047A269 /* CourseList.swift in Sources */,
 				0884696C1E7C2E01009131E9 /* LastStepGlobalContext.swift in Sources */,
 				080F74661BD924B80064AAEA /* VideoQualityTableViewController.swift in Sources */,
 				08F485AA1C580D61000165AA /* MathReply.swift in Sources */,
@@ -11867,6 +11912,7 @@
 				2C1B60E51F4C4AEF00236804 /* AssignmentsAPI.swift in Sources */,
 				2C1B60E61F4C4AEF00236804 /* ProgressesAPI.swift in Sources */,
 				2C1B60E71F4C4AEF00236804 /* ViewsAPI.swift in Sources */,
+				087585B41FB51D720047A269 /* CourseList.swift in Sources */,
 				2C1B60E81F4C4AEF00236804 /* SearchResultsAPI.swift in Sources */,
 				2C1B60E91F4C4AEF00236804 /* AttemptsAPI.swift in Sources */,
 				2C1B60EA1F4C4AEF00236804 /* SubmissionsAPI.swift in Sources */,
@@ -11894,6 +11940,7 @@
 				2C1B60FD1F4C4AEF00236804 /* ProfilesAPI.swift in Sources */,
 				2C1B60FE1F4C4AEF00236804 /* StepOptions+CoreDataProperties.swift in Sources */,
 				2C1B60FF1F4C4AEF00236804 /* CodeElementsSize.swift in Sources */,
+				087585BD1FB51D840047A269 /* CourseList+CoreDataProperties.swift in Sources */,
 				2C1B61001F4C4AEF00236804 /* PickerViewController.swift in Sources */,
 				2C1B61011F4C4AEF00236804 /* StepikAlertViewController.swift in Sources */,
 				2C1B61021F4C4AEF00236804 /* AdaptiveStepViewController.swift in Sources */,
@@ -12076,6 +12123,7 @@
 				2C1B61A81F4C4AEF00236804 /* AchievementManager.swift in Sources */,
 				2C1B61A91F4C4AEF00236804 /* CourseSubscriptionManager.swift in Sources */,
 				2C1B61AA1F4C4AEF00236804 /* RemoteVersionManager.swift in Sources */,
+				087585A91FB50D640047A269 /* CourseListsAPI.swift in Sources */,
 				2C1B61AB1F4C4AEF00236804 /* UpdateChecker.swift in Sources */,
 				2C1B61AC1F4C4AEF00236804 /* CodeQuizToolbarDelegate.swift in Sources */,
 				2C1B61AD1F4C4AEF00236804 /* UpdatePreferencesContainer.swift in Sources */,
@@ -12307,6 +12355,7 @@
 				2C1B62F61F4C590700236804 /* AssignmentsAPI.swift in Sources */,
 				2C1B62F71F4C590700236804 /* ProgressesAPI.swift in Sources */,
 				2C1B62F81F4C590700236804 /* ViewsAPI.swift in Sources */,
+				087585B51FB51D720047A269 /* CourseList.swift in Sources */,
 				2C1B62F91F4C590700236804 /* SearchResultsAPI.swift in Sources */,
 				2C1B62FA1F4C590700236804 /* AttemptsAPI.swift in Sources */,
 				2C1B62FB1F4C590700236804 /* SubmissionsAPI.swift in Sources */,
@@ -12334,6 +12383,7 @@
 				2C1B630E1F4C590700236804 /* ProfilesAPI.swift in Sources */,
 				2C1B630F1F4C590700236804 /* StepOptions+CoreDataProperties.swift in Sources */,
 				2C1B63101F4C590700236804 /* CodeElementsSize.swift in Sources */,
+				087585BE1FB51D840047A269 /* CourseList+CoreDataProperties.swift in Sources */,
 				2C1B63111F4C590700236804 /* PickerViewController.swift in Sources */,
 				2C1B63121F4C590700236804 /* StepikAlertViewController.swift in Sources */,
 				2C1B63131F4C590700236804 /* AdaptiveStepViewController.swift in Sources */,
@@ -12516,6 +12566,7 @@
 				2C1B63B91F4C590700236804 /* AchievementManager.swift in Sources */,
 				2C1B63BA1F4C590700236804 /* CourseSubscriptionManager.swift in Sources */,
 				2C1B63BB1F4C590700236804 /* RemoteVersionManager.swift in Sources */,
+				087585AA1FB50D640047A269 /* CourseListsAPI.swift in Sources */,
 				2C1B63BC1F4C590700236804 /* UpdateChecker.swift in Sources */,
 				2C1B63BD1F4C590700236804 /* CodeQuizToolbarDelegate.swift in Sources */,
 				2C1B63BE1F4C590700236804 /* UpdatePreferencesContainer.swift in Sources */,
@@ -12747,6 +12798,7 @@
 				2C8652931F4B33DE00D51654 /* AssignmentsAPI.swift in Sources */,
 				2C8652941F4B33DE00D51654 /* ProgressesAPI.swift in Sources */,
 				2C8652951F4B33DE00D51654 /* ViewsAPI.swift in Sources */,
+				087585B11FB51D720047A269 /* CourseList.swift in Sources */,
 				2C8652961F4B33DE00D51654 /* SearchResultsAPI.swift in Sources */,
 				2C8652971F4B33DE00D51654 /* AttemptsAPI.swift in Sources */,
 				2C8652981F4B33DE00D51654 /* SubmissionsAPI.swift in Sources */,
@@ -12774,6 +12826,7 @@
 				2C8652AB1F4B33DE00D51654 /* ProfilesAPI.swift in Sources */,
 				2C8652AC1F4B33DE00D51654 /* StepOptions+CoreDataProperties.swift in Sources */,
 				2C8652AD1F4B33DE00D51654 /* CodeElementsSize.swift in Sources */,
+				087585BA1FB51D840047A269 /* CourseList+CoreDataProperties.swift in Sources */,
 				2C8652AE1F4B33DE00D51654 /* PickerViewController.swift in Sources */,
 				2C8652AF1F4B33DE00D51654 /* StepikAlertViewController.swift in Sources */,
 				2C8652B01F4B33DE00D51654 /* AdaptiveStepViewController.swift in Sources */,
@@ -12956,6 +13009,7 @@
 				2C8653561F4B33DE00D51654 /* AchievementManager.swift in Sources */,
 				2C8653571F4B33DE00D51654 /* CourseSubscriptionManager.swift in Sources */,
 				2C8653581F4B33DE00D51654 /* RemoteVersionManager.swift in Sources */,
+				087585A61FB50D640047A269 /* CourseListsAPI.swift in Sources */,
 				2C8653591F4B33DE00D51654 /* UpdateChecker.swift in Sources */,
 				2C86535A1F4B33DE00D51654 /* CodeQuizToolbarDelegate.swift in Sources */,
 				2C86535B1F4B33DE00D51654 /* UpdatePreferencesContainer.swift in Sources */,
@@ -13367,6 +13421,7 @@
 				2C89AA251F4C289900227C3B /* SharingHelper.swift in Sources */,
 				2C89AA261F4C289900227C3B /* AnalyticsEvents.swift in Sources */,
 				2C89AA271F4C289900227C3B /* AnalyticsReporter.swift in Sources */,
+				087585A71FB50D640047A269 /* CourseListsAPI.swift in Sources */,
 				2C89AA281F4C289900227C3B /* WatchDataHelper.swift in Sources */,
 				2C89AA291F4C289900227C3B /* WatchCoursesDisplayingHelper.swift in Sources */,
 				08DF78911F5D6A7600AEEA85 /* HeaderMenuBlockTableViewCell.swift in Sources */,
@@ -13560,12 +13615,14 @@
 				2C89AACE1F4C289900227C3B /* StepicApplicationsInfo.swift in Sources */,
 				2C89AACF1F4C289900227C3B /* NSDateExtensions.swift in Sources */,
 				2C89AAD01F4C289900227C3B /* StringExtensions.swift in Sources */,
+				087585BB1FB51D840047A269 /* CourseList+CoreDataProperties.swift in Sources */,
 				2C89AAD11F4C289900227C3B /* UIViewExtensions.swift in Sources */,
 				2C89AAD31F4C289900227C3B /* Profile+CoreDataProperties.swift in Sources */,
 				2C89AAD51F4C289900227C3B /* FullHeightTableView.swift in Sources */,
 				2C89AAD61F4C289900227C3B /* StepOptions.swift in Sources */,
 				2C89AAD71F4C289900227C3B /* NSAttributedStringExtensions.swift in Sources */,
 				2C89AAD81F4C289900227C3B /* AlamofireExtensions.swift in Sources */,
+				087585B21FB51D720047A269 /* CourseList.swift in Sources */,
 				2C89AAD91F4C289900227C3B /* AdaptiveStepDelegate.swift in Sources */,
 				2C89AADA1F4C289900227C3B /* ErrorEnums.swift in Sources */,
 				2C89AADB1F4C289900227C3B /* CodeTemplate.swift in Sources */,
@@ -13626,6 +13683,7 @@
 				2C97312D1F4C38F600AC9301 /* AssignmentsAPI.swift in Sources */,
 				2C97312E1F4C38F600AC9301 /* ProgressesAPI.swift in Sources */,
 				2C97312F1F4C38F600AC9301 /* ViewsAPI.swift in Sources */,
+				087585B31FB51D720047A269 /* CourseList.swift in Sources */,
 				2C9731301F4C38F600AC9301 /* SearchResultsAPI.swift in Sources */,
 				2C9731311F4C38F600AC9301 /* AttemptsAPI.swift in Sources */,
 				2C9731321F4C38F600AC9301 /* SubmissionsAPI.swift in Sources */,
@@ -13653,6 +13711,7 @@
 				2C9731451F4C38F600AC9301 /* ProfilesAPI.swift in Sources */,
 				2C9731461F4C38F600AC9301 /* StepOptions+CoreDataProperties.swift in Sources */,
 				2C9731471F4C38F600AC9301 /* CodeElementsSize.swift in Sources */,
+				087585BC1FB51D840047A269 /* CourseList+CoreDataProperties.swift in Sources */,
 				2C9731481F4C38F600AC9301 /* PickerViewController.swift in Sources */,
 				2C9731491F4C38F600AC9301 /* StepikAlertViewController.swift in Sources */,
 				2C97314A1F4C38F600AC9301 /* AdaptiveStepViewController.swift in Sources */,
@@ -13835,6 +13894,7 @@
 				2C9731F01F4C38F600AC9301 /* AchievementManager.swift in Sources */,
 				2C9731F11F4C38F600AC9301 /* CourseSubscriptionManager.swift in Sources */,
 				2C9731F21F4C38F600AC9301 /* RemoteVersionManager.swift in Sources */,
+				087585A81FB50D640047A269 /* CourseListsAPI.swift in Sources */,
 				2C9731F31F4C38F600AC9301 /* UpdateChecker.swift in Sources */,
 				2C9731F41F4C38F600AC9301 /* CodeQuizToolbarDelegate.swift in Sources */,
 				2C9731F51F4C38F600AC9301 /* UpdatePreferencesContainer.swift in Sources */,
@@ -14120,6 +14180,7 @@
 				864514EE1E9FD4F6007F73BE /* AssignmentsAPI.swift in Sources */,
 				864514EF1E9FD4F6007F73BE /* ProgressesAPI.swift in Sources */,
 				864514F01E9FD4F6007F73BE /* ViewsAPI.swift in Sources */,
+				087585B01FB51D720047A269 /* CourseList.swift in Sources */,
 				864514F11E9FD4F6007F73BE /* SearchResultsAPI.swift in Sources */,
 				864514F21E9FD4F6007F73BE /* AttemptsAPI.swift in Sources */,
 				864514F31E9FD4F6007F73BE /* SubmissionsAPI.swift in Sources */,
@@ -14147,6 +14208,7 @@
 				2CD8464D1F25FE8B00E8153C /* ProfilesAPI.swift in Sources */,
 				0846B1091EDDED4400D64D77 /* StepOptions+CoreDataProperties.swift in Sources */,
 				0888D10B1F1E42A000A16863 /* CodeElementsSize.swift in Sources */,
+				087585B91FB51D840047A269 /* CourseList+CoreDataProperties.swift in Sources */,
 				864D67511E83E08E001E8D9E /* PickerViewController.swift in Sources */,
 				864D67531E83E08E001E8D9E /* StepikAlertViewController.swift in Sources */,
 				86795EF31E85265C00A985C2 /* AdaptiveStepViewController.swift in Sources */,
@@ -14329,6 +14391,7 @@
 				2C6640CF1F2F47A90033A274 /* AchievementManager.swift in Sources */,
 				864D66B71E83DE03001E8D9E /* CourseSubscriptionManager.swift in Sources */,
 				864D66B81E83DE03001E8D9E /* RemoteVersionManager.swift in Sources */,
+				087585A51FB50D640047A269 /* CourseListsAPI.swift in Sources */,
 				864D66B91E83DE03001E8D9E /* UpdateChecker.swift in Sources */,
 				080C5E861EFD252D0036EB3D /* CodeQuizToolbarDelegate.swift in Sources */,
 				864D66BA1E83DE03001E8D9E /* UpdatePreferencesContainer.swift in Sources */,
@@ -16125,6 +16188,7 @@
 		08D1EF6E1BB5618700BE84E6 /* Model.xcdatamodeld */ = {
 			isa = XCVersionGroup;
 			children = (
+				087585AB1FB50E220047A269 /* Model_courselists_v21.xcdatamodel */,
 				084DB9D31FA283C00074B11E /* Model_progress_activities_v20.xcdatamodel */,
 				2C9E3F351F7A79E600DDF1AA /* Model_notifications.xcdatamodel */,
 				08EDD6331F7CFAEC005203E4 /* Model_course_info_v18.xcdatamodel */,
@@ -16146,7 +16210,7 @@
 				0802AC531C7222B200C4F3E6 /* Model_v2.xcdatamodel */,
 				08D1EF6F1BB5618700BE84E6 /* Model.xcdatamodel */,
 			);
-			currentVersion = 084DB9D31FA283C00074B11E /* Model_progress_activities_v20.xcdatamodel */;
+			currentVersion = 087585AB1FB50E220047A269 /* Model_courselists_v21.xcdatamodel */;
 			path = Model.xcdatamodeld;
 			sourceTree = "<group>";
 			versionGroupType = wrapper.xcdatamodel;

--- a/Stepic.xcodeproj/project.pbxproj
+++ b/Stepic.xcodeproj/project.pbxproj
@@ -602,6 +602,22 @@
 		087F6B971CE9E2C8002649AB /* HTMLParsingUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = 087F6B951CE9E2C8002649AB /* HTMLParsingUtil.swift */; };
 		0884696C1E7C2E01009131E9 /* LastStepGlobalContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0884696B1E7C2E00009131E9 /* LastStepGlobalContext.swift */; };
 		0884696D1E7C2E01009131E9 /* LastStepGlobalContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0884696B1E7C2E00009131E9 /* LastStepGlobalContext.swift */; };
+		0885B8D21FB64452005A7B2E /* ContentLanguageCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0885B8D01FB64452005A7B2E /* ContentLanguageCollectionViewCell.swift */; };
+		0885B8D31FB64452005A7B2E /* ContentLanguageCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0885B8D01FB64452005A7B2E /* ContentLanguageCollectionViewCell.swift */; };
+		0885B8D41FB64452005A7B2E /* ContentLanguageCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0885B8D01FB64452005A7B2E /* ContentLanguageCollectionViewCell.swift */; };
+		0885B8D51FB64452005A7B2E /* ContentLanguageCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0885B8D01FB64452005A7B2E /* ContentLanguageCollectionViewCell.swift */; };
+		0885B8D61FB64452005A7B2E /* ContentLanguageCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0885B8D01FB64452005A7B2E /* ContentLanguageCollectionViewCell.swift */; };
+		0885B8D71FB64452005A7B2E /* ContentLanguageCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0885B8D01FB64452005A7B2E /* ContentLanguageCollectionViewCell.swift */; };
+		0885B8D81FB64452005A7B2E /* ContentLanguageCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0885B8D01FB64452005A7B2E /* ContentLanguageCollectionViewCell.swift */; };
+		0885B8D91FB64452005A7B2E /* ContentLanguageCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0885B8D01FB64452005A7B2E /* ContentLanguageCollectionViewCell.swift */; };
+		0885B8DA1FB64452005A7B2E /* ContentLanguageCollectionViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 0885B8D11FB64452005A7B2E /* ContentLanguageCollectionViewCell.xib */; };
+		0885B8DB1FB64452005A7B2E /* ContentLanguageCollectionViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 0885B8D11FB64452005A7B2E /* ContentLanguageCollectionViewCell.xib */; };
+		0885B8DC1FB64452005A7B2E /* ContentLanguageCollectionViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 0885B8D11FB64452005A7B2E /* ContentLanguageCollectionViewCell.xib */; };
+		0885B8DD1FB64452005A7B2E /* ContentLanguageCollectionViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 0885B8D11FB64452005A7B2E /* ContentLanguageCollectionViewCell.xib */; };
+		0885B8DE1FB64452005A7B2E /* ContentLanguageCollectionViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 0885B8D11FB64452005A7B2E /* ContentLanguageCollectionViewCell.xib */; };
+		0885B8DF1FB64452005A7B2E /* ContentLanguageCollectionViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 0885B8D11FB64452005A7B2E /* ContentLanguageCollectionViewCell.xib */; };
+		0885B8E01FB64452005A7B2E /* ContentLanguageCollectionViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 0885B8D11FB64452005A7B2E /* ContentLanguageCollectionViewCell.xib */; };
+		0885B8E11FB64452005A7B2E /* ContentLanguageCollectionViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 0885B8D11FB64452005A7B2E /* ContentLanguageCollectionViewCell.xib */; };
 		0885F8471BA833C600F2A188 /* CourseTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0885F8451BA833C600F2A188 /* CourseTableViewCell.swift */; };
 		0885F8481BA833C600F2A188 /* CourseTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 0885F8461BA833C600F2A188 /* CourseTableViewCell.xib */; };
 		0885F84E1BA837E200F2A188 /* ApiDataDownloader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0885F84D1BA837E200F2A188 /* ApiDataDownloader.swift */; };
@@ -892,6 +908,22 @@
 		08CB0D3F1FB5FB28001A1E02 /* Explore.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 08CB0D391FB5FB28001A1E02 /* Explore.storyboard */; };
 		08CB0D401FB5FB28001A1E02 /* Explore.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 08CB0D391FB5FB28001A1E02 /* Explore.storyboard */; };
 		08CB0D411FB5FB28001A1E02 /* Explore.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 08CB0D391FB5FB28001A1E02 /* Explore.storyboard */; };
+		08CB0D441FB63F74001A1E02 /* ContentLanguagesView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 08CB0D431FB63F74001A1E02 /* ContentLanguagesView.xib */; };
+		08CB0D451FB63F74001A1E02 /* ContentLanguagesView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 08CB0D431FB63F74001A1E02 /* ContentLanguagesView.xib */; };
+		08CB0D461FB63F74001A1E02 /* ContentLanguagesView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 08CB0D431FB63F74001A1E02 /* ContentLanguagesView.xib */; };
+		08CB0D471FB63F74001A1E02 /* ContentLanguagesView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 08CB0D431FB63F74001A1E02 /* ContentLanguagesView.xib */; };
+		08CB0D481FB63F74001A1E02 /* ContentLanguagesView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 08CB0D431FB63F74001A1E02 /* ContentLanguagesView.xib */; };
+		08CB0D491FB63F74001A1E02 /* ContentLanguagesView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 08CB0D431FB63F74001A1E02 /* ContentLanguagesView.xib */; };
+		08CB0D4A1FB63F74001A1E02 /* ContentLanguagesView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 08CB0D431FB63F74001A1E02 /* ContentLanguagesView.xib */; };
+		08CB0D4B1FB63F74001A1E02 /* ContentLanguagesView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 08CB0D431FB63F74001A1E02 /* ContentLanguagesView.xib */; };
+		08CB0D4D1FB63F83001A1E02 /* ContentLanguagesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08CB0D4C1FB63F83001A1E02 /* ContentLanguagesView.swift */; };
+		08CB0D4E1FB63F83001A1E02 /* ContentLanguagesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08CB0D4C1FB63F83001A1E02 /* ContentLanguagesView.swift */; };
+		08CB0D4F1FB63F83001A1E02 /* ContentLanguagesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08CB0D4C1FB63F83001A1E02 /* ContentLanguagesView.swift */; };
+		08CB0D501FB63F83001A1E02 /* ContentLanguagesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08CB0D4C1FB63F83001A1E02 /* ContentLanguagesView.swift */; };
+		08CB0D511FB63F83001A1E02 /* ContentLanguagesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08CB0D4C1FB63F83001A1E02 /* ContentLanguagesView.swift */; };
+		08CB0D521FB63F83001A1E02 /* ContentLanguagesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08CB0D4C1FB63F83001A1E02 /* ContentLanguagesView.swift */; };
+		08CB0D531FB63F83001A1E02 /* ContentLanguagesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08CB0D4C1FB63F83001A1E02 /* ContentLanguagesView.swift */; };
+		08CB0D541FB63F83001A1E02 /* ContentLanguagesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08CB0D4C1FB63F83001A1E02 /* ContentLanguagesView.swift */; };
 		08CB4ABE1C4D3DCE00D7F918 /* WKWebViewPanelManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 08CB4ABD1C4D3DCE00D7F918 /* WKWebViewPanelManager.m */; };
 		08CBA2F81F573F6900302154 /* MenuViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08CBA2F71F573F6900302154 /* MenuViewController.swift */; };
 		08CBA2F91F573F6900302154 /* MenuViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08CBA2F71F573F6900302154 /* MenuViewController.swift */; };
@@ -4663,6 +4695,8 @@
 		087D96BA1EBB7F5500059408 /* Tokens.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Tokens.swift; sourceTree = "<group>"; };
 		087F6B951CE9E2C8002649AB /* HTMLParsingUtil.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HTMLParsingUtil.swift; sourceTree = "<group>"; };
 		0884696B1E7C2E00009131E9 /* LastStepGlobalContext.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LastStepGlobalContext.swift; sourceTree = "<group>"; };
+		0885B8D01FB64452005A7B2E /* ContentLanguageCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentLanguageCollectionViewCell.swift; sourceTree = "<group>"; };
+		0885B8D11FB64452005A7B2E /* ContentLanguageCollectionViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ContentLanguageCollectionViewCell.xib; sourceTree = "<group>"; };
 		0885F8451BA833C600F2A188 /* CourseTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CourseTableViewCell.swift; sourceTree = "<group>"; };
 		0885F8461BA833C600F2A188 /* CourseTableViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = CourseTableViewCell.xib; sourceTree = "<group>"; };
 		0885F84D1BA837E200F2A188 /* ApiDataDownloader.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = ApiDataDownloader.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
@@ -4793,6 +4827,8 @@
 		08CB0D271FB5CD5E001A1E02 /* CourseListsCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseListsCache.swift; sourceTree = "<group>"; };
 		08CB0D301FB5F9FC001A1E02 /* ExploreViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExploreViewController.swift; sourceTree = "<group>"; };
 		08CB0D391FB5FB28001A1E02 /* Explore.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = Explore.storyboard; sourceTree = "<group>"; };
+		08CB0D431FB63F74001A1E02 /* ContentLanguagesView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ContentLanguagesView.xib; sourceTree = "<group>"; };
+		08CB0D4C1FB63F83001A1E02 /* ContentLanguagesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentLanguagesView.swift; sourceTree = "<group>"; };
 		08CB4ABC1C4D3DCE00D7F918 /* WKWebViewPanelManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKWebViewPanelManager.h; sourceTree = "<group>"; };
 		08CB4ABD1C4D3DCE00D7F918 /* WKWebViewPanelManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WKWebViewPanelManager.m; sourceTree = "<group>"; };
 		08CBA2F71F573F6900302154 /* MenuViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MenuViewController.swift; sourceTree = "<group>"; };
@@ -6149,6 +6185,7 @@
 		086E965C1BF6682000AB952D /* Views */ = {
 			isa = PBXGroup;
 			children = (
+				08CB0D421FB63F58001A1E02 /* ContentLanguagesView */,
 				2C9704221F3B1BFE00C36F0A /* TapProxyView.swift */,
 				08F476201E82C12B0018E82C /* StreaksView */,
 				08970EC91C6A325600846119 /* PlaceholderView */,
@@ -6578,6 +6615,17 @@
 				08047E6D1BFDC0470071C875 /* TitleTextTableViewCell.xib */,
 			);
 			name = "Cell classes";
+			sourceTree = "<group>";
+		};
+		08CB0D421FB63F58001A1E02 /* ContentLanguagesView */ = {
+			isa = PBXGroup;
+			children = (
+				08CB0D431FB63F74001A1E02 /* ContentLanguagesView.xib */,
+				08CB0D4C1FB63F83001A1E02 /* ContentLanguagesView.swift */,
+				0885B8D01FB64452005A7B2E /* ContentLanguageCollectionViewCell.swift */,
+				0885B8D11FB64452005A7B2E /* ContentLanguageCollectionViewCell.xib */,
+			);
+			name = ContentLanguagesView;
 			sourceTree = "<group>";
 		};
 		08CB4ABB1C4D3DAB00D7F918 /* WKWebViewPanelManager */ = {
@@ -8458,6 +8506,7 @@
 				083F2B241E9E645000714173 /* CertificateTableViewCell.xib in Resources */,
 				08EDB8CE1F7C4BDB0028A9AE /* CourseStatCollectionViewCell.xib in Resources */,
 				08EB85F91D10454E00E4F345 /* DiscussionsStoryboard.storyboard in Resources */,
+				08CB0D451FB63F74001A1E02 /* ContentLanguagesView.xib in Resources */,
 				086494A41E8C7A270083E0BE /* SbAuth.storyboard in Resources */,
 				0815661C1F69C3910082B359 /* CustomSearchBar.xib in Resources */,
 				08C6E31F1DFB2691007F7E39 /* StreakAlertViewController.xib in Resources */,
@@ -8501,6 +8550,7 @@
 				08D1211B1C937B2200A54ABC /* TeacherCollectionViewCell.xib in Resources */,
 				08D1211C1C937B2200A54ABC /* SectionTableViewCell.xib in Resources */,
 				08D1211D1C937B2200A54ABC /* SortingQuizTableViewCell.xib in Resources */,
+				0885B8DB1FB64452005A7B2E /* ContentLanguageCollectionViewCell.xib in Resources */,
 				084472091D05918E00197166 /* ChoiceQuizTableViewCell.xib in Resources */,
 				08E8F97E1F34E64E008CF4A1 /* SearchSuggestionTableViewCell.xib in Resources */,
 				08D1211E1C937B2200A54ABC /* StepicVideoPlayerViewController.xib in Resources */,
@@ -8525,6 +8575,7 @@
 				084DB9D51FA2A19F0074B11E /* ContinueLearningWidgetView.xib in Resources */,
 				08C7CB741FA7ACB9001D8241 /* CourseListEmptyPlaceholder.xib in Resources */,
 				08C0A4361BF12CDF0010F049 /* CustomMessagesDesign.json in Resources */,
+				0885B8DA1FB64452005A7B2E /* ContentLanguageCollectionViewCell.xib in Resources */,
 				084472081D05918E00197166 /* ChoiceQuizTableViewCell.xib in Resources */,
 				08047E6F1BFDC0480071C875 /* TitleTextTableViewCell.xib in Resources */,
 				081A7DF51C56A0DD00583728 /* UnknownTypeQuizViewController.xib in Resources */,
@@ -8581,6 +8632,7 @@
 				089056131E98021000B8FE6A /* RateAppViewController.xib in Resources */,
 				0869F6D81CE3684000F8A6DB /* default_sound.wav in Resources */,
 				08F4761E1E82C11C0018E82C /* StreaksView.xib in Resources */,
+				08CB0D441FB63F74001A1E02 /* ContentLanguagesView.xib in Resources */,
 				2CB9E8D11F839C8E0004E17F /* NotificationsTableViewCell.xib in Resources */,
 				08FEFC1E1F117257005CA0FB /* CodeSuggestionTableViewCell.xib in Resources */,
 				083F2B111E9D8E8F00714173 /* CertificatesStoryboard.storyboard in Resources */,
@@ -8673,6 +8725,7 @@
 				2C1B62731F4C4AEF00236804 /* CodeInputAccessoryView.xib in Resources */,
 				2C1B62741F4C4AEF00236804 /* SignInCoursesTableViewCell.xib in Resources */,
 				2C1B62751F4C4AEF00236804 /* PlayerTestStoryboard.storyboard in Resources */,
+				0885B8E01FB64452005A7B2E /* ContentLanguageCollectionViewCell.xib in Resources */,
 				2C1B62771F4C4AEF00236804 /* DownloadTableViewCell.xib in Resources */,
 				2C1B627A1F4C4AEF00236804 /* DiscussionWebTableViewCell.xib in Resources */,
 				2C1B627B1F4C4AEF00236804 /* CardOverlayView.xib in Resources */,
@@ -8708,6 +8761,7 @@
 				2C1B62951F4C4AEF00236804 /* UserPreferences.storyboard in Resources */,
 				2C1B62961F4C4AEF00236804 /* RefreshTableViewCell.xib in Resources */,
 				2C1B62981F4C4AEF00236804 /* CourseTableViewCell.xib in Resources */,
+				08CB0D4A1FB63F74001A1E02 /* ContentLanguagesView.xib in Resources */,
 				2C1B62991F4C4AEF00236804 /* SectionTableViewCell.xib in Resources */,
 				2C1B629A1F4C4AEF00236804 /* UnitTableViewCell.xib in Resources */,
 				2C1B629B1F4C4AEF00236804 /* Images.xcassets in Resources */,
@@ -8779,6 +8833,7 @@
 				2C1B64851F4C590700236804 /* step2.html in Resources */,
 				2C1B64861F4C590700236804 /* CodeInputAccessoryView.xib in Resources */,
 				2C1B64871F4C590700236804 /* SignInCoursesTableViewCell.xib in Resources */,
+				0885B8E11FB64452005A7B2E /* ContentLanguageCollectionViewCell.xib in Resources */,
 				2C1B64881F4C590700236804 /* PlayerTestStoryboard.storyboard in Resources */,
 				2C1B648A1F4C590700236804 /* DownloadTableViewCell.xib in Resources */,
 				2C1B648D1F4C590700236804 /* DiscussionWebTableViewCell.xib in Resources */,
@@ -8814,6 +8869,7 @@
 				2C1B64DE1F4C596500236804 /* GoogleService-Info.plist in Resources */,
 				2C1B64AA1F4C590700236804 /* step4.html in Resources */,
 				2C1B64AB1F4C590700236804 /* UserPreferences.storyboard in Resources */,
+				08CB0D4B1FB63F74001A1E02 /* ContentLanguagesView.xib in Resources */,
 				2C1B64AC1F4C590700236804 /* RefreshTableViewCell.xib in Resources */,
 				2C1B64AE1F4C590700236804 /* CourseTableViewCell.xib in Resources */,
 				2C1B64AF1F4C590700236804 /* SectionTableViewCell.xib in Resources */,
@@ -8860,10 +8916,12 @@
 				2C86540E1F4B33DE00D51654 /* Main.storyboard in Resources */,
 				2C86540F1F4B33DE00D51654 /* StepCardView.xib in Resources */,
 				2C8654101F4B33DE00D51654 /* CodeSuggestionsTableViewController.xib in Resources */,
+				0885B8DD1FB64452005A7B2E /* ContentLanguageCollectionViewCell.xib in Resources */,
 				2C8654111F4B33DE00D51654 /* PlaceholderView.storyboard in Resources */,
 				2C35C4E21F4DA486002F3BF4 /* nouns_f.plist in Resources */,
 				2C8654121F4B33DE00D51654 /* VideoDownloadView.xib in Resources */,
 				2C86548B1F4B3A6200D51654 /* Icons.xcassets in Resources */,
+				08CB0D471FB63F74001A1E02 /* ContentLanguagesView.xib in Resources */,
 				2C8654131F4B33DE00D51654 /* WarningView.xib in Resources */,
 				2C86548F1F4B3E1300D51654 /* MathJax in Resources */,
 				2C8654141F4B33DE00D51654 /* StepTabView.xib in Resources */,
@@ -8967,10 +9025,12 @@
 				2C89AAEE1F4C289900227C3B /* overlay_simple.png in Resources */,
 				2C89AAEF1F4C289900227C3B /* CurrentBestStreakViewController.xib in Resources */,
 				2C89AAF01F4C289900227C3B /* Main.storyboard in Resources */,
+				0885B8DE1FB64452005A7B2E /* ContentLanguageCollectionViewCell.xib in Resources */,
 				2C89AAF11F4C289900227C3B /* StepCardView.xib in Resources */,
 				2C35C4E31F4DA487002F3BF4 /* nouns_f.plist in Resources */,
 				2C89AAF21F4C289900227C3B /* CodeSuggestionsTableViewController.xib in Resources */,
 				2C89AAF31F4C289900227C3B /* PlaceholderView.storyboard in Resources */,
+				08CB0D481FB63F74001A1E02 /* ContentLanguagesView.xib in Resources */,
 				2C89AAF41F4C289900227C3B /* VideoDownloadView.xib in Resources */,
 				2C89AAF61F4C289900227C3B /* WarningView.xib in Resources */,
 				2C89AAF71F4C289900227C3B /* MathJax in Resources */,
@@ -9099,6 +9159,7 @@
 				2C9732B51F4C38F600AC9301 /* StepicVideoPlayerViewController.xib in Resources */,
 				2C9732B71F4C38F600AC9301 /* step2.html in Resources */,
 				2C9732B81F4C38F600AC9301 /* CodeInputAccessoryView.xib in Resources */,
+				0885B8DF1FB64452005A7B2E /* ContentLanguageCollectionViewCell.xib in Resources */,
 				2C9732B91F4C38F600AC9301 /* SignInCoursesTableViewCell.xib in Resources */,
 				2C9732BA1F4C38F600AC9301 /* PlayerTestStoryboard.storyboard in Resources */,
 				2C9732BC1F4C38F600AC9301 /* DownloadTableViewCell.xib in Resources */,
@@ -9134,6 +9195,7 @@
 				2C9732D41F4C38F600AC9301 /* TitleTextTableViewCell.xib in Resources */,
 				2C9732D51F4C38F600AC9301 /* step4.html in Resources */,
 				2C9732D61F4C38F600AC9301 /* UserPreferences.storyboard in Resources */,
+				08CB0D491FB63F74001A1E02 /* ContentLanguagesView.xib in Resources */,
 				2C9732D71F4C38F600AC9301 /* RefreshTableViewCell.xib in Resources */,
 				2C9732D91F4C38F600AC9301 /* CourseTableViewCell.xib in Resources */,
 				2C35C4E41F4DA487002F3BF4 /* nouns_f.plist in Resources */,
@@ -9253,6 +9315,7 @@
 				86AE94771E84511A00F67691 /* PlayerTestStoryboard.storyboard in Resources */,
 				86AE94781E84511A00F67691 /* DownloadTableViewCell.xib in Resources */,
 				86AE94791E84511A00F67691 /* DiscussionWebTableViewCell.xib in Resources */,
+				0885B8DC1FB64452005A7B2E /* ContentLanguageCollectionViewCell.xib in Resources */,
 				866DDDC61EA8076D00BAD48E /* CardOverlayView.xib in Resources */,
 				86AE947A1E84511A00F67691 /* DiscussionTableViewCell.xib in Resources */,
 				86AE947B1E84511A00F67691 /* DiscussionsViewController.xib in Resources */,
@@ -9288,6 +9351,7 @@
 				2C9704211F3B0B7F00C36F0A /* step4.html in Resources */,
 				86AE94881E84511A00F67691 /* UserPreferences.storyboard in Resources */,
 				86AE94891E84511A00F67691 /* RefreshTableViewCell.xib in Resources */,
+				08CB0D461FB63F74001A1E02 /* ContentLanguagesView.xib in Resources */,
 				86AE948A1E84511A00F67691 /* CourseTableViewCell.xib in Resources */,
 				86AE948B1E84511A00F67691 /* SectionTableViewCell.xib in Resources */,
 				86AE948C1E84511A00F67691 /* UnitTableViewCell.xib in Resources */,
@@ -11229,6 +11293,7 @@
 				08D1209C1C937B2200A54ABC /* ControllerHelper.swift in Sources */,
 				085C4FF71D8C835600B27C95 /* StepsControllerDeepLinkRouter.swift in Sources */,
 				08E6BB691DC8DF59006622EC /* UserActivitiesAPI.swift in Sources */,
+				08CB0D4E1FB63F83001A1E02 /* ContentLanguagesView.swift in Sources */,
 				0846B1041EDDED1000D64D77 /* StepOptions.swift in Sources */,
 				08D1209D1C937B2200A54ABC /* Progress+CoreDataProperties.swift in Sources */,
 				080EBA341EA64BC000C43C93 /* PresentationContainer.swift in Sources */,
@@ -11383,6 +11448,7 @@
 				0846B1081EDDED4400D64D77 /* StepOptions+CoreDataProperties.swift in Sources */,
 				08E8F96D1F34DD48008CF4A1 /* SearchQueriesView.swift in Sources */,
 				086442C41F764FEE000CC53D /* EmailAuthPresenter.swift in Sources */,
+				0885B8D31FB64452005A7B2E /* ContentLanguageCollectionViewCell.swift in Sources */,
 				081959EB1FA007D800E6D6CD /* HomeScreenViewController.swift in Sources */,
 				08D120DF1C937B2200A54ABC /* EmptyDatasetState.swift in Sources */,
 				0864949F1E8C79690083E0BE /* SbEntranceViewController.swift in Sources */,
@@ -11502,6 +11568,7 @@
 				0846B1031EDDED1000D64D77 /* StepOptions.swift in Sources */,
 				08D1EF741BB5636700BE84E6 /* Course.swift in Sources */,
 				088CB1EC1D4BD5ED00C6ED1B /* FreeAnswerDataset.swift in Sources */,
+				08CB0D4D1FB63F83001A1E02 /* ContentLanguagesView.swift in Sources */,
 				08AF59FC1E6D9BE800423EFF /* RGPageViewControllerDelegate.swift in Sources */,
 				086A9D621C74AF90003611DC /* GlobalFunctions.swift in Sources */,
 				08EB85E91D0F649700E4F345 /* CellOperationsUtil.swift in Sources */,
@@ -11748,6 +11815,7 @@
 				0899842F1ECDE19E005C0B27 /* LessonView.swift in Sources */,
 				0891424B1BCEE4EF0000BCB0 /* VideoURL.swift in Sources */,
 				080EBA371EA64C0C00C43C93 /* CertificatesPresentationContainer.swift in Sources */,
+				0885B8D21FB64452005A7B2E /* ContentLanguageCollectionViewCell.swift in Sources */,
 				08EB85F01D101D7800E4F345 /* WriteCommentViewController.swift in Sources */,
 				08AEC3A71CCA75F400FFF29E /* APIDefaults.swift in Sources */,
 				080CE1611E9581960089A27F /* SubmissionsAPI.swift in Sources */,
@@ -12196,6 +12264,7 @@
 				08195A1E1FA0AF1200E6D6CD /* HorizontalCoursesView.swift in Sources */,
 				2C1B61A81F4C4AEF00236804 /* AchievementManager.swift in Sources */,
 				2C1B61A91F4C4AEF00236804 /* CourseSubscriptionManager.swift in Sources */,
+				0885B8D81FB64452005A7B2E /* ContentLanguageCollectionViewCell.swift in Sources */,
 				2C1B61AA1F4C4AEF00236804 /* RemoteVersionManager.swift in Sources */,
 				087585A91FB50D640047A269 /* CourseListsAPI.swift in Sources */,
 				2C1B61AB1F4C4AEF00236804 /* UpdateChecker.swift in Sources */,
@@ -12203,6 +12272,7 @@
 				2C1B61AD1F4C4AEF00236804 /* UpdatePreferencesContainer.swift in Sources */,
 				2C1B61AE1F4C4AEF00236804 /* VersionUpdateAlertConstructor.swift in Sources */,
 				2C1B61AF1F4C4AEF00236804 /* Version.swift in Sources */,
+				08CB0D531FB63F83001A1E02 /* ContentLanguagesView.swift in Sources */,
 				2C1B61B01F4C4AEF00236804 /* SubmissonManager.swift in Sources */,
 				2C1B61B11F4C4AEF00236804 /* QuizDataManager.swift in Sources */,
 				2C1B61B21F4C4AEF00236804 /* Executable.swift in Sources */,
@@ -12643,6 +12713,7 @@
 				08195A1F1FA0AF1200E6D6CD /* HorizontalCoursesView.swift in Sources */,
 				2C1B63B91F4C590700236804 /* AchievementManager.swift in Sources */,
 				2C1B63BA1F4C590700236804 /* CourseSubscriptionManager.swift in Sources */,
+				0885B8D91FB64452005A7B2E /* ContentLanguageCollectionViewCell.swift in Sources */,
 				2C1B63BB1F4C590700236804 /* RemoteVersionManager.swift in Sources */,
 				087585AA1FB50D640047A269 /* CourseListsAPI.swift in Sources */,
 				2C1B63BC1F4C590700236804 /* UpdateChecker.swift in Sources */,
@@ -12650,6 +12721,7 @@
 				2C1B63BE1F4C590700236804 /* UpdatePreferencesContainer.swift in Sources */,
 				2C1B63BF1F4C590700236804 /* VersionUpdateAlertConstructor.swift in Sources */,
 				2C1B63C01F4C590700236804 /* Version.swift in Sources */,
+				08CB0D541FB63F83001A1E02 /* ContentLanguagesView.swift in Sources */,
 				2C1B63C11F4C590700236804 /* SubmissonManager.swift in Sources */,
 				2C1B63C21F4C590700236804 /* QuizDataManager.swift in Sources */,
 				2C1B63C31F4C590700236804 /* Executable.swift in Sources */,
@@ -13090,6 +13162,7 @@
 				08195A1B1FA0AF1200E6D6CD /* HorizontalCoursesView.swift in Sources */,
 				2C8653561F4B33DE00D51654 /* AchievementManager.swift in Sources */,
 				2C8653571F4B33DE00D51654 /* CourseSubscriptionManager.swift in Sources */,
+				0885B8D51FB64452005A7B2E /* ContentLanguageCollectionViewCell.swift in Sources */,
 				2C8653581F4B33DE00D51654 /* RemoteVersionManager.swift in Sources */,
 				087585A61FB50D640047A269 /* CourseListsAPI.swift in Sources */,
 				2C8653591F4B33DE00D51654 /* UpdateChecker.swift in Sources */,
@@ -13097,6 +13170,7 @@
 				2C86535B1F4B33DE00D51654 /* UpdatePreferencesContainer.swift in Sources */,
 				2C86535C1F4B33DE00D51654 /* VersionUpdateAlertConstructor.swift in Sources */,
 				2C86535D1F4B33DE00D51654 /* Version.swift in Sources */,
+				08CB0D501FB63F83001A1E02 /* ContentLanguagesView.swift in Sources */,
 				2C86535E1F4B33DE00D51654 /* SubmissonManager.swift in Sources */,
 				2C86535F1F4B33DE00D51654 /* QuizDataManager.swift in Sources */,
 				2C8653601F4B33DE00D51654 /* Executable.swift in Sources */,
@@ -13365,6 +13439,7 @@
 				2C89A99E1F4C289900227C3B /* DiscussionWebTableViewCell.swift in Sources */,
 				2C89A99F1F4C289900227C3B /* DiscussionTableViewCell.swift in Sources */,
 				2C89A9A01F4C289900227C3B /* HTMLContentView.swift in Sources */,
+				0885B8D61FB64452005A7B2E /* ContentLanguageCollectionViewCell.swift in Sources */,
 				2C89A9A11F4C289900227C3B /* HTMLStringWrapperUtil.swift in Sources */,
 				2C89A9A21F4C289900227C3B /* HTMLContentViewInteractionDelegate.swift in Sources */,
 				2C89A9A31F4C289900227C3B /* AdaptiveStepsPresenter.swift in Sources */,
@@ -13499,6 +13574,7 @@
 				2C89AA1F1F4C289900227C3B /* RatingHelper.swift in Sources */,
 				2C89AA201F4C289900227C3B /* TimeFormatHelper.swift in Sources */,
 				084490041F5CE15200D01940 /* SettingsPresenter.swift in Sources */,
+				08CB0D511FB63F83001A1E02 /* ContentLanguagesView.swift in Sources */,
 				2C89AA211F4C289900227C3B /* WebViewHorizontalScrollHelper.swift in Sources */,
 				0897009A1F6B2A830041C24E /* NibInitializableView.swift in Sources */,
 				2C89AA221F4C289900227C3B /* CodeInputAccessoryCollectionViewCell.swift in Sources */,
@@ -13983,6 +14059,7 @@
 				08195A1D1FA0AF1200E6D6CD /* HorizontalCoursesView.swift in Sources */,
 				2C9731F01F4C38F600AC9301 /* AchievementManager.swift in Sources */,
 				2C9731F11F4C38F600AC9301 /* CourseSubscriptionManager.swift in Sources */,
+				0885B8D71FB64452005A7B2E /* ContentLanguageCollectionViewCell.swift in Sources */,
 				2C9731F21F4C38F600AC9301 /* RemoteVersionManager.swift in Sources */,
 				087585A81FB50D640047A269 /* CourseListsAPI.swift in Sources */,
 				2C9731F31F4C38F600AC9301 /* UpdateChecker.swift in Sources */,
@@ -13990,6 +14067,7 @@
 				2C9731F51F4C38F600AC9301 /* UpdatePreferencesContainer.swift in Sources */,
 				2C9731F61F4C38F600AC9301 /* VersionUpdateAlertConstructor.swift in Sources */,
 				2C9731F71F4C38F600AC9301 /* Version.swift in Sources */,
+				08CB0D521FB63F83001A1E02 /* ContentLanguagesView.swift in Sources */,
 				2C9731F81F4C38F600AC9301 /* SubmissonManager.swift in Sources */,
 				2C9731F91F4C38F600AC9301 /* QuizDataManager.swift in Sources */,
 				2C9731FA1F4C38F600AC9301 /* Executable.swift in Sources */,
@@ -14484,6 +14562,7 @@
 				08195A1A1FA0AF1200E6D6CD /* HorizontalCoursesView.swift in Sources */,
 				2C6640CF1F2F47A90033A274 /* AchievementManager.swift in Sources */,
 				864D66B71E83DE03001E8D9E /* CourseSubscriptionManager.swift in Sources */,
+				0885B8D41FB64452005A7B2E /* ContentLanguageCollectionViewCell.swift in Sources */,
 				864D66B81E83DE03001E8D9E /* RemoteVersionManager.swift in Sources */,
 				087585A51FB50D640047A269 /* CourseListsAPI.swift in Sources */,
 				864D66B91E83DE03001E8D9E /* UpdateChecker.swift in Sources */,
@@ -14491,6 +14570,7 @@
 				864D66BA1E83DE03001E8D9E /* UpdatePreferencesContainer.swift in Sources */,
 				864D66BB1E83DE03001E8D9E /* VersionUpdateAlertConstructor.swift in Sources */,
 				082E5E101F46379100F41426 /* ReplyCache.swift in Sources */,
+				08CB0D4F1FB63F83001A1E02 /* ContentLanguagesView.swift in Sources */,
 				864D66BC1E83DE03001E8D9E /* Version.swift in Sources */,
 				864D66BD1E83DE03001E8D9E /* SubmissonManager.swift in Sources */,
 				864D66BE1E83DE03001E8D9E /* QuizDataManager.swift in Sources */,

--- a/Stepic.xcodeproj/project.pbxproj
+++ b/Stepic.xcodeproj/project.pbxproj
@@ -848,6 +848,22 @@
 		08C0A4361BF12CDF0010F049 /* CustomMessagesDesign.json in Resources */ = {isa = PBXBuildFile; fileRef = 08C0A4351BF12CDF0010F049 /* CustomMessagesDesign.json */; };
 		08C194401ED0A05D00A41B72 /* PagerController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08C1943F1ED0A05D00A41B72 /* PagerController.swift */; };
 		08C194411ED0A05D00A41B72 /* PagerController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08C1943F1ED0A05D00A41B72 /* PagerController.swift */; };
+		08C1BF281FB9ED01008F342F /* SearchResultsPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08C1BF271FB9ED01008F342F /* SearchResultsPresenter.swift */; };
+		08C1BF291FB9ED01008F342F /* SearchResultsPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08C1BF271FB9ED01008F342F /* SearchResultsPresenter.swift */; };
+		08C1BF2A1FB9ED01008F342F /* SearchResultsPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08C1BF271FB9ED01008F342F /* SearchResultsPresenter.swift */; };
+		08C1BF2B1FB9ED01008F342F /* SearchResultsPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08C1BF271FB9ED01008F342F /* SearchResultsPresenter.swift */; };
+		08C1BF2C1FB9ED01008F342F /* SearchResultsPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08C1BF271FB9ED01008F342F /* SearchResultsPresenter.swift */; };
+		08C1BF2D1FB9ED01008F342F /* SearchResultsPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08C1BF271FB9ED01008F342F /* SearchResultsPresenter.swift */; };
+		08C1BF2E1FB9ED01008F342F /* SearchResultsPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08C1BF271FB9ED01008F342F /* SearchResultsPresenter.swift */; };
+		08C1BF2F1FB9ED01008F342F /* SearchResultsPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08C1BF271FB9ED01008F342F /* SearchResultsPresenter.swift */; };
+		08C1BF311FBA0CA1008F342F /* NewSearchResultsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08C1BF301FBA0CA1008F342F /* NewSearchResultsViewController.swift */; };
+		08C1BF321FBA0CA1008F342F /* NewSearchResultsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08C1BF301FBA0CA1008F342F /* NewSearchResultsViewController.swift */; };
+		08C1BF331FBA0CA1008F342F /* NewSearchResultsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08C1BF301FBA0CA1008F342F /* NewSearchResultsViewController.swift */; };
+		08C1BF341FBA0CA1008F342F /* NewSearchResultsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08C1BF301FBA0CA1008F342F /* NewSearchResultsViewController.swift */; };
+		08C1BF351FBA0CA1008F342F /* NewSearchResultsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08C1BF301FBA0CA1008F342F /* NewSearchResultsViewController.swift */; };
+		08C1BF361FBA0CA1008F342F /* NewSearchResultsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08C1BF301FBA0CA1008F342F /* NewSearchResultsViewController.swift */; };
+		08C1BF371FBA0CA1008F342F /* NewSearchResultsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08C1BF301FBA0CA1008F342F /* NewSearchResultsViewController.swift */; };
+		08C1BF381FBA0CA1008F342F /* NewSearchResultsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08C1BF301FBA0CA1008F342F /* NewSearchResultsViewController.swift */; };
 		08C1FC331F41E74500E14B46 /* QuizPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08C1FC321F41E74500E14B46 /* QuizPresenter.swift */; };
 		08C1FC341F41E74500E14B46 /* QuizPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08C1FC321F41E74500E14B46 /* QuizPresenter.swift */; };
 		08C1FC351F41E74500E14B46 /* QuizPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08C1FC321F41E74500E14B46 /* QuizPresenter.swift */; };
@@ -4806,6 +4822,8 @@
 		08C0A4331BF1276C0010F049 /* Messages.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Messages.swift; sourceTree = "<group>"; };
 		08C0A4351BF12CDF0010F049 /* CustomMessagesDesign.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = CustomMessagesDesign.json; sourceTree = "<group>"; };
 		08C1943F1ED0A05D00A41B72 /* PagerController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PagerController.swift; sourceTree = "<group>"; };
+		08C1BF271FB9ED01008F342F /* SearchResultsPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchResultsPresenter.swift; sourceTree = "<group>"; };
+		08C1BF301FBA0CA1008F342F /* NewSearchResultsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewSearchResultsViewController.swift; sourceTree = "<group>"; };
 		08C1FC321F41E74500E14B46 /* QuizPresenter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = QuizPresenter.swift; sourceTree = "<group>"; };
 		08C5E4FC1C315272004AA626 /* AudioManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AudioManager.swift; sourceTree = "<group>"; };
 		08C6E31A1DFB2691007F7E39 /* StreakAlertViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StreakAlertViewController.swift; sourceTree = "<group>"; };
@@ -6295,6 +6313,7 @@
 		0885F84C1BA8378B00F2A188 /* Courses */ = {
 			isa = PBXGroup;
 			children = (
+				08C1BF261FB9ECE2008F342F /* Search Results */,
 				085290C41FB5C43C0053F22D /* Explore */,
 				08C7CB721FA7AC73001D8241 /* CourseListEmptyPlaceholder */,
 				084896931F9E8A1E00CFA273 /* Continue Learning Widget */,
@@ -6586,6 +6605,15 @@
 				08CBA3531F5A2D9400302154 /* Profile.storyboard */,
 			);
 			name = new;
+			sourceTree = "<group>";
+		};
+		08C1BF261FB9ECE2008F342F /* Search Results */ = {
+			isa = PBXGroup;
+			children = (
+				08C1BF271FB9ED01008F342F /* SearchResultsPresenter.swift */,
+				08C1BF301FBA0CA1008F342F /* NewSearchResultsViewController.swift */,
+			);
+			name = "Search Results";
 			sourceTree = "<group>";
 		};
 		08C7CB721FA7AC73001D8241 /* CourseListEmptyPlaceholder */ = {
@@ -11502,6 +11530,7 @@
 				08D120F11C937B2200A54ABC /* Meta.swift in Sources */,
 				08D120F31C937B2200A54ABC /* StepicToken.swift in Sources */,
 				08D120F41C937B2200A54ABC /* Styles.swift in Sources */,
+				08C1BF321FBA0CA1008F342F /* NewSearchResultsViewController.swift in Sources */,
 				080217841F55B1B200186245 /* Menu.swift in Sources */,
 				08D120F51C937B2200A54ABC /* SectionsViewController.swift in Sources */,
 				088EDB511F8E8A5D009B736E /* CourseListVerticalViewController.swift in Sources */,
@@ -11515,6 +11544,7 @@
 				0805FE451F0D390B001226B4 /* CodePlaygroundManager.swift in Sources */,
 				08D120F81C937B2200A54ABC /* ChoiceDataset.swift in Sources */,
 				08263D711DE5F230002E5B7F /* NotificationTimePickerViewController.swift in Sources */,
+				08C1BF291FB9ED01008F342F /* SearchResultsPresenter.swift in Sources */,
 				08D120F91C937B2200A54ABC /* TeacherCollectionViewCell.swift in Sources */,
 				08AF59F31E6D9BE800423EFF /* RGPageViewController+UIPageViewControllerDelegate.swift in Sources */,
 				085DF8D91C99C49E006809D9 /* VideoRate.swift in Sources */,
@@ -11759,6 +11789,7 @@
 				080CE1431E955D300089A27F /* CoursesAPI.swift in Sources */,
 				08FB30E31DC385B400E4684F /* ProfileViewController.swift in Sources */,
 				08F485A51C57AF2E000165AA /* FreeAnswerReply.swift in Sources */,
+				08C1BF311FBA0CA1008F342F /* NewSearchResultsViewController.swift in Sources */,
 				08C1FC331F41E74500E14B46 /* QuizPresenter.swift in Sources */,
 				9F9C71581E076B3E00EC8DA3 /* CoursePlainEntity.swift in Sources */,
 				084490001F5CE15200D01940 /* SettingsPresenter.swift in Sources */,
@@ -11885,6 +11916,7 @@
 				086BE2851F901CCF00B4BE56 /* LastStepRouter.swift in Sources */,
 				08B5E29A1BF509C900B875E6 /* UIThreadHelper.swift in Sources */,
 				08AF59EA1E6D9BE800423EFF /* RGPageViewController+UICollectionViewDataSource.swift in Sources */,
+				08C1BF281FB9ED01008F342F /* SearchResultsPresenter.swift in Sources */,
 				080EBA331EA64BC000C43C93 /* PresentationContainer.swift in Sources */,
 				0889FEAF1BFB771200C6417E /* DownloadsViewController.swift in Sources */,
 				083749371DE5C7DC00144C14 /* LocalNotificationManager.swift in Sources */,
@@ -12104,6 +12136,7 @@
 				2C1B61101F4C4AEF00236804 /* DiscussionsViewController.swift in Sources */,
 				2C1B61111F4C4AEF00236804 /* LoadMoreTableViewCell.swift in Sources */,
 				2C1B61121F4C4AEF00236804 /* DiscussionUpdateDelegate.swift in Sources */,
+				08C1BF371FBA0CA1008F342F /* NewSearchResultsViewController.swift in Sources */,
 				2C1B61131F4C4AEF00236804 /* CellOperationsUtil.swift in Sources */,
 				088EDB5F1F8F5A48009B736E /* CourseListViewController.swift in Sources */,
 				2C1B61141F4C4AEF00236804 /* AdaptiveStepPresenter.swift in Sources */,
@@ -12172,6 +12205,7 @@
 				2C1B614D1F4C4AEF00236804 /* ProfileViewController.swift in Sources */,
 				2C1B614E1F4C4AEF00236804 /* NotificationTimePickerViewController.swift in Sources */,
 				2C1B614F1F4C4AEF00236804 /* RefreshTableViewCell.swift in Sources */,
+				08C1BF2E1FB9ED01008F342F /* SearchResultsPresenter.swift in Sources */,
 				2C1B61501F4C4AEF00236804 /* StepCardView.swift in Sources */,
 				2C1B61511F4C4AEF00236804 /* TapProxyView.swift in Sources */,
 				2C1B61571F4C4AEF00236804 /* CodeSample+CoreDataProperties.swift in Sources */,
@@ -12553,6 +12587,7 @@
 				2C1B63211F4C590700236804 /* DiscussionsViewController.swift in Sources */,
 				2C1B63221F4C590700236804 /* LoadMoreTableViewCell.swift in Sources */,
 				2C1B63231F4C590700236804 /* DiscussionUpdateDelegate.swift in Sources */,
+				08C1BF381FBA0CA1008F342F /* NewSearchResultsViewController.swift in Sources */,
 				2C1B63241F4C590700236804 /* CellOperationsUtil.swift in Sources */,
 				088EDB601F8F5A48009B736E /* CourseListViewController.swift in Sources */,
 				2C1B63251F4C590700236804 /* AdaptiveStepPresenter.swift in Sources */,
@@ -12621,6 +12656,7 @@
 				2C1B635E1F4C590700236804 /* ProfileViewController.swift in Sources */,
 				2C1B635F1F4C590700236804 /* NotificationTimePickerViewController.swift in Sources */,
 				2C1B63601F4C590700236804 /* RefreshTableViewCell.swift in Sources */,
+				08C1BF2F1FB9ED01008F342F /* SearchResultsPresenter.swift in Sources */,
 				2C1B63611F4C590700236804 /* StepCardView.swift in Sources */,
 				2C1B63621F4C590700236804 /* TapProxyView.swift in Sources */,
 				2C1B63681F4C590700236804 /* CodeSample+CoreDataProperties.swift in Sources */,
@@ -13002,6 +13038,7 @@
 				2C8652BE1F4B33DE00D51654 /* DiscussionsViewController.swift in Sources */,
 				2C8652BF1F4B33DE00D51654 /* LoadMoreTableViewCell.swift in Sources */,
 				2C8652C01F4B33DE00D51654 /* DiscussionUpdateDelegate.swift in Sources */,
+				08C1BF341FBA0CA1008F342F /* NewSearchResultsViewController.swift in Sources */,
 				2C8652C11F4B33DE00D51654 /* CellOperationsUtil.swift in Sources */,
 				088EDB5C1F8F5A48009B736E /* CourseListViewController.swift in Sources */,
 				2C8652C21F4B33DE00D51654 /* AdaptiveStepPresenter.swift in Sources */,
@@ -13070,6 +13107,7 @@
 				2C8652FB1F4B33DE00D51654 /* ProfileViewController.swift in Sources */,
 				2C8652FC1F4B33DE00D51654 /* NotificationTimePickerViewController.swift in Sources */,
 				2C8652FD1F4B33DE00D51654 /* RefreshTableViewCell.swift in Sources */,
+				08C1BF2B1FB9ED01008F342F /* SearchResultsPresenter.swift in Sources */,
 				2C8652FE1F4B33DE00D51654 /* StepCardView.swift in Sources */,
 				2C8652FF1F4B33DE00D51654 /* TapProxyView.swift in Sources */,
 				2C8653051F4B33DE00D51654 /* CodeSample+CoreDataProperties.swift in Sources */,
@@ -13522,6 +13560,7 @@
 				2C89A9F21F4C289900227C3B /* FindCoursesViewController.swift in Sources */,
 				086442BF1F764F92000CC53D /* EmailAuthViewController.swift in Sources */,
 				2C89A9F31F4C289900227C3B /* MyCoursesViewController.swift in Sources */,
+				08C1BF351FBA0CA1008F342F /* NewSearchResultsViewController.swift in Sources */,
 				2C89A9F41F4C289900227C3B /* CoursesViewController.swift in Sources */,
 				086BE2B61F93A21B00B4BE56 /* LoadingCourseWidgetView.swift in Sources */,
 				2C89A9F51F4C289900227C3B /* DefaultsStorageManager.swift in Sources */,
@@ -13534,6 +13573,7 @@
 				2C89A9FC1F4C289900227C3B /* FullscreenCodeQuizViewController.swift in Sources */,
 				2C89A9FD1F4C289900227C3B /* UnitTableViewCell.swift in Sources */,
 				2C89A9FE1F4C289900227C3B /* SectionNavigationDelegate.swift in Sources */,
+				08C1BF2C1FB9ED01008F342F /* SearchResultsPresenter.swift in Sources */,
 				2C89A9FF1F4C289900227C3B /* ReplaceLastSegue.swift in Sources */,
 				2C89AA001F4C289900227C3B /* StyledNavigationViewController.swift in Sources */,
 				08CBA32B1F57563C00302154 /* TransitionMenuBlockTableViewCell.swift in Sources */,
@@ -13899,6 +13939,7 @@
 				2C9731581F4C38F600AC9301 /* DiscussionsViewController.swift in Sources */,
 				2C9731591F4C38F600AC9301 /* LoadMoreTableViewCell.swift in Sources */,
 				2C97315A1F4C38F600AC9301 /* DiscussionUpdateDelegate.swift in Sources */,
+				08C1BF361FBA0CA1008F342F /* NewSearchResultsViewController.swift in Sources */,
 				2C97315B1F4C38F600AC9301 /* CellOperationsUtil.swift in Sources */,
 				088EDB5E1F8F5A48009B736E /* CourseListViewController.swift in Sources */,
 				2C97315C1F4C38F600AC9301 /* AdaptiveStepPresenter.swift in Sources */,
@@ -13967,6 +14008,7 @@
 				2C9731951F4C38F600AC9301 /* ProfileViewController.swift in Sources */,
 				2C9731961F4C38F600AC9301 /* NotificationTimePickerViewController.swift in Sources */,
 				2C9731971F4C38F600AC9301 /* RefreshTableViewCell.swift in Sources */,
+				08C1BF2D1FB9ED01008F342F /* SearchResultsPresenter.swift in Sources */,
 				2C9731981F4C38F600AC9301 /* StepCardView.swift in Sources */,
 				2C9731991F4C38F600AC9301 /* TapProxyView.swift in Sources */,
 				2C97319F1F4C38F600AC9301 /* CodeSample+CoreDataProperties.swift in Sources */,
@@ -14402,6 +14444,7 @@
 				864D67671E83E08E001E8D9E /* DiscussionsViewController.swift in Sources */,
 				864D67691E83E08E001E8D9E /* LoadMoreTableViewCell.swift in Sources */,
 				864D676B1E83E08E001E8D9E /* DiscussionUpdateDelegate.swift in Sources */,
+				08C1BF331FBA0CA1008F342F /* NewSearchResultsViewController.swift in Sources */,
 				864D676C1E83E08E001E8D9E /* CellOperationsUtil.swift in Sources */,
 				088EDB5B1F8F5A48009B736E /* CourseListViewController.swift in Sources */,
 				2C5F48D71F0F6FBD00C3A398 /* AdaptiveStepPresenter.swift in Sources */,
@@ -14470,6 +14513,7 @@
 				864D67AB1E83E08E001E8D9E /* ProfileViewController.swift in Sources */,
 				864D67AC1E83E08E001E8D9E /* NotificationTimePickerViewController.swift in Sources */,
 				864D67AD1E83E08E001E8D9E /* RefreshTableViewCell.swift in Sources */,
+				08C1BF2A1FB9ED01008F342F /* SearchResultsPresenter.swift in Sources */,
 				86ABC66C1E96867A0012E8A6 /* StepCardView.swift in Sources */,
 				2C9704231F3B1BFE00C36F0A /* TapProxyView.swift in Sources */,
 				080C5E821EFC28CF0036EB3D /* CodeSample+CoreDataProperties.swift in Sources */,

--- a/Stepic.xcodeproj/project.pbxproj
+++ b/Stepic.xcodeproj/project.pbxproj
@@ -575,6 +575,14 @@
 		087585BC1FB51D840047A269 /* CourseList+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 087585B61FB51D840047A269 /* CourseList+CoreDataProperties.swift */; };
 		087585BD1FB51D840047A269 /* CourseList+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 087585B61FB51D840047A269 /* CourseList+CoreDataProperties.swift */; };
 		087585BE1FB51D840047A269 /* CourseList+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 087585B61FB51D840047A269 /* CourseList+CoreDataProperties.swift */; };
+		087585C01FB524C20047A269 /* ContentLanguage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 087585BF1FB524C20047A269 /* ContentLanguage.swift */; };
+		087585C11FB524C20047A269 /* ContentLanguage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 087585BF1FB524C20047A269 /* ContentLanguage.swift */; };
+		087585C21FB524C20047A269 /* ContentLanguage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 087585BF1FB524C20047A269 /* ContentLanguage.swift */; };
+		087585C31FB524C20047A269 /* ContentLanguage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 087585BF1FB524C20047A269 /* ContentLanguage.swift */; };
+		087585C41FB524C20047A269 /* ContentLanguage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 087585BF1FB524C20047A269 /* ContentLanguage.swift */; };
+		087585C51FB524C20047A269 /* ContentLanguage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 087585BF1FB524C20047A269 /* ContentLanguage.swift */; };
+		087585C61FB524C20047A269 /* ContentLanguage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 087585BF1FB524C20047A269 /* ContentLanguage.swift */; };
+		087585C71FB524C20047A269 /* ContentLanguage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 087585BF1FB524C20047A269 /* ContentLanguage.swift */; };
 		08758A9B1CDB99C400159233 /* DevicesAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08AEC3A21CCA69C700FFF29E /* DevicesAPI.swift */; };
 		08758A9C1CDB99C700159233 /* APIDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08AEC3A61CCA75F400FFF29E /* APIDefaults.swift */; };
 		08758A9D1CDB99CF00159233 /* Device.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08AEC3A41CCA69F300FFF29E /* Device.swift */; };
@@ -4616,6 +4624,7 @@
 		087585AB1FB50E220047A269 /* Model_courselists_v21.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = Model_courselists_v21.xcdatamodel; sourceTree = "<group>"; };
 		087585AD1FB51D720047A269 /* CourseList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseList.swift; sourceTree = "<group>"; };
 		087585B61FB51D840047A269 /* CourseList+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CourseList+CoreDataProperties.swift"; sourceTree = "<group>"; };
+		087585BF1FB524C20047A269 /* ContentLanguage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentLanguage.swift; sourceTree = "<group>"; };
 		087854F41DF6EE0D00368A50 /* wysiwyg.css */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.css; path = wysiwyg.css; sourceTree = "<group>"; };
 		087D96B81EBB7C7700059408 /* Tokens.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Tokens.plist; sourceTree = "<group>"; };
 		087D96BA1EBB7F5500059408 /* Tokens.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Tokens.swift; sourceTree = "<group>"; };
@@ -6772,6 +6781,7 @@
 			children = (
 				087387D91BB9B768003CFAD1 /* ErrorEnums.swift */,
 				08E542021C6C75FD00DEC38E /* EmptyDatasetState.swift */,
+				087585BF1FB524C20047A269 /* ContentLanguage.swift */,
 			);
 			name = Enums;
 			sourceTree = "<group>";
@@ -11139,6 +11149,7 @@
 				0835542A1CC8FD2D004C4E85 /* NotificationRegistrator.swift in Sources */,
 				088E58C21DE34E2F0009B9CE /* SocialSDKProvider.swift in Sources */,
 				08D120971C937B2200A54ABC /* Assignment.swift in Sources */,
+				087585C11FB524C20047A269 /* ContentLanguage.swift in Sources */,
 				08D120981C937B2200A54ABC /* PathManager.swift in Sources */,
 				0800B8201D06FDE5006C987E /* DiscussionProxiesAPI.swift in Sources */,
 				0829B8361E9D025C009B4A84 /* CertificatesAPI.swift in Sources */,
@@ -11605,6 +11616,7 @@
 				0828FF761BC5E6B0000AFEA7 /* SectionTableViewCell.swift in Sources */,
 				08F485A01C579319000165AA /* NumberReply.swift in Sources */,
 				2CD846471F25FB6C00E8153C /* Profile+CoreDataProperties.swift in Sources */,
+				087585C01FB524C20047A269 /* ContentLanguage.swift in Sources */,
 				08901E631CD0EDB300D94613 /* RemoteVersionManager.swift in Sources */,
 				085E9E751F18ED7000D6A4BC /* SignInCoursesTableViewCell.swift in Sources */,
 				0828FF7C1BC7F9D7000AFEA7 /* Unit+CoreDataProperties.swift in Sources */,
@@ -12154,6 +12166,7 @@
 				2C1B61C21F4C4AEF00236804 /* DictionarySerializable.swift in Sources */,
 				2C1B61C31F4C4AEF00236804 /* PersistentTaskManagerProtocol.swift in Sources */,
 				2C1B61C41F4C4AEF00236804 /* SearchQueriesPresenter.swift in Sources */,
+				087585C61FB524C20047A269 /* ContentLanguage.swift in Sources */,
 				2C1B61C51F4C4AEF00236804 /* RoutingManager.swift in Sources */,
 				2C1B61C61F4C4AEF00236804 /* NotificationRegistrator.swift in Sources */,
 				2C1B61C71F4C4AEF00236804 /* NotificationAlertConstructor.swift in Sources */,
@@ -12597,6 +12610,7 @@
 				2C1B63D31F4C590700236804 /* DictionarySerializable.swift in Sources */,
 				2C1B63D41F4C590700236804 /* PersistentTaskManagerProtocol.swift in Sources */,
 				2C1B63D51F4C590700236804 /* SearchQueriesPresenter.swift in Sources */,
+				087585C71FB524C20047A269 /* ContentLanguage.swift in Sources */,
 				2C1B63D61F4C590700236804 /* RoutingManager.swift in Sources */,
 				2C1B63D71F4C590700236804 /* NotificationRegistrator.swift in Sources */,
 				2C1B63D81F4C590700236804 /* NotificationAlertConstructor.swift in Sources */,
@@ -13040,6 +13054,7 @@
 				2C8653701F4B33DE00D51654 /* DictionarySerializable.swift in Sources */,
 				2C8653711F4B33DE00D51654 /* PersistentTaskManagerProtocol.swift in Sources */,
 				2C8653721F4B33DE00D51654 /* SearchQueriesPresenter.swift in Sources */,
+				087585C31FB524C20047A269 /* ContentLanguage.swift in Sources */,
 				2C8653731F4B33DE00D51654 /* RoutingManager.swift in Sources */,
 				2C8653741F4B33DE00D51654 /* NotificationRegistrator.swift in Sources */,
 				2C8653751F4B33DE00D51654 /* NotificationAlertConstructor.swift in Sources */,
@@ -13534,6 +13549,7 @@
 				2C89AA8A1F4C289900227C3B /* Unit.swift in Sources */,
 				08EDD62E1F7C6785005203E4 /* StepikButton.swift in Sources */,
 				2C89AA8B1F4C289900227C3B /* Section+CoreDataProperties.swift in Sources */,
+				087585C41FB524C20047A269 /* ContentLanguage.swift in Sources */,
 				2C89AA8C1F4C289900227C3B /* Section.swift in Sources */,
 				2C89AA8D1F4C289900227C3B /* Course+CoreDataProperties.swift in Sources */,
 				2C89AA8E1F4C289900227C3B /* Course.swift in Sources */,
@@ -13925,6 +13941,7 @@
 				2C97320A1F4C38F600AC9301 /* DictionarySerializable.swift in Sources */,
 				2C97320B1F4C38F600AC9301 /* PersistentTaskManagerProtocol.swift in Sources */,
 				2C97320C1F4C38F600AC9301 /* SearchQueriesPresenter.swift in Sources */,
+				087585C51FB524C20047A269 /* ContentLanguage.swift in Sources */,
 				2C97320D1F4C38F600AC9301 /* RoutingManager.swift in Sources */,
 				2C97320E1F4C38F600AC9301 /* NotificationRegistrator.swift in Sources */,
 				2C97320F1F4C38F600AC9301 /* NotificationAlertConstructor.swift in Sources */,
@@ -14422,6 +14439,7 @@
 				864D66CA1E83DE03001E8D9E /* ExecutableTaskTypes.swift in Sources */,
 				864D66CB1E83DE03001E8D9E /* DictionarySerializable.swift in Sources */,
 				864D66CC1E83DE03001E8D9E /* PersistentTaskManagerProtocol.swift in Sources */,
+				087585C21FB524C20047A269 /* ContentLanguage.swift in Sources */,
 				08E8F9691F34DD2C008CF4A1 /* SearchQueriesPresenter.swift in Sources */,
 				08E3A3B71E93C21300E9C2EF /* RoutingManager.swift in Sources */,
 				864D66CD1E83DE03001E8D9E /* NotificationRegistrator.swift in Sources */,

--- a/Stepic.xcodeproj/project.pbxproj
+++ b/Stepic.xcodeproj/project.pbxproj
@@ -363,6 +363,14 @@
 		084F7AAB1E76EF780088368A /* LastStep+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 084F7AA91E76EF780088368A /* LastStep+CoreDataProperties.swift */; };
 		084F7AAD1E775A210088368A /* LastStepsAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 084F7AAC1E775A210088368A /* LastStepsAPI.swift */; };
 		084F7AAE1E775A210088368A /* LastStepsAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 084F7AAC1E775A210088368A /* LastStepsAPI.swift */; };
+		085290C61FB5C4550053F22D /* ExplorePresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 085290C51FB5C4550053F22D /* ExplorePresenter.swift */; };
+		085290C71FB5C4550053F22D /* ExplorePresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 085290C51FB5C4550053F22D /* ExplorePresenter.swift */; };
+		085290C81FB5C4550053F22D /* ExplorePresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 085290C51FB5C4550053F22D /* ExplorePresenter.swift */; };
+		085290C91FB5C4550053F22D /* ExplorePresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 085290C51FB5C4550053F22D /* ExplorePresenter.swift */; };
+		085290CA1FB5C4550053F22D /* ExplorePresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 085290C51FB5C4550053F22D /* ExplorePresenter.swift */; };
+		085290CB1FB5C4550053F22D /* ExplorePresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 085290C51FB5C4550053F22D /* ExplorePresenter.swift */; };
+		085290CC1FB5C4550053F22D /* ExplorePresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 085290C51FB5C4550053F22D /* ExplorePresenter.swift */; };
+		085290CD1FB5C4550053F22D /* ExplorePresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 085290C51FB5C4550053F22D /* ExplorePresenter.swift */; };
 		085514EB1CFB09760080CB88 /* CellWebViewHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 085514EA1CFB09760080CB88 /* CellWebViewHelper.swift */; };
 		085514EC1CFB09760080CB88 /* CellWebViewHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 085514EA1CFB09760080CB88 /* CellWebViewHelper.swift */; };
 		0857AA211BECDA640044B505 /* VideoDownload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0857AA201BECDA640044B505 /* VideoDownload.swift */; };
@@ -860,6 +868,30 @@
 		08CA59F11BBFD65E008DC44D /* User+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08CA59EF1BBFD65E008DC44D /* User+CoreDataProperties.swift */; };
 		08CA59F21BBFD65E008DC44D /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08CA59F01BBFD65E008DC44D /* User.swift */; };
 		08CA59F41BC020E3008DC44D /* UIImageViewExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08CA59F31BC020E2008DC44D /* UIImageViewExtension.swift */; };
+		08CB0D281FB5CD5E001A1E02 /* CourseListsCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08CB0D271FB5CD5E001A1E02 /* CourseListsCache.swift */; };
+		08CB0D291FB5CD5E001A1E02 /* CourseListsCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08CB0D271FB5CD5E001A1E02 /* CourseListsCache.swift */; };
+		08CB0D2A1FB5CD5E001A1E02 /* CourseListsCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08CB0D271FB5CD5E001A1E02 /* CourseListsCache.swift */; };
+		08CB0D2B1FB5CD5E001A1E02 /* CourseListsCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08CB0D271FB5CD5E001A1E02 /* CourseListsCache.swift */; };
+		08CB0D2C1FB5CD5E001A1E02 /* CourseListsCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08CB0D271FB5CD5E001A1E02 /* CourseListsCache.swift */; };
+		08CB0D2D1FB5CD5E001A1E02 /* CourseListsCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08CB0D271FB5CD5E001A1E02 /* CourseListsCache.swift */; };
+		08CB0D2E1FB5CD5E001A1E02 /* CourseListsCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08CB0D271FB5CD5E001A1E02 /* CourseListsCache.swift */; };
+		08CB0D2F1FB5CD5E001A1E02 /* CourseListsCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08CB0D271FB5CD5E001A1E02 /* CourseListsCache.swift */; };
+		08CB0D311FB5F9FC001A1E02 /* ExploreViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08CB0D301FB5F9FC001A1E02 /* ExploreViewController.swift */; };
+		08CB0D321FB5F9FC001A1E02 /* ExploreViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08CB0D301FB5F9FC001A1E02 /* ExploreViewController.swift */; };
+		08CB0D331FB5F9FC001A1E02 /* ExploreViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08CB0D301FB5F9FC001A1E02 /* ExploreViewController.swift */; };
+		08CB0D341FB5F9FC001A1E02 /* ExploreViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08CB0D301FB5F9FC001A1E02 /* ExploreViewController.swift */; };
+		08CB0D351FB5F9FC001A1E02 /* ExploreViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08CB0D301FB5F9FC001A1E02 /* ExploreViewController.swift */; };
+		08CB0D361FB5F9FC001A1E02 /* ExploreViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08CB0D301FB5F9FC001A1E02 /* ExploreViewController.swift */; };
+		08CB0D371FB5F9FC001A1E02 /* ExploreViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08CB0D301FB5F9FC001A1E02 /* ExploreViewController.swift */; };
+		08CB0D381FB5F9FC001A1E02 /* ExploreViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08CB0D301FB5F9FC001A1E02 /* ExploreViewController.swift */; };
+		08CB0D3A1FB5FB28001A1E02 /* Explore.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 08CB0D391FB5FB28001A1E02 /* Explore.storyboard */; };
+		08CB0D3B1FB5FB28001A1E02 /* Explore.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 08CB0D391FB5FB28001A1E02 /* Explore.storyboard */; };
+		08CB0D3C1FB5FB28001A1E02 /* Explore.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 08CB0D391FB5FB28001A1E02 /* Explore.storyboard */; };
+		08CB0D3D1FB5FB28001A1E02 /* Explore.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 08CB0D391FB5FB28001A1E02 /* Explore.storyboard */; };
+		08CB0D3E1FB5FB28001A1E02 /* Explore.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 08CB0D391FB5FB28001A1E02 /* Explore.storyboard */; };
+		08CB0D3F1FB5FB28001A1E02 /* Explore.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 08CB0D391FB5FB28001A1E02 /* Explore.storyboard */; };
+		08CB0D401FB5FB28001A1E02 /* Explore.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 08CB0D391FB5FB28001A1E02 /* Explore.storyboard */; };
+		08CB0D411FB5FB28001A1E02 /* Explore.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 08CB0D391FB5FB28001A1E02 /* Explore.storyboard */; };
 		08CB4ABE1C4D3DCE00D7F918 /* WKWebViewPanelManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 08CB4ABD1C4D3DCE00D7F918 /* WKWebViewPanelManager.m */; };
 		08CBA2F81F573F6900302154 /* MenuViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08CBA2F71F573F6900302154 /* MenuViewController.swift */; };
 		08CBA2F91F573F6900302154 /* MenuViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08CBA2F71F573F6900302154 /* MenuViewController.swift */; };
@@ -4550,6 +4582,7 @@
 		084F7AA61E76EF690088368A /* LastStep.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LastStep.swift; sourceTree = "<group>"; };
 		084F7AA91E76EF780088368A /* LastStep+CoreDataProperties.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "LastStep+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		084F7AAC1E775A210088368A /* LastStepsAPI.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LastStepsAPI.swift; sourceTree = "<group>"; };
+		085290C51FB5C4550053F22D /* ExplorePresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExplorePresenter.swift; sourceTree = "<group>"; };
 		085514EA1CFB09760080CB88 /* CellWebViewHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CellWebViewHelper.swift; sourceTree = "<group>"; };
 		0857AA201BECDA640044B505 /* VideoDownload.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VideoDownload.swift; sourceTree = "<group>"; };
 		0858B7081CFF271200459A6A /* TagDetectionUtil.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TagDetectionUtil.swift; sourceTree = "<group>"; };
@@ -4757,6 +4790,9 @@
 		08CA59EF1BBFD65E008DC44D /* User+CoreDataProperties.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "User+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		08CA59F01BBFD65E008DC44D /* User.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = User.swift; sourceTree = "<group>"; };
 		08CA59F31BC020E2008DC44D /* UIImageViewExtension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIImageViewExtension.swift; sourceTree = "<group>"; };
+		08CB0D271FB5CD5E001A1E02 /* CourseListsCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseListsCache.swift; sourceTree = "<group>"; };
+		08CB0D301FB5F9FC001A1E02 /* ExploreViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExploreViewController.swift; sourceTree = "<group>"; };
+		08CB0D391FB5FB28001A1E02 /* Explore.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = Explore.storyboard; sourceTree = "<group>"; };
 		08CB4ABC1C4D3DCE00D7F918 /* WKWebViewPanelManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKWebViewPanelManager.h; sourceTree = "<group>"; };
 		08CB4ABD1C4D3DCE00D7F918 /* WKWebViewPanelManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WKWebViewPanelManager.m; sourceTree = "<group>"; };
 		08CBA2F71F573F6900302154 /* MenuViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MenuViewController.swift; sourceTree = "<group>"; };
@@ -5927,6 +5963,17 @@
 			name = "API Endpoints";
 			sourceTree = "<group>";
 		};
+		085290C41FB5C43C0053F22D /* Explore */ = {
+			isa = PBXGroup;
+			children = (
+				085290C51FB5C4550053F22D /* ExplorePresenter.swift */,
+				08CB0D271FB5CD5E001A1E02 /* CourseListsCache.swift */,
+				08CB0D301FB5F9FC001A1E02 /* ExploreViewController.swift */,
+				08CB0D391FB5FB28001A1E02 /* Explore.storyboard */,
+			);
+			name = Explore;
+			sourceTree = "<group>";
+		};
 		085514E91CFB09170080CB88 /* WebViewHelpers */ = {
 			isa = PBXGroup;
 			children = (
@@ -6211,6 +6258,7 @@
 		0885F84C1BA8378B00F2A188 /* Courses */ = {
 			isa = PBXGroup;
 			children = (
+				085290C41FB5C43C0053F22D /* Explore */,
 				08C7CB721FA7AC73001D8241 /* CourseListEmptyPlaceholder */,
 				084896931F9E8A1E00CFA273 /* Continue Learning Widget */,
 				088EDCAE1F949A2C0098DEC7 /* New Widgets Collection View Cell */,
@@ -8456,6 +8504,7 @@
 				084472091D05918E00197166 /* ChoiceQuizTableViewCell.xib in Resources */,
 				08E8F97E1F34E64E008CF4A1 /* SearchSuggestionTableViewCell.xib in Resources */,
 				08D1211E1C937B2200A54ABC /* StepicVideoPlayerViewController.xib in Resources */,
+				08CB0D3B1FB5FB28001A1E02 /* Explore.storyboard in Resources */,
 				086494A11E8C7A060083E0BE /* SberbankUniversity.xcassets in Resources */,
 				08C7CB751FA7ACB9001D8241 /* CourseListEmptyPlaceholder.xib in Resources */,
 				08FF752D1DF993BF00D656C4 /* StepikAlertViewController.xib in Resources */,
@@ -8522,6 +8571,7 @@
 				08B9770B1D19D5AA00FFC52C /* DiscussionWebTableViewCell.xib in Resources */,
 				08CBA3541F5A2D9400302154 /* Profile.storyboard in Resources */,
 				0860D91B1F115D830087D61B /* CodeSuggestionsTableViewController.xib in Resources */,
+				08CB0D3A1FB5FB28001A1E02 /* Explore.storyboard in Resources */,
 				08FB30DA1DC384CC00E4684F /* UserPreferences.storyboard in Resources */,
 				2CC351861F6827BE004255B6 /* Auth.storyboard in Resources */,
 				083622DC1CD1FA6700CD8915 /* StepTabView.xib in Resources */,
@@ -8616,6 +8666,7 @@
 				08CBA3641F5AFDCF00302154 /* ProfileStreaksView.xib in Resources */,
 				2C1B62701F4C4AEF00236804 /* StepicVideoPlayerViewController.xib in Resources */,
 				2C35C4DE1F4DA47F002F3BF4 /* adjectives_m.plist in Resources */,
+				08CB0D401FB5FB28001A1E02 /* Explore.storyboard in Resources */,
 				08DF789B1F5D6A7600AEEA85 /* HeaderMenuBlockTableViewCell.xib in Resources */,
 				08195A0C1FA00FF400E6D6CD /* CourseLists.storyboard in Resources */,
 				2C1B62721F4C4AEF00236804 /* step2.html in Resources */,
@@ -8721,6 +8772,7 @@
 				08CBA3651F5AFDCF00302154 /* ProfileStreaksView.xib in Resources */,
 				2C1B64DF1F4C596500236804 /* Tokens.plist in Resources */,
 				2C35C4DF1F4DA480002F3BF4 /* adjectives_m.plist in Resources */,
+				08CB0D411FB5FB28001A1E02 /* Explore.storyboard in Resources */,
 				08DF789C1F5D6A7600AEEA85 /* HeaderMenuBlockTableViewCell.xib in Resources */,
 				08195A0D1FA00FF400E6D6CD /* CourseLists.storyboard in Resources */,
 				2C1B64831F4C590700236804 /* StepicVideoPlayerViewController.xib in Resources */,
@@ -8838,6 +8890,7 @@
 				2C35C4E81F4DA48E002F3BF4 /* nouns_m.plist in Resources */,
 				2C8654231F4B33DE00D51654 /* DiscussionWebTableViewCell.xib in Resources */,
 				2C8654241F4B33DE00D51654 /* CardOverlayView.xib in Resources */,
+				08CB0D3D1FB5FB28001A1E02 /* Explore.storyboard in Resources */,
 				2C8654251F4B33DE00D51654 /* DiscussionTableViewCell.xib in Resources */,
 				2C8654261F4B33DE00D51654 /* DiscussionsViewController.xib in Resources */,
 				2C8654291F4B33DE00D51654 /* LoadMoreTableViewCell.xib in Resources */,
@@ -8944,6 +8997,7 @@
 				2C35C4E91F4DA48E002F3BF4 /* nouns_m.plist in Resources */,
 				2C89AB0B1F4C289900227C3B /* CardOverlayView.xib in Resources */,
 				2C89AB0D1F4C289900227C3B /* DiscussionTableViewCell.xib in Resources */,
+				08CB0D3E1FB5FB28001A1E02 /* Explore.storyboard in Resources */,
 				2C89AB0E1F4C289900227C3B /* DiscussionsViewController.xib in Resources */,
 				2C89AB0F1F4C289900227C3B /* LoadMoreTableViewCell.xib in Resources */,
 				2C89AB101F4C289900227C3B /* DiscussionsStoryboard.storyboard in Resources */,
@@ -9038,6 +9092,7 @@
 				08CBA3631F5AFDCF00302154 /* ProfileStreaksView.xib in Resources */,
 				2C9732B21F4C38F600AC9301 /* AchievementTableViewCell.xib in Resources */,
 				2C35C4E01F4DA481002F3BF4 /* adjectives_m.plist in Resources */,
+				08CB0D3F1FB5FB28001A1E02 /* Explore.storyboard in Resources */,
 				08DF789A1F5D6A7600AEEA85 /* HeaderMenuBlockTableViewCell.xib in Resources */,
 				08195A0B1FA00FF400E6D6CD /* CourseLists.storyboard in Resources */,
 				2C9732B31F4C38F600AC9301 /* StreakAlertViewController.xib in Resources */,
@@ -9191,6 +9246,7 @@
 				08CBA3601F5AFDCF00302154 /* ProfileStreaksView.xib in Resources */,
 				2C04C1031F160643006B69B3 /* step2.html in Resources */,
 				0888D0FB1F1E3CEF00A16863 /* CodeInputAccessoryView.xib in Resources */,
+				08CB0D3C1FB5FB28001A1E02 /* Explore.storyboard in Resources */,
 				08DF78971F5D6A7600AEEA85 /* HeaderMenuBlockTableViewCell.xib in Resources */,
 				08195A081FA00FF400E6D6CD /* CourseLists.storyboard in Resources */,
 				085E9E7A1F18ED7000D6A4BC /* SignInCoursesTableViewCell.xib in Resources */,
@@ -11186,6 +11242,7 @@
 				08AF59F11E6D9BE800423EFF /* RGPageViewController+UIPageViewControllerDataSource.swift in Sources */,
 				0888D10A1F1E42A000A16863 /* CodeElementsSize.swift in Sources */,
 				08D120A21C937B2200A54ABC /* SortingQuizTableViewCell.swift in Sources */,
+				085290C71FB5C4550053F22D /* ExplorePresenter.swift in Sources */,
 				08AF59E71E6D9BE800423EFF /* RGTabBarItem.swift in Sources */,
 				088AADAA1D175DA00034D86D /* HTMLContentView.swift in Sources */,
 				08D120A31C937B2200A54ABC /* UIViewExtensions.swift in Sources */,
@@ -11281,6 +11338,7 @@
 				084F7AAE1E775A210088368A /* LastStepsAPI.swift in Sources */,
 				0846B11A1EDDF64F00D64D77 /* CodeTemplate+CoreDataProperties.swift in Sources */,
 				0846B1161EDDF63200D64D77 /* CodeTemplate.swift in Sources */,
+				08CB0D321FB5F9FC001A1E02 /* ExploreViewController.swift in Sources */,
 				089504841F27C5C600EEC939 /* FullHeightTableView.swift in Sources */,
 				08D120CC1C937B2200A54ABC /* PlaceholderTestViewController.swift in Sources */,
 				08D120CD1C937B2200A54ABC /* StepicVideoPlayerViewController.swift in Sources */,
@@ -11402,6 +11460,7 @@
 				08ECC4481DB8D3D60005D401 /* StyledNavigationViewController.swift in Sources */,
 				08AC21461CDD493A00FBB9CD /* PersistentRecoveryManager.swift in Sources */,
 				085C4FF41D89C86F00B27C95 /* UnitsAPI.swift in Sources */,
+				08CB0D291FB5CD5E001A1E02 /* CourseListsCache.swift in Sources */,
 				080CE1441E955D300089A27F /* CoursesAPI.swift in Sources */,
 				08901E6E1CD102DF00D94613 /* UpdatePreferencesContainer.swift in Sources */,
 				08D120FB1C937B2200A54ABC /* UnitTableViewCell.swift in Sources */,
@@ -11542,6 +11601,7 @@
 				0806B2C21EBDBB0200FDE0F7 /* PostViewsExecutableTask.swift in Sources */,
 				084156951BCBFFBD006B8C73 /* Step+CoreDataProperties.swift in Sources */,
 				080E80F51F0070C900DC0EA5 /* CodeLanguages.swift in Sources */,
+				085290C61FB5C4550053F22D /* ExplorePresenter.swift in Sources */,
 				08F555631C4FE30400C877E8 /* UnknownTypeQuizViewController.swift in Sources */,
 				08E542091C6CD65500DEC38E /* CourseSubscriptionManager.swift in Sources */,
 				082799481E9B81AF008A3786 /* RateAppAlertManager.swift in Sources */,
@@ -11773,6 +11833,7 @@
 				0837492A1DE5AF8A00144C14 /* StreaksAlertManager.swift in Sources */,
 				0828FF801BC7FD24000AFEA7 /* Lesson+CoreDataProperties.swift in Sources */,
 				080CE1491E9562430089A27F /* LessonsAPI.swift in Sources */,
+				08CB0D281FB5CD5E001A1E02 /* CourseListsCache.swift in Sources */,
 				086E96601BF66A1800AB952D /* VideoDownloadView.swift in Sources */,
 				080ACF611BD7DE2A00329F2B /* TCBlobDownloadManager.swift in Sources */,
 				08DE94391B8E3FCE00D278AB /* UIColorExtensions.swift in Sources */,
@@ -11830,6 +11891,7 @@
 				084490091F5D67E300D01940 /* NewSettingsViewController.swift in Sources */,
 				08DA79011DB6BB36003491C4 /* ControllerHelperLaunchExtension.swift in Sources */,
 				083540671CE5FC0E00BDFEA5 /* Notification.swift in Sources */,
+				08CB0D311FB5F9FC001A1E02 /* ExploreViewController.swift in Sources */,
 				086A8B281D21796800F45C45 /* VotesAPI.swift in Sources */,
 				083622D81CD1FA4800CD8915 /* StepTabView.swift in Sources */,
 				0868C17E1F375A1200D77C5F /* SearchQueriesPersistentManager.swift in Sources */,
@@ -12242,6 +12304,7 @@
 				2C1B62081F4C4AEF00236804 /* FBSocialSDKProvider.swift in Sources */,
 				2C1B62091F4C4AEF00236804 /* RequestChain.swift in Sources */,
 				2C1B620A1F4C4AEF00236804 /* ApiRequest.swift in Sources */,
+				08CB0D2E1FB5CD5E001A1E02 /* CourseListsCache.swift in Sources */,
 				2C1B620B1F4C4AEF00236804 /* AuthManager.swift in Sources */,
 				2C1B620C1F4C4AEF00236804 /* QueriesAPI.swift in Sources */,
 				2C1B620D1F4C4AEF00236804 /* AutocompleteWords.swift in Sources */,
@@ -12249,6 +12312,7 @@
 				2C1B620F1F4C4AEF00236804 /* Meta.swift in Sources */,
 				2C1B62101F4C4AEF00236804 /* RegistrationErrorInfo.swift in Sources */,
 				2C1B62111F4C4AEF00236804 /* DevicesAPI.swift in Sources */,
+				08CB0D371FB5F9FC001A1E02 /* ExploreViewController.swift in Sources */,
 				2C1B62121F4C4AEF00236804 /* APIDefaults.swift in Sources */,
 				2C1B62131F4C4AEF00236804 /* AdaptiveOnboardingPresenter.swift in Sources */,
 				2C35C4AD1F4DA3F1002F3BF4 /* LeaderboardTableViewCell.swift in Sources */,
@@ -12304,6 +12368,7 @@
 				2C1B623D1F4C4AEF00236804 /* UIViewExtensions.swift in Sources */,
 				2C1B623F1F4C4AEF00236804 /* Profile+CoreDataProperties.swift in Sources */,
 				2C1B62411F4C4AEF00236804 /* FullHeightTableView.swift in Sources */,
+				085290CC1FB5C4550053F22D /* ExplorePresenter.swift in Sources */,
 				2C1B62421F4C4AEF00236804 /* StepOptions.swift in Sources */,
 				2C1B62431F4C4AEF00236804 /* NSAttributedStringExtensions.swift in Sources */,
 				2C1B62441F4C4AEF00236804 /* AlamofireExtensions.swift in Sources */,
@@ -12686,6 +12751,7 @@
 				2C1B64191F4C590700236804 /* FBSocialSDKProvider.swift in Sources */,
 				2C1B641A1F4C590700236804 /* RequestChain.swift in Sources */,
 				2C1B641B1F4C590700236804 /* ApiRequest.swift in Sources */,
+				08CB0D2F1FB5CD5E001A1E02 /* CourseListsCache.swift in Sources */,
 				2C1B641C1F4C590700236804 /* AuthManager.swift in Sources */,
 				2C1B641D1F4C590700236804 /* QueriesAPI.swift in Sources */,
 				2C1B641E1F4C590700236804 /* AutocompleteWords.swift in Sources */,
@@ -12693,6 +12759,7 @@
 				2C1B64201F4C590700236804 /* Meta.swift in Sources */,
 				2C1B64211F4C590700236804 /* RegistrationErrorInfo.swift in Sources */,
 				2C1B64221F4C590700236804 /* DevicesAPI.swift in Sources */,
+				08CB0D381FB5F9FC001A1E02 /* ExploreViewController.swift in Sources */,
 				2C1B64231F4C590700236804 /* APIDefaults.swift in Sources */,
 				2C1B64241F4C590700236804 /* AdaptiveOnboardingPresenter.swift in Sources */,
 				2C35C4AF1F4DA3F2002F3BF4 /* LeaderboardTableViewCell.swift in Sources */,
@@ -12748,6 +12815,7 @@
 				2C1B644E1F4C590700236804 /* UIViewExtensions.swift in Sources */,
 				2C1B64501F4C590700236804 /* Profile+CoreDataProperties.swift in Sources */,
 				2C1B64521F4C590700236804 /* FullHeightTableView.swift in Sources */,
+				085290CD1FB5C4550053F22D /* ExplorePresenter.swift in Sources */,
 				2C1B64531F4C590700236804 /* StepOptions.swift in Sources */,
 				2C1B64541F4C590700236804 /* NSAttributedStringExtensions.swift in Sources */,
 				2C1B64551F4C590700236804 /* AlamofireExtensions.swift in Sources */,
@@ -13130,6 +13198,7 @@
 				2C8653B61F4B33DE00D51654 /* FBSocialSDKProvider.swift in Sources */,
 				2C8653B71F4B33DE00D51654 /* RequestChain.swift in Sources */,
 				2C8653B81F4B33DE00D51654 /* ApiRequest.swift in Sources */,
+				08CB0D2B1FB5CD5E001A1E02 /* CourseListsCache.swift in Sources */,
 				2C8653B91F4B33DE00D51654 /* AuthManager.swift in Sources */,
 				2C8653BA1F4B33DE00D51654 /* QueriesAPI.swift in Sources */,
 				2C8653BB1F4B33DE00D51654 /* AutocompleteWords.swift in Sources */,
@@ -13137,6 +13206,7 @@
 				2C8653BD1F4B33DE00D51654 /* Meta.swift in Sources */,
 				2C8653BE1F4B33DE00D51654 /* RegistrationErrorInfo.swift in Sources */,
 				2C8653BF1F4B33DE00D51654 /* DevicesAPI.swift in Sources */,
+				08CB0D341FB5F9FC001A1E02 /* ExploreViewController.swift in Sources */,
 				2C8653C01F4B33DE00D51654 /* APIDefaults.swift in Sources */,
 				2C8653C11F4B33DE00D51654 /* AdaptiveOnboardingPresenter.swift in Sources */,
 				2C35C4AB1F4DA3F0002F3BF4 /* LeaderboardTableViewCell.swift in Sources */,
@@ -13192,6 +13262,7 @@
 				2C8653EB1F4B33DE00D51654 /* UIViewExtensions.swift in Sources */,
 				2C8653ED1F4B33DE00D51654 /* Profile+CoreDataProperties.swift in Sources */,
 				2C8653EF1F4B33DE00D51654 /* FullHeightTableView.swift in Sources */,
+				085290C91FB5C4550053F22D /* ExplorePresenter.swift in Sources */,
 				2C8653F01F4B33DE00D51654 /* StepOptions.swift in Sources */,
 				2C8653F11F4B33DE00D51654 /* NSAttributedStringExtensions.swift in Sources */,
 				2C8653F21F4B33DE00D51654 /* AlamofireExtensions.swift in Sources */,
@@ -13519,6 +13590,7 @@
 				2C89AA6E1F4C289900227C3B /* ChoiceReply.swift in Sources */,
 				2C89AA6F1F4C289900227C3B /* TextReply.swift in Sources */,
 				2C89AA701F4C289900227C3B /* NumberReply.swift in Sources */,
+				08CB0D2C1FB5CD5E001A1E02 /* CourseListsCache.swift in Sources */,
 				2C89AA711F4C289900227C3B /* FreeAnswerReply.swift in Sources */,
 				2C89AA721F4C289900227C3B /* MathReply.swift in Sources */,
 				2C89AA731F4C289900227C3B /* SortingReply.swift in Sources */,
@@ -13533,6 +13605,7 @@
 				2C89AA7B1F4C289900227C3B /* Assignment.swift in Sources */,
 				2C89AA7C1F4C289900227C3B /* Progress+CoreDataProperties.swift in Sources */,
 				2C89AA7D1F4C289900227C3B /* Progress.swift in Sources */,
+				08CB0D351FB5F9FC001A1E02 /* ExploreViewController.swift in Sources */,
 				2C89AA7E1F4C289900227C3B /* Video+CoreDataProperties.swift in Sources */,
 				2C89AA7F1F4C289900227C3B /* Video.swift in Sources */,
 				2C89AA801F4C289900227C3B /* VideoURL+CoreDataProperties.swift in Sources */,
@@ -13634,6 +13707,7 @@
 				087585BB1FB51D840047A269 /* CourseList+CoreDataProperties.swift in Sources */,
 				2C89AAD11F4C289900227C3B /* UIViewExtensions.swift in Sources */,
 				2C89AAD31F4C289900227C3B /* Profile+CoreDataProperties.swift in Sources */,
+				085290CA1FB5C4550053F22D /* ExplorePresenter.swift in Sources */,
 				2C89AAD51F4C289900227C3B /* FullHeightTableView.swift in Sources */,
 				2C89AAD61F4C289900227C3B /* StepOptions.swift in Sources */,
 				2C89AAD71F4C289900227C3B /* NSAttributedStringExtensions.swift in Sources */,
@@ -14017,6 +14091,7 @@
 				2C9732501F4C38F600AC9301 /* FBSocialSDKProvider.swift in Sources */,
 				2C9732511F4C38F600AC9301 /* RequestChain.swift in Sources */,
 				2C9732521F4C38F600AC9301 /* ApiRequest.swift in Sources */,
+				08CB0D2D1FB5CD5E001A1E02 /* CourseListsCache.swift in Sources */,
 				2C9732531F4C38F600AC9301 /* AuthManager.swift in Sources */,
 				2C9732541F4C38F600AC9301 /* QueriesAPI.swift in Sources */,
 				2C9732551F4C38F600AC9301 /* AutocompleteWords.swift in Sources */,
@@ -14024,6 +14099,7 @@
 				2C9732571F4C38F600AC9301 /* Meta.swift in Sources */,
 				2C9732581F4C38F600AC9301 /* RegistrationErrorInfo.swift in Sources */,
 				2C9732591F4C38F600AC9301 /* DevicesAPI.swift in Sources */,
+				08CB0D361FB5F9FC001A1E02 /* ExploreViewController.swift in Sources */,
 				2C97325A1F4C38F600AC9301 /* APIDefaults.swift in Sources */,
 				2C97325B1F4C38F600AC9301 /* AdaptiveOnboardingPresenter.swift in Sources */,
 				2C35C4AE1F4DA3F1002F3BF4 /* LeaderboardTableViewCell.swift in Sources */,
@@ -14079,6 +14155,7 @@
 				2C9732851F4C38F600AC9301 /* UIViewExtensions.swift in Sources */,
 				2C9732871F4C38F600AC9301 /* Profile+CoreDataProperties.swift in Sources */,
 				2C9732891F4C38F600AC9301 /* FullHeightTableView.swift in Sources */,
+				085290CB1FB5C4550053F22D /* ExplorePresenter.swift in Sources */,
 				2C97328A1F4C38F600AC9301 /* StepOptions.swift in Sources */,
 				2C97328B1F4C38F600AC9301 /* NSAttributedStringExtensions.swift in Sources */,
 				2C97328C1F4C38F600AC9301 /* AlamofireExtensions.swift in Sources */,
@@ -14515,6 +14592,7 @@
 				864D67041E83DE03001E8D9E /* FBSocialSDKProvider.swift in Sources */,
 				864D67051E83DE03001E8D9E /* RequestChain.swift in Sources */,
 				864D67061E83DE03001E8D9E /* ApiRequest.swift in Sources */,
+				08CB0D2A1FB5CD5E001A1E02 /* CourseListsCache.swift in Sources */,
 				864D67071E83DE03001E8D9E /* AuthManager.swift in Sources */,
 				08964BCF1F3072BA00DBBCCE /* QueriesAPI.swift in Sources */,
 				085E9E701F138C3B00D6A4BC /* AutocompleteWords.swift in Sources */,
@@ -14522,6 +14600,7 @@
 				864D67091E83DE03001E8D9E /* Meta.swift in Sources */,
 				864D670A1E83DE03001E8D9E /* RegistrationErrorInfo.swift in Sources */,
 				864D670B1E83DE03001E8D9E /* DevicesAPI.swift in Sources */,
+				08CB0D331FB5F9FC001A1E02 /* ExploreViewController.swift in Sources */,
 				864D670C1E83DE03001E8D9E /* APIDefaults.swift in Sources */,
 				2CA50B9E1F0FE66B00418E7D /* AdaptiveOnboardingPresenter.swift in Sources */,
 				2C35C4AA1F4DA3EF002F3BF4 /* LeaderboardTableViewCell.swift in Sources */,
@@ -14577,6 +14656,7 @@
 				864D672D1E83DE03001E8D9E /* UIViewExtensions.swift in Sources */,
 				2CD846491F25FB6C00E8153C /* Profile+CoreDataProperties.swift in Sources */,
 				089504851F27C5C600EEC939 /* FullHeightTableView.swift in Sources */,
+				085290C81FB5C4550053F22D /* ExplorePresenter.swift in Sources */,
 				0846B1051EDDED1000D64D77 /* StepOptions.swift in Sources */,
 				864D67311E83DE03001E8D9E /* NSAttributedStringExtensions.swift in Sources */,
 				864D67321E83DE03001E8D9E /* AlamofireExtensions.swift in Sources */,

--- a/Stepic/AnalyticsEvents.swift
+++ b/Stepic/AnalyticsEvents.swift
@@ -125,6 +125,7 @@ struct AnalyticsEvents {
         static let certificatesClicked = "main_choice_certificates"
         static let profileClicked = "main_choice_profile"
         static let notificationsClicked = "main_choice_notifications"
+        static let catalogClicked = "main_choice_catalog"
     }
 
     struct Streaks {

--- a/Stepic/Base.lproj/Main.storyboard
+++ b/Stepic/Base.lproj/Main.storyboard
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13196" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="0uJ-IX-W04">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="0uJ-IX-W04">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13173"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13527"/>
         <capability name="Aspect ratio constraints" minToolsVersion="5.1"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -229,12 +229,12 @@
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="Course name" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="8q0-dk-g4x" customClass="StepikLabel" customModule="Adaptive_1838" customModuleProvider="target">
-                                                    <rect key="frame" x="8" y="8" width="367" height="27"/>
+                                                    <rect key="frame" x="15" y="11" width="353" height="24"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <segmentedControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="0" translatesAutoresizingMaskIntoConstraints="NO" id="uiF-lQ-kcC">
-                                                    <rect key="frame" x="8" y="91" width="367" height="28"/>
+                                                    <rect key="frame" x="15" y="91" width="353" height="28"/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" constant="27" id="iIs-Kj-1Bm"/>
                                                     </constraints>
@@ -249,7 +249,7 @@
                                                     </connections>
                                                 </segmentedControl>
                                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="MZy-dW-Bj2">
-                                                    <rect key="frame" x="8" y="43" width="367" height="40"/>
+                                                    <rect key="frame" x="15" y="43" width="353" height="40"/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" constant="40" id="b8c-PG-IWL"/>
                                                     </constraints>
@@ -288,7 +288,7 @@
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" showsVerticalScrollIndicator="NO" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="yjX-Bt-pbi">
-                                                    <rect key="frame" x="8" y="38" width="367" height="120.5"/>
+                                                    <rect key="frame" x="15" y="35.5" width="353" height="120.5"/>
                                                     <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" constant="120" id="PlW-Vx-HY5"/>
@@ -302,7 +302,7 @@
                                                     <cells/>
                                                 </collectionView>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Teachers" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Yls-tG-Jse" customClass="StepikLabel" customModule="Adaptive_1838" customModuleProvider="target">
-                                                    <rect key="frame" x="16" y="8" width="359" height="21"/>
+                                                    <rect key="frame" x="23" y="11" width="345" height="15.5"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
@@ -892,79 +892,6 @@
             </objects>
             <point key="canvasLocation" x="1644" y="4304"/>
         </scene>
-        <!--Home View Controller-->
-        <scene sceneID="s6h-OY-0bS">
-            <objects>
-                <viewController id="d0o-Sj-8DK" customClass="HomeViewController" customModule="Adaptive_1838" customModuleProvider="target" sceneMemberID="viewController">
-                    <layoutGuides>
-                        <viewControllerLayoutGuide type="top" id="NTB-Ke-5RJ"/>
-                        <viewControllerLayoutGuide type="bottom" id="F3D-5i-SQS"/>
-                    </layoutGuides>
-                    <view key="view" contentMode="scaleToFill" id="Myu-Hj-kcu">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
-                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <subviews>
-                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Tu7-UM-iao">
-                                <rect key="frame" x="0.0" y="20" width="375" height="259"/>
-                                <color key="backgroundColor" red="0.32549019610000002" green="0.32549019610000002" blue="0.40000000000000002" alpha="1" colorSpace="calibratedRGB"/>
-                            </view>
-                            <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="cWP-KR-cSl">
-                                <rect key="frame" x="0.0" y="71" width="375" height="208"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="208" id="hXQ-fN-RkX"/>
-                                </constraints>
-                                <connections>
-                                    <segue destination="pyi-5x-TNr" kind="embed" identifier="enrolledEmbed" id="F1v-Zg-6Fj"/>
-                                </connections>
-                            </containerView>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Enrolled" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="EDj-hh-tS7">
-                                <rect key="frame" x="16" y="36" width="343" height="21"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Popular" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="r2Q-Y5-zt7">
-                                <rect key="frame" x="16" y="287" width="343" height="21"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Kp5-Oo-jbD">
-                                <rect key="frame" x="0.0" y="321" width="375" height="208"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="208" id="yfX-u0-CHP"/>
-                                </constraints>
-                                <connections>
-                                    <segue destination="wbc-iz-F9S" kind="embed" identifier="popularEmbed" id="dUK-Jq-Krn"/>
-                                </connections>
-                            </containerView>
-                        </subviews>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                        <constraints>
-                            <constraint firstItem="EDj-hh-tS7" firstAttribute="leading" secondItem="Myu-Hj-kcu" secondAttribute="leading" constant="16" id="6HP-0c-aDO"/>
-                            <constraint firstItem="cWP-KR-cSl" firstAttribute="top" secondItem="EDj-hh-tS7" secondAttribute="bottom" constant="14" id="87X-ff-YJE"/>
-                            <constraint firstItem="r2Q-Y5-zt7" firstAttribute="top" secondItem="cWP-KR-cSl" secondAttribute="bottom" constant="8" id="98k-o7-rkC"/>
-                            <constraint firstItem="r2Q-Y5-zt7" firstAttribute="leading" secondItem="Myu-Hj-kcu" secondAttribute="leading" constant="16" id="9gO-7M-gcp"/>
-                            <constraint firstItem="Tu7-UM-iao" firstAttribute="leading" secondItem="Myu-Hj-kcu" secondAttribute="leading" id="FS2-Eb-Lx4"/>
-                            <constraint firstAttribute="trailing" secondItem="Tu7-UM-iao" secondAttribute="trailing" id="JxQ-Xb-gb6"/>
-                            <constraint firstAttribute="trailing" secondItem="EDj-hh-tS7" secondAttribute="trailing" constant="16" id="LrS-Uh-6HT"/>
-                            <constraint firstItem="Tu7-UM-iao" firstAttribute="top" secondItem="NTB-Ke-5RJ" secondAttribute="bottom" id="QQT-MM-IXb"/>
-                            <constraint firstItem="EDj-hh-tS7" firstAttribute="top" secondItem="NTB-Ke-5RJ" secondAttribute="bottom" constant="16" id="S4j-5g-Ikv"/>
-                            <constraint firstItem="cWP-KR-cSl" firstAttribute="leading" secondItem="Myu-Hj-kcu" secondAttribute="leading" id="S5r-0F-4dN"/>
-                            <constraint firstAttribute="trailing" secondItem="cWP-KR-cSl" secondAttribute="trailing" id="cfW-S9-D1j"/>
-                            <constraint firstItem="Kp5-Oo-jbD" firstAttribute="leading" secondItem="Myu-Hj-kcu" secondAttribute="leading" id="cvb-rj-lXW"/>
-                            <constraint firstAttribute="trailing" secondItem="Kp5-Oo-jbD" secondAttribute="trailing" id="fYr-b1-TUI"/>
-                            <constraint firstAttribute="trailing" secondItem="r2Q-Y5-zt7" secondAttribute="trailing" constant="16" id="h15-ip-vAT"/>
-                            <constraint firstItem="r2Q-Y5-zt7" firstAttribute="top" secondItem="Tu7-UM-iao" secondAttribute="bottom" constant="8" id="pI4-VM-1dN"/>
-                            <constraint firstItem="Kp5-Oo-jbD" firstAttribute="top" secondItem="r2Q-Y5-zt7" secondAttribute="bottom" constant="13" id="tyj-eg-fS3"/>
-                        </constraints>
-                    </view>
-                    <navigationItem key="navigationItem" id="LKs-0X-N5O"/>
-                </viewController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="3xn-qW-TVH" userLabel="First Responder" sceneMemberID="firstResponder"/>
-            </objects>
-            <point key="canvasLocation" x="2105" y="4078"/>
-        </scene>
         <!--Profile-->
         <scene sceneID="eaY-rL-sMF">
             <objects>
@@ -982,42 +909,6 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Fgf-Uu-lLh" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="2378" y="856"/>
-        </scene>
-        <!--Course List Horizontal View Controller-->
-        <scene sceneID="paf-Tf-bfn">
-            <objects>
-                <viewController id="pyi-5x-TNr" customClass="CourseListHorizontalViewController" customModule="Adaptive_1838" customModuleProvider="target" sceneMemberID="viewController">
-                    <layoutGuides>
-                        <viewControllerLayoutGuide type="top" id="cVP-Vh-nzc"/>
-                        <viewControllerLayoutGuide type="bottom" id="zoX-dx-Iix"/>
-                    </layoutGuides>
-                    <view key="view" contentMode="scaleToFill" id="mKo-kb-msn">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="208"/>
-                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                    </view>
-                </viewController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="Ck7-dM-7og" userLabel="First Responder" sceneMemberID="firstResponder"/>
-            </objects>
-            <point key="canvasLocation" x="2414" y="4133"/>
-        </scene>
-        <!--Course List Horizontal View Controller-->
-        <scene sceneID="Xh7-Wd-vF4">
-            <objects>
-                <viewController id="wbc-iz-F9S" customClass="CourseListHorizontalViewController" customModule="Adaptive_1838" customModuleProvider="target" sceneMemberID="viewController">
-                    <layoutGuides>
-                        <viewControllerLayoutGuide type="top" id="Jc5-aP-SjK"/>
-                        <viewControllerLayoutGuide type="bottom" id="1jY-De-HlH"/>
-                    </layoutGuides>
-                    <view key="view" contentMode="scaleToFill" id="ZuC-c2-HHQ">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="208"/>
-                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                    </view>
-                </viewController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="dDh-Df-fS8" userLabel="First Responder" sceneMemberID="firstResponder"/>
-            </objects>
-            <point key="canvasLocation" x="2414" y="4326"/>
         </scene>
         <!--Styled Navigation View Controller-->
         <scene sceneID="r2H-fY-2yw">
@@ -1042,7 +933,7 @@
         <image name="Info" width="25" height="25"/>
         <image name="play_dark" width="50" height="50"/>
         <image name="success" width="28" height="28"/>
-        <image name="tab-certificates" width="25" height="25"/>
+        <image name="tab-certificates" width="24" height="22"/>
         <image name="tab-downloads" width="20" height="22"/>
         <image name="tab-find-courses" width="22" height="22"/>
         <image name="tab-my-courses" width="26" height="26"/>

--- a/Stepic/Config.plist
+++ b/Stepic/Config.plist
@@ -7,7 +7,7 @@
 		<key>tabs</key>
 		<array>
 			<string>Home</string>
-			<string>Explore</string>
+			<string>Catalog</string>
 			<string>Profile</string>
 			<string>Certificates</string>
 			<string>Notifications</string>

--- a/Stepic/Config.plist
+++ b/Stepic/Config.plist
@@ -7,6 +7,7 @@
 		<key>tabs</key>
 		<array>
 			<string>Home</string>
+			<string>Explore</string>
 			<string>FindCourses</string>
 			<string>Profile</string>
 			<string>Certificates</string>

--- a/Stepic/Config.plist
+++ b/Stepic/Config.plist
@@ -8,7 +8,6 @@
 		<array>
 			<string>Home</string>
 			<string>Explore</string>
-			<string>FindCourses</string>
 			<string>Profile</string>
 			<string>Certificates</string>
 			<string>Notifications</string>

--- a/Stepic/ContentLanguage.swift
+++ b/Stepic/ContentLanguage.swift
@@ -31,6 +31,15 @@ enum ContentLanguage {
         }
     }
 
+    var displayingString: String {
+        switch self {
+        case .russian:
+            return "Ru"
+        case .english:
+            return "En"
+        }
+    }
+
     private static var appInterfaceLanguage: ContentLanguage {
         let currentLanguageString = Bundle.main.preferredLocalizations.first ?? "en"
         return ContentLanguage(languageString: currentLanguageString)

--- a/Stepic/ContentLanguage.swift
+++ b/Stepic/ContentLanguage.swift
@@ -10,7 +10,7 @@ import Foundation
 
 enum ContentLanguage {
     case english, russian
-    
+
     init(languageString: String) {
         switch languageString {
         case "ru":
@@ -21,7 +21,7 @@ enum ContentLanguage {
             self = .english
         }
     }
-    
+
     var languageString: String {
         switch self {
         case .russian:
@@ -30,7 +30,7 @@ enum ContentLanguage {
             return "en"
         }
     }
-    
+
     static var appInterfaceLanguage: ContentLanguage {
         let currentLanguageString = Bundle.main.preferredLocalizations.first ?? "en"
         return ContentLanguage(languageString: currentLanguageString)

--- a/Stepic/ContentLanguage.swift
+++ b/Stepic/ContentLanguage.swift
@@ -31,8 +31,23 @@ enum ContentLanguage {
         }
     }
 
-    static var appInterfaceLanguage: ContentLanguage {
+    private static var appInterfaceLanguage: ContentLanguage {
         let currentLanguageString = Bundle.main.preferredLocalizations.first ?? "en"
         return ContentLanguage(languageString: currentLanguageString)
+    }
+
+    private static let sharedContentLanguageKey = "contentLanguage"
+    static var sharedContentLanguage: ContentLanguage {
+        set(value) {
+            UserDefaults.standard.setValue(value.languageString, forKey: sharedContentLanguageKey)
+        }
+        get {
+            if let cachedValue = UserDefaults.standard.value(forKey: sharedContentLanguageKey) as? String {
+                return ContentLanguage(languageString: cachedValue)
+            } else {
+                self.sharedContentLanguage = appInterfaceLanguage
+                return appInterfaceLanguage
+            }
+        }
     }
 }

--- a/Stepic/ContentLanguage.swift
+++ b/Stepic/ContentLanguage.swift
@@ -1,0 +1,38 @@
+//
+//  ContentLanguage.swift
+//  Stepic
+//
+//  Created by Ostrenkiy on 10.11.2017.
+//  Copyright © 2017 Alex Karpov. All rights reserved.
+//
+
+import Foundation
+
+enum ContentLanguage {
+    case english, russian
+    
+    init(languageString: String) {
+        switch languageString {
+        case "ru":
+            self = .russian
+        case "en":
+            self = .english
+        default:
+            self = .english
+        }
+    }
+    
+    var languageString: String {
+        switch self {
+        case .russian:
+            return "ru"
+        case .english:
+            return "en"
+        }
+    }
+    
+    static var appInterfaceLanguage: ContentLanguage {
+        let currentLanguageString = Bundle.main.preferredLocalizations.first ?? "en"
+        return ContentLanguage(languageString: currentLanguageString)
+    }
+}

--- a/Stepic/ContentLanguageCollectionViewCell.swift
+++ b/Stepic/ContentLanguageCollectionViewCell.swift
@@ -1,0 +1,39 @@
+//
+//  ContentLanguageCollectionViewCell.swift
+//  Stepic
+//
+//  Created by Ostrenkiy on 10.11.2017.
+//  Copyright © 2017 Alex Karpov. All rights reserved.
+//
+
+import UIKit
+
+class ContentLanguageCollectionViewCell: UICollectionViewCell {
+    @IBOutlet weak var languageLabel: StepikLabel!
+
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        // Initialization code
+        contentView.setRoundedCorners(cornerRadius: 4)
+        languageLabel.colorMode = .dark
+        contentView.backgroundColor = UIColor.mainLight
+    }
+
+    var language: String = "" {
+        didSet {
+            languageLabel.text = language
+        }
+    }
+
+    override var isSelected: Bool {
+        didSet {
+            if isSelected {
+                languageLabel.colorMode = .light
+                contentView.backgroundColor = UIColor.mainDark
+            } else {
+                languageLabel.colorMode = .dark
+                contentView.backgroundColor = UIColor.mainLight
+            }
+        }
+    }
+}

--- a/Stepic/ContentLanguageCollectionViewCell.xib
+++ b/Stepic/ContentLanguageCollectionViewCell.xib
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13527"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="gTV-IL-0wX" customClass="ContentLanguageCollectionViewCell" customModule="Adaptive_1838" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="50" height="50"/>
+            <autoresizingMask key="autoresizingMask"/>
+            <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center">
+                <rect key="frame" x="0.0" y="0.0" width="50" height="50"/>
+                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                <subviews>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LMa-Dh-9t2" customClass="StepikLabel" customModule="Adaptive_1838" customModuleProvider="target">
+                        <rect key="frame" x="0.0" y="0.0" width="50" height="50"/>
+                        <fontDescription key="fontDescription" type="system" weight="light" pointSize="16"/>
+                        <nil key="textColor"/>
+                        <nil key="highlightedColor"/>
+                    </label>
+                </subviews>
+            </view>
+            <constraints>
+                <constraint firstItem="LMa-Dh-9t2" firstAttribute="top" secondItem="gTV-IL-0wX" secondAttribute="top" id="8PU-Wg-qgM"/>
+                <constraint firstAttribute="bottom" secondItem="LMa-Dh-9t2" secondAttribute="bottom" id="Au3-oO-cq6"/>
+                <constraint firstItem="LMa-Dh-9t2" firstAttribute="leading" secondItem="gTV-IL-0wX" secondAttribute="leading" id="LGa-uP-TCh"/>
+                <constraint firstAttribute="trailing" secondItem="LMa-Dh-9t2" secondAttribute="trailing" id="gTH-Lw-ko0"/>
+            </constraints>
+            <connections>
+                <outlet property="languageLabel" destination="LMa-Dh-9t2" id="YTO-MK-RJQ"/>
+            </connections>
+        </collectionViewCell>
+    </objects>
+</document>

--- a/Stepic/ContentLanguagesView.swift
+++ b/Stepic/ContentLanguagesView.swift
@@ -37,7 +37,7 @@ class ContentLanguagesView: NibInitializableView {
         flowLayout.minimumInteritemSpacing = 12
         flowLayout.minimumLineSpacing = 12
         titleLabel.colorMode = .gray
-        titleLabel.text = "Choose search language"
+        titleLabel.text = NSLocalizedString("ChooseSearchLanguage", comment: "")
     }
 }
 

--- a/Stepic/ContentLanguagesView.swift
+++ b/Stepic/ContentLanguagesView.swift
@@ -1,0 +1,77 @@
+//
+//  ContentLanguagesView.swift
+//  Stepic
+//
+//  Created by Ostrenkiy on 10.11.2017.
+//  Copyright © 2017 Alex Karpov. All rights reserved.
+//
+
+import Foundation
+
+class ContentLanguagesView: NibInitializableView {
+    @IBOutlet weak var collectionView: UICollectionView!
+    @IBOutlet weak var flowLayout: UICollectionViewFlowLayout!
+
+    @IBOutlet weak var titleLabel: StepikLabel!
+
+    var languages: [ContentLanguage] = [] {
+        didSet {
+            collectionView.reloadData()
+        }
+    }
+
+    var currentlySelectedIndexPath: IndexPath?
+
+    var initialLanguage: ContentLanguage?
+    var languageSelectedAction: ((ContentLanguage) -> Void)?
+
+    override var nibName: String {
+        return "ContentLanguagesView"
+    }
+
+    override func setupSubviews() {
+        collectionView.register(UINib(nibName: "ContentLanguageCollectionViewCell", bundle: nil), forCellWithReuseIdentifier: "ContentLanguageCollectionViewCell")
+        collectionView.delegate = self
+        collectionView.dataSource = self
+        flowLayout.itemSize = CGSize(width: 46, height: 40)
+        flowLayout.minimumInteritemSpacing = 12
+        flowLayout.minimumLineSpacing = 12
+        titleLabel.colorMode = .gray
+        titleLabel.text = "Choose search language"
+    }
+}
+
+extension ContentLanguagesView: UICollectionViewDelegate {
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        if indexPath != currentlySelectedIndexPath {
+            if let currentlySelectedIndexPath = currentlySelectedIndexPath {
+                collectionView.deselectItem(at: currentlySelectedIndexPath, animated: false)
+                (collectionView.cellForItem(at: currentlySelectedIndexPath) as? ContentLanguageCollectionViewCell)?.isSelected = false
+            }
+            currentlySelectedIndexPath = indexPath
+            languageSelectedAction?(languages[indexPath.item])
+        }
+    }
+}
+
+extension ContentLanguagesView: UICollectionViewDataSource {
+    func numberOfSections(in collectionView: UICollectionView) -> Int {
+        return 1
+    }
+
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        return languages.count
+    }
+
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "ContentLanguageCollectionViewCell", for: indexPath) as? ContentLanguageCollectionViewCell else {
+            return UICollectionViewCell()
+        }
+        cell.language = languages[indexPath.item].displayingString
+        if languages[indexPath.item] == initialLanguage {
+            cell.isSelected = true
+            currentlySelectedIndexPath = indexPath
+        }
+        return cell
+    }
+}

--- a/Stepic/ContentLanguagesView.xib
+++ b/Stepic/ContentLanguagesView.xib
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13527"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="ContentLanguagesView" customModule="Adaptive_1838" customModuleProvider="target">
+            <connections>
+                <outlet property="collectionView" destination="SaG-SC-tA2" id="Bls-Q0-spj"/>
+                <outlet property="flowLayout" destination="1gR-IX-UOI" id="lOY-PR-lRh"/>
+                <outlet property="titleLabel" destination="2Df-Uu-cul" id="LSX-hR-yfT"/>
+            </connections>
+        </placeholder>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="iN0-l3-epB">
+            <rect key="frame" x="0.0" y="0.0" width="375" height="77"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="none" translatesAutoresizingMaskIntoConstraints="NO" id="SaG-SC-tA2">
+                    <rect key="frame" x="0.0" y="37" width="375" height="40"/>
+                    <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                    <constraints>
+                        <constraint firstAttribute="height" priority="999" constant="40" id="yLe-Fl-i6W"/>
+                    </constraints>
+                    <collectionViewFlowLayout key="collectionViewLayout" minimumLineSpacing="0.0" minimumInteritemSpacing="0.0" id="1gR-IX-UOI">
+                        <size key="itemSize" width="50" height="50"/>
+                        <size key="headerReferenceSize" width="0.0" height="0.0"/>
+                        <size key="footerReferenceSize" width="0.0" height="0.0"/>
+                        <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
+                    </collectionViewFlowLayout>
+                </collectionView>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Chose language" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2Df-Uu-cul" customClass="StepikLabel" customModule="Adaptive_1838" customModuleProvider="target">
+                    <rect key="frame" x="0.0" y="0.0" width="375" height="17"/>
+                    <fontDescription key="fontDescription" type="system" pointSize="20"/>
+                    <nil key="textColor"/>
+                    <nil key="highlightedColor"/>
+                </label>
+            </subviews>
+            <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <constraints>
+                <constraint firstAttribute="bottom" secondItem="SaG-SC-tA2" secondAttribute="bottom" id="RN5-Lv-3Fl"/>
+                <constraint firstAttribute="trailing" secondItem="SaG-SC-tA2" secondAttribute="trailing" id="a5c-t6-Yun"/>
+                <constraint firstAttribute="trailing" secondItem="2Df-Uu-cul" secondAttribute="trailing" id="aSZ-m0-n15"/>
+                <constraint firstItem="SaG-SC-tA2" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="jhT-2q-AiQ"/>
+                <constraint firstItem="2Df-Uu-cul" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" id="nKQ-WU-M8t"/>
+                <constraint firstItem="2Df-Uu-cul" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="qIg-tq-ivb"/>
+                <constraint firstItem="SaG-SC-tA2" firstAttribute="top" secondItem="2Df-Uu-cul" secondAttribute="bottom" constant="20" id="rgS-6k-Vfz"/>
+            </constraints>
+            <nil key="simulatedTopBarMetrics"/>
+            <nil key="simulatedBottomBarMetrics"/>
+            <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
+            <point key="canvasLocation" x="33.5" y="-204.5"/>
+        </view>
+    </objects>
+</document>

--- a/Stepic/CourseList+CoreDataProperties.swift
+++ b/Stepic/CourseList+CoreDataProperties.swift
@@ -10,7 +10,7 @@ import Foundation
 import CoreData
 
 extension CourseList {
-    
+
     @NSManaged var managedId: NSNumber?
     @NSManaged var managedTitle: String?
     @NSManaged var managedDescription: String?
@@ -18,15 +18,14 @@ extension CourseList {
     @NSManaged var managedPosition: NSNumber?
     @NSManaged var managedCoursesArray: NSObject?
 
-    
     class var oldEntity: NSEntityDescription {
         return NSEntityDescription.entity(forEntityName: "CourseList", in: CoreDataHelper.instance.context)!
     }
-    
+
     convenience init() {
         self.init(entity: CourseList.oldEntity, insertInto: CoreDataHelper.instance.context)
     }
-    
+
     var id: Int {
         set(newId) {
             self.managedId = newId as NSNumber?
@@ -35,7 +34,7 @@ extension CourseList {
             return managedId?.intValue ?? -1
         }
     }
-    
+
     var title: String {
         set(value) {
             managedTitle = value
@@ -44,7 +43,7 @@ extension CourseList {
             return managedTitle ?? ""
         }
     }
-    
+
     var listDescription: String {
         set(value) {
             managedDescription = value
@@ -53,7 +52,7 @@ extension CourseList {
             return managedDescription ?? ""
         }
     }
-    
+
     var languageString: String {
         set(value) {
             managedLanguage = value
@@ -62,7 +61,7 @@ extension CourseList {
             return managedLanguage ?? ""
         }
     }
-    
+
     var position: Int {
         set(value) {
             self.managedPosition = value as NSNumber?
@@ -71,7 +70,7 @@ extension CourseList {
             return managedPosition?.intValue ?? 0
         }
     }
-    
+
     var coursesArray: [Int] {
         set(value) {
             self.managedCoursesArray = value as NSObject?
@@ -81,4 +80,3 @@ extension CourseList {
         }
     }
 }
-

--- a/Stepic/CourseList+CoreDataProperties.swift
+++ b/Stepic/CourseList+CoreDataProperties.swift
@@ -1,0 +1,84 @@
+//
+//  CourseList+CoreDataProperties.swift
+//  Stepic
+//
+//  Created by Ostrenkiy on 10.11.2017.
+//  Copyright © 2017 Alex Karpov. All rights reserved.
+//
+
+import Foundation
+import CoreData
+
+extension CourseList {
+    
+    @NSManaged var managedId: NSNumber?
+    @NSManaged var managedTitle: String?
+    @NSManaged var managedDescription: String?
+    @NSManaged var managedLanguage: String?
+    @NSManaged var managedPosition: NSNumber?
+    @NSManaged var managedCoursesArray: NSObject?
+
+    
+    class var oldEntity: NSEntityDescription {
+        return NSEntityDescription.entity(forEntityName: "CourseList", in: CoreDataHelper.instance.context)!
+    }
+    
+    convenience init() {
+        self.init(entity: CourseList.oldEntity, insertInto: CoreDataHelper.instance.context)
+    }
+    
+    var id: Int {
+        set(newId) {
+            self.managedId = newId as NSNumber?
+        }
+        get {
+            return managedId?.intValue ?? -1
+        }
+    }
+    
+    var title: String {
+        set(value) {
+            managedTitle = value
+        }
+        get {
+            return managedTitle ?? ""
+        }
+    }
+    
+    var listDescription: String {
+        set(value) {
+            managedDescription = value
+        }
+        get {
+            return managedDescription ?? ""
+        }
+    }
+    
+    var languageString: String {
+        set(value) {
+            managedLanguage = value
+        }
+        get {
+            return managedLanguage ?? ""
+        }
+    }
+    
+    var position: Int {
+        set(value) {
+            self.managedPosition = value as NSNumber?
+        }
+        get {
+            return managedPosition?.intValue ?? 0
+        }
+    }
+    
+    var coursesArray: [Int] {
+        set(value) {
+            self.managedCoursesArray = value as NSObject?
+        }
+        get {
+            return (self.managedCoursesArray as? [Int]) ?? []
+        }
+    }
+}
+

--- a/Stepic/CourseList.swift
+++ b/Stepic/CourseList.swift
@@ -1,0 +1,38 @@
+//
+//  CourseList.swift
+//  Stepic
+//
+//  Created by Ostrenkiy on 10.11.2017.
+//  Copyright © 2017 Alex Karpov. All rights reserved.
+//
+
+import Foundation
+import CoreData
+import SwiftyJSON
+
+class CourseList: NSManagedObject, JSONInitializable {
+    typealias idType = Int
+    
+    convenience required init(json: JSON) {
+        self.init()
+        initialize(json)
+    }
+    
+    func initialize(_ json: JSON) {
+        id = json["id"].intValue
+        title = json["title"].stringValue
+        listDescription = json["description"].stringValue
+        position = json["position"].intValue
+        languageString = json["language"].stringValue
+        coursesArray = json["courses"].arrayObject as! [Int]
+    }
+    
+    func update(json: JSON) {
+        initialize(json)
+    }
+    
+    func hasEqualId(json: JSON) -> Bool {
+        return id == json["id"].int
+    }
+
+}

--- a/Stepic/CourseList.swift
+++ b/Stepic/CourseList.swift
@@ -35,6 +35,10 @@ class CourseList: NSManagedObject, JSONInitializable {
         return id == json["id"].int
     }
     
+    var language: ContentLanguage {
+        return ContentLanguage(languageString: languageString)
+    }
+    
     class func recover(ids: [Int]) -> [CourseList] {
         let request = NSFetchRequest<NSFetchRequestResult>(entityName: "CourseList")
         let descriptor = NSSortDescriptor(key: "managedPosition", ascending: false)

--- a/Stepic/CourseList.swift
+++ b/Stepic/CourseList.swift
@@ -12,12 +12,12 @@ import SwiftyJSON
 
 class CourseList: NSManagedObject, JSONInitializable {
     typealias idType = Int
-    
+
     convenience required init(json: JSON) {
         self.init()
         initialize(json)
     }
-    
+
     func initialize(_ json: JSON) {
         id = json["id"].intValue
         title = json["title"].stringValue
@@ -26,31 +26,31 @@ class CourseList: NSManagedObject, JSONInitializable {
         languageString = json["language"].stringValue
         coursesArray = json["courses"].arrayObject as! [Int]
     }
-    
+
     func update(json: JSON) {
         initialize(json)
     }
-    
+
     func hasEqualId(json: JSON) -> Bool {
         return id == json["id"].int
     }
-    
+
     var language: ContentLanguage {
         return ContentLanguage(languageString: languageString)
     }
-    
+
     class func recover(ids: [Int]) -> [CourseList] {
         let request = NSFetchRequest<NSFetchRequestResult>(entityName: "CourseList")
         let descriptor = NSSortDescriptor(key: "managedPosition", ascending: false)
-        
+
         let idPredicates = ids.map {
             NSPredicate(format: "managedId == %@", $0 as NSNumber)
         }
         let idCompoundPredicate = NSCompoundPredicate(type: NSCompoundPredicate.LogicalType.or, subpredicates: idPredicates)
-        
+
         request.predicate = idCompoundPredicate
         request.sortDescriptors = [descriptor]
-        
+
         do {
             let results = try CoreDataHelper.instance.context.fetch(request)
             return results as? [CourseList] ?? []

--- a/Stepic/CourseList.swift
+++ b/Stepic/CourseList.swift
@@ -34,5 +34,24 @@ class CourseList: NSManagedObject, JSONInitializable {
     func hasEqualId(json: JSON) -> Bool {
         return id == json["id"].int
     }
-
+    
+    class func recover(ids: [Int]) -> [CourseList] {
+        let request = NSFetchRequest<NSFetchRequestResult>(entityName: "CourseList")
+        let descriptor = NSSortDescriptor(key: "managedPosition", ascending: false)
+        
+        let idPredicates = ids.map {
+            NSPredicate(format: "managedId == %@", $0 as NSNumber)
+        }
+        let idCompoundPredicate = NSCompoundPredicate(type: NSCompoundPredicate.LogicalType.or, subpredicates: idPredicates)
+        
+        request.predicate = idCompoundPredicate
+        request.sortDescriptors = [descriptor]
+        
+        do {
+            let results = try CoreDataHelper.instance.context.fetch(request)
+            return results as? [CourseList] ?? []
+        } catch {
+            return []
+        }
+    }
 }

--- a/Stepic/CourseListEmptyPlaceholder.xib
+++ b/Stepic/CourseListEmptyPlaceholder.xib
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13196" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13173"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13527"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -20,13 +20,13 @@
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="tjf-Pi-oU4">
-                    <rect key="frame" x="16" y="0.0" width="366" height="206"/>
+                    <rect key="frame" x="16" y="28" width="366" height="150"/>
                     <subviews>
                         <imageView contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="course_list_purple_placeholder" translatesAutoresizingMaskIntoConstraints="NO" id="jcL-z5-Ha9">
-                            <rect key="frame" x="0.0" y="0.0" width="366" height="206"/>
+                            <rect key="frame" x="0.0" y="0.0" width="366" height="150"/>
                         </imageView>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="FP1-Cf-vcP" customClass="StepikLabel" customModule="Adaptive_1838" customModuleProvider="target">
-                            <rect key="frame" x="16" y="8" width="334" height="190"/>
+                            <rect key="frame" x="16" y="8" width="334" height="134"/>
                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                             <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             <nil key="highlightedColor"/>
@@ -35,6 +35,7 @@
                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     <constraints>
                         <constraint firstAttribute="trailing" secondItem="FP1-Cf-vcP" secondAttribute="trailing" constant="16" id="4SV-pZ-AGq"/>
+                        <constraint firstAttribute="height" priority="999" constant="150" id="8vz-OA-uwI"/>
                         <constraint firstItem="FP1-Cf-vcP" firstAttribute="top" secondItem="tjf-Pi-oU4" secondAttribute="top" constant="8" id="IvC-oq-325"/>
                         <constraint firstItem="jcL-z5-Ha9" firstAttribute="leading" secondItem="tjf-Pi-oU4" secondAttribute="leading" id="aBN-6Y-8T5"/>
                         <constraint firstItem="FP1-Cf-vcP" firstAttribute="leading" secondItem="tjf-Pi-oU4" secondAttribute="leading" constant="16" id="eoc-ju-vWV"/>
@@ -47,8 +48,9 @@
             </subviews>
             <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
             <constraints>
-                <constraint firstItem="tjf-Pi-oU4" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" id="XCB-7c-NYV"/>
-                <constraint firstAttribute="bottom" secondItem="tjf-Pi-oU4" secondAttribute="bottom" id="Yca-Lt-9Pc"/>
+                <constraint firstItem="tjf-Pi-oU4" firstAttribute="centerY" secondItem="iN0-l3-epB" secondAttribute="centerY" id="Oln-Cd-QsV"/>
+                <constraint firstItem="tjf-Pi-oU4" firstAttribute="top" relation="greaterThanOrEqual" secondItem="iN0-l3-epB" secondAttribute="top" id="XCB-7c-NYV"/>
+                <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="tjf-Pi-oU4" secondAttribute="bottom" id="Yca-Lt-9Pc"/>
                 <constraint firstAttribute="trailing" secondItem="tjf-Pi-oU4" secondAttribute="trailing" constant="16" id="dBe-AF-emG"/>
                 <constraint firstItem="tjf-Pi-oU4" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="16" id="w2D-m1-Ngi"/>
             </constraints>

--- a/Stepic/CourseListPresenter.swift
+++ b/Stepic/CourseListPresenter.swift
@@ -43,6 +43,7 @@ class CourseListPresenter {
     private var progressesAPI: ProgressesAPI
     private var reviewSummariesAPI: CourseReviewSummariesAPI
     private var searchResultsAPI: SearchResultsAPI
+    private var subscriptionManager: CourseSubscriptionManager
 
     private var colorMode: CourseListColorMode
     private var onlyLocal: Bool
@@ -58,8 +59,6 @@ class CourseListPresenter {
 
     private var lastUser: User?
     private var lastLanguage: ContentLanguage
-
-    private var subscriptionManager = CourseSubscriptionManager()
 
     weak var lastStepDataSource: LastStepWidgetDataSource?
     weak var couseListCountDelegate: CourseListCountDelegate?
@@ -106,7 +105,7 @@ class CourseListPresenter {
         return result
     }
 
-    init(view: CourseListView, ID: String, limit: Int?, listType: CourseListType, colorMode: CourseListColorMode, onlyLocal: Bool, coursesAPI: CoursesAPI, progressesAPI: ProgressesAPI, reviewSummariesAPI: CourseReviewSummariesAPI, searchResultsAPI: SearchResultsAPI) {
+    init(view: CourseListView, ID: String, limit: Int?, listType: CourseListType, colorMode: CourseListColorMode, onlyLocal: Bool, subscriptionManager: CourseSubscriptionManager, coursesAPI: CoursesAPI, progressesAPI: ProgressesAPI, reviewSummariesAPI: CourseReviewSummariesAPI, searchResultsAPI: SearchResultsAPI) {
         self.view = view
         self.ID = ID
         self.coursesAPI = coursesAPI
@@ -119,6 +118,7 @@ class CourseListPresenter {
         self.lastLanguage = ContentLanguage.sharedContentLanguage
         self.onlyLocal = onlyLocal
         self.searchResultsAPI = searchResultsAPI
+        self.subscriptionManager = subscriptionManager
         subscriptionManager.handleUpdatesBlock = {
             [weak self] in
             self?.handleCourseSubscriptionUpdates()

--- a/Stepic/CourseListPresenter.swift
+++ b/Stepic/CourseListPresenter.swift
@@ -688,9 +688,12 @@ enum CourseListType {
     }
 
     func request(page: Int, language: ContentLanguage, withAPI coursesAPI: CoursesAPI, progressesAPI: ProgressesAPI, searchResultsAPI: SearchResultsAPI) -> Promise<([Course], Meta)>? {
+
+        let requestedLanguage: ContentLanguage? = language == .russian ? nil : language
+
         switch self {
         case .popular:
-            return coursesAPI.retrieve(featured: true, excludeEnded: true, isPublic: true, order: "-activity", language: language, page: page)
+            return coursesAPI.retrieve(featured: true, excludeEnded: true, isPublic: true, order: "-activity", language: requestedLanguage, page: page)
         case .enrolled:
             return requestAllEnrolled(coursesAPI: coursesAPI, progressesAPI: progressesAPI)
         case let .search(query: query):
@@ -698,7 +701,7 @@ enum CourseListType {
             var searchCoursesIDs: [Int] = []
             return Promise<([Course], Meta)> {
                 fulfill, reject in
-                searchResultsAPI.searchCourse(query: query, page: page).then {
+                searchResultsAPI.searchCourse(query: query, language: requestedLanguage, page: page).then {
                     (searchResults, meta) -> Promise<([Course])> in
                     resultMeta = meta
                     searchCoursesIDs = searchResults.flatMap { $0.courseId }

--- a/Stepic/CourseListPresenter.swift
+++ b/Stepic/CourseListPresenter.swift
@@ -335,8 +335,8 @@ class CourseListPresenter {
                 return
             }
             strongSelf.courses = courses
+            strongSelf.state = courses.isEmpty ? .empty: .displaying
             strongSelf.view?.display(courses: strongSelf.getData(from: strongSelf.displayingCourses))
-
             strongSelf.updateReviewSummaries(for: courses)
             if updateProgresses {
                 strongSelf.updateProgresses(for: courses)
@@ -344,7 +344,6 @@ class CourseListPresenter {
             strongSelf.currentPage = meta.page
             strongSelf.hasNextPage = meta.hasNext
             strongSelf.view?.setPaginationStatus(status: strongSelf.shouldLoadNextPage ? .loading : .none)
-            strongSelf.state = courses.isEmpty ? .empty: .displaying
             strongSelf.didRefreshOnce = true
             completion?()
             }.catch {
@@ -373,13 +372,13 @@ class CourseListPresenter {
                     return
                 }
                 strongSelf.courses = Sorter.sort(courses, byIds: ids)
+                strongSelf.state = courses.isEmpty ? .empty: .displaying
                 strongSelf.view?.display(courses: strongSelf.getData(from: strongSelf.displayingCourses))
                 strongSelf.updateReviewSummaries(for: courses)
                 strongSelf.updateProgresses(for: courses)
                 strongSelf.currentPage = 1
                 strongSelf.hasNextPage = false
                 strongSelf.view?.setPaginationStatus(status: strongSelf.shouldLoadNextPage ? .loading : .none)
-                strongSelf.state = courses.isEmpty ? .empty: .displaying
                 strongSelf.didRefreshOnce = true
             }.catch {
                 [weak self]

--- a/Stepic/CourseListViewController.swift
+++ b/Stepic/CourseListViewController.swift
@@ -152,6 +152,8 @@ class CourseListViewController: UIViewController, CourseListView {
                     emptyPlaceholder.text = NSLocalizedString("HomePlaceholderEmptyEnrolled", comment: "")
                 case .popular:
                     emptyPlaceholder.text = NSLocalizedString("HomePlaceholderEmptyPopular", comment: "")
+                case .search(query: _):
+                    emptyPlaceholder.text = NSLocalizedString("SearchPlaceholderEmpty", comment: "")
                 default:
                     emptyPlaceholder.text = "Empty"
                     break
@@ -170,6 +172,8 @@ class CourseListViewController: UIViewController, CourseListView {
                     emptyPlaceholder.text = NSLocalizedString("HomePlaceHolderErrorEnrolled", comment: "")
                 case .popular:
                     emptyPlaceholder.text = NSLocalizedString("HomePlaceholderErrorPopular", comment: "")
+                case .search(query: _):
+                    emptyPlaceholder.text = NSLocalizedString("SearchPlaceholderError", comment: "")
                 default:
                     emptyPlaceholder.text = "Error"
                     break

--- a/Stepic/CourseListsAPI.swift
+++ b/Stepic/CourseListsAPI.swift
@@ -1,0 +1,17 @@
+//
+//  CourseListsAPI.swift
+//  Stepic
+//
+//  Created by Ostrenkiy on 10.11.2017.
+//  Copyright © 2017 Alex Karpov. All rights reserved.
+//
+
+import Foundation
+
+class CourseListsAPI: APIEndpoint {
+    override var name: String {
+        return "course-lists"
+    }
+    
+    
+}

--- a/Stepic/CourseListsAPI.swift
+++ b/Stepic/CourseListsAPI.swift
@@ -7,11 +7,51 @@
 //
 
 import Foundation
+import Alamofire
+import SwiftyJSON
+import PromiseKit
 
 class CourseListsAPI: APIEndpoint {
     override var name: String {
         return "course-lists"
     }
     
-    
+    @discardableResult func retrieve(language: ContentLanguage, page: Int = 1, headers: [String: String] = AuthInfo.shared.initialHTTPHeaders) -> Promise<([CourseList], Meta)> {
+        let params : Parameters = [
+            "language": language.languageString,
+            "page": page
+        ]
+        
+        return Promise<([CourseList], Meta)> {
+            fulfill, reject in
+            manager.request("\(StepicApplicationsInfo.apiURL)/\(name)", method: .get, parameters: params, headers: headers).validate().responseSwiftyJSON { response in
+                switch response.result {
+                    
+                case .failure(let error):
+                    reject(RetrieveError(error: error))
+                    
+                case .success(let json):
+                    let meta = Meta(json: json["meta"])
+                    //TODO: Better make this recovery-update mechanism more generic to avoid code duplication. Think about it.
+                    let jsonArray: [JSON] = json["course-lists"].array ?? []
+                    let listIds: [Int] = jsonArray.map {
+                        $0["id"].intValue
+                    }
+                    let recoveredLists = CourseList.recover(ids: listIds)
+                    let resultArray: [CourseList] = jsonArray.map {
+                        objectJSON in
+                        if let recoveredIndex = recoveredLists.index(where: { $0.hasEqualId(json: objectJSON) }) {
+                            recoveredLists[recoveredIndex].update(json: objectJSON)
+                            return recoveredLists[recoveredIndex]
+                        } else {
+                            return CourseList(json: objectJSON)
+                        }
+                    }
+                    
+                    CoreDataHelper.instance.save()
+                    fulfill((resultArray, meta))
+                }
+            }
+        }
+    }
 }

--- a/Stepic/CourseListsAPI.swift
+++ b/Stepic/CourseListsAPI.swift
@@ -15,21 +15,21 @@ class CourseListsAPI: APIEndpoint {
     override var name: String {
         return "course-lists"
     }
-    
+
     @discardableResult func retrieve(language: ContentLanguage, page: Int = 1, headers: [String: String] = AuthInfo.shared.initialHTTPHeaders) -> Promise<([CourseList], Meta)> {
         let params : Parameters = [
             "language": language.languageString,
             "page": page
         ]
-        
+
         return Promise<([CourseList], Meta)> {
             fulfill, reject in
             manager.request("\(StepicApplicationsInfo.apiURL)/\(name)", method: .get, parameters: params, headers: headers).validate().responseSwiftyJSON { response in
                 switch response.result {
-                    
+
                 case .failure(let error):
                     reject(RetrieveError(error: error))
-                    
+
                 case .success(let json):
                     let meta = Meta(json: json["meta"])
                     //TODO: Better make this recovery-update mechanism more generic to avoid code duplication. Think about it.
@@ -47,7 +47,7 @@ class CourseListsAPI: APIEndpoint {
                             return CourseList(json: objectJSON)
                         }
                     }
-                    
+
                     CoreDataHelper.instance.save()
                     fulfill((resultArray, meta))
                 }

--- a/Stepic/CourseListsAPI.swift
+++ b/Stepic/CourseListsAPI.swift
@@ -18,6 +18,7 @@ class CourseListsAPI: APIEndpoint {
 
     @discardableResult func retrieve(language: ContentLanguage, page: Int = 1, headers: [String: String] = AuthInfo.shared.initialHTTPHeaders) -> Promise<([CourseList], Meta)> {
         let params : Parameters = [
+            "platform": "mobile",
             "language": language.languageString,
             "page": page
         ]

--- a/Stepic/CourseListsCache.swift
+++ b/Stepic/CourseListsCache.swift
@@ -1,0 +1,24 @@
+//
+//  CourseListsCache.swift
+//  Stepic
+//
+//  Created by Ostrenkiy on 10.11.2017.
+//  Copyright © 2017 Alex Karpov. All rights reserved.
+//
+
+import Foundation
+
+class CourseListsCache {
+
+    private func getKey(forLanguage language: ContentLanguage) -> String {
+        return "ListIds_\(language.languageString)"
+    }
+
+    func set(ids: [Int], forLanguage language: ContentLanguage) {
+        UserDefaults.standard.setValue(ids, forKey: getKey(forLanguage: language))
+    }
+
+    func get(forLanguage language: ContentLanguage) -> [Int] {
+        return UserDefaults.standard.value(forKey: getKey(forLanguage: language)) as? [Int] ?? []
+    }
+}

--- a/Stepic/CoursesAPI.swift
+++ b/Stepic/CoursesAPI.swift
@@ -79,7 +79,7 @@ class CoursesAPI: APIEndpoint {
         return getObjectsByIds(ids: ids, updating: existing)
     }
 
-    @discardableResult func retrieve(featured: Bool? = nil, enrolled: Bool? = nil, excludeEnded: Bool? = nil, isPublic: Bool? = nil, order: String? = nil, page: Int = 1, headers: [String: String] = AuthInfo.shared.initialHTTPHeaders, success successHandler: @escaping ([Course], Meta) -> Void, error errorHandler: @escaping (Error) -> Void) -> Request? {
+    @discardableResult func retrieve(featured: Bool? = nil, enrolled: Bool? = nil, excludeEnded: Bool? = nil, isPublic: Bool? = nil, order: String? = nil, language: ContentLanguage? = nil, page: Int = 1, headers: [String: String] = AuthInfo.shared.initialHTTPHeaders, success successHandler: @escaping ([Course], Meta) -> Void, error errorHandler: @escaping (Error) -> Void) -> Request? {
         var params = Parameters()
 
         if let isFeatured = featured {
@@ -100,6 +100,10 @@ class CoursesAPI: APIEndpoint {
 
         if let order = order {
             params["order"] = order
+        }
+
+        if let language = language {
+            params["language"] = language.languageString
         }
 
         params["page"] = page
@@ -138,9 +142,9 @@ class CoursesAPI: APIEndpoint {
     }
 
     //Could wrap retrieveDisplayedIds 
-    @discardableResult func retrieve(featured: Bool? = nil, enrolled: Bool? = nil, excludeEnded: Bool? = nil, isPublic: Bool? = nil, order: String? = nil, page: Int = 1, headers: [String: String] = AuthInfo.shared.initialHTTPHeaders) -> Promise<([Course], Meta)> {
+    @discardableResult func retrieve(featured: Bool? = nil, enrolled: Bool? = nil, excludeEnded: Bool? = nil, isPublic: Bool? = nil, order: String? = nil, language: ContentLanguage? = nil, page: Int = 1, headers: [String: String] = AuthInfo.shared.initialHTTPHeaders) -> Promise<([Course], Meta)> {
         return Promise { fulfill, reject in
-            retrieve(featured: featured, enrolled: enrolled, excludeEnded: excludeEnded, isPublic: isPublic, order: order, page: page, headers: headers, success: {
+            retrieve(featured: featured, enrolled: enrolled, excludeEnded: excludeEnded, isPublic: isPublic, order: order, language: language, page: page, headers: headers, success: {
                 courses, meta in
                 fulfill((courses, meta))
             }, error: {

--- a/Stepic/ErrorEnums.swift
+++ b/Stepic/ErrorEnums.swift
@@ -15,3 +15,7 @@ enum FetchError: Error {
 enum ConnectionError: Error {
     case noDataRecievedError, parsingError, tokenRefreshError
 }
+
+enum WeakSelfError: Error {
+    case noStrong
+}

--- a/Stepic/Explore.storyboard
+++ b/Stepic/Explore.storyboard
@@ -5,7 +5,6 @@
     </device>
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13527"/>
-        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -29,11 +28,10 @@
         <scene sceneID="0BJ-UV-kMQ">
             <objects>
                 <viewController id="8D7-26-KxZ" customClass="ExploreViewController" customModule="Adaptive_1838" customModuleProvider="target" sceneMemberID="viewController">
-                    <view key="view" contentMode="scaleToFill" id="7W9-A9-Bnp">
+                    <view key="view" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="7W9-A9-Bnp">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                        <viewLayoutGuide key="safeArea" id="zWe-e7-JJJ"/>
                     </view>
                     <navigationItem key="navigationItem" id="PyV-Ko-NDr"/>
                 </viewController>
@@ -45,11 +43,10 @@
         <scene sceneID="dhu-7K-Qt2">
             <objects>
                 <viewController storyboardIdentifier="SearchResultsViewController" id="vcj-M0-Gei" customClass="NewSearchResultsViewController" customModule="Adaptive_1838" customModuleProvider="target" sceneMemberID="viewController">
-                    <view key="view" contentMode="scaleToFill" id="0gB-sS-lNc">
+                    <view key="view" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="0gB-sS-lNc">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                        <viewLayoutGuide key="safeArea" id="2d8-uE-Mbc"/>
                     </view>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="yOE-pl-AFP" userLabel="First Responder" sceneMemberID="firstResponder"/>

--- a/Stepic/Explore.storyboard
+++ b/Stepic/Explore.storyboard
@@ -41,5 +41,20 @@
             </objects>
             <point key="canvasLocation" x="354" y="134"/>
         </scene>
+        <!--New Search Results View Controller-->
+        <scene sceneID="dhu-7K-Qt2">
+            <objects>
+                <viewController storyboardIdentifier="SearchResultsViewController" id="vcj-M0-Gei" customClass="NewSearchResultsViewController" customModule="Adaptive_1838" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="0gB-sS-lNc">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <viewLayoutGuide key="safeArea" id="2d8-uE-Mbc"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="yOE-pl-AFP" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="769" y="923"/>
+        </scene>
     </scenes>
 </document>

--- a/Stepic/Explore.storyboard
+++ b/Stepic/Explore.storyboard
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13527"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--Styled Navigation View Controller-->
+        <scene sceneID="7B8-z4-Jty">
+            <objects>
+                <navigationController storyboardIdentifier="ExploreNavigation" id="lRX-Op-x38" customClass="StyledNavigationViewController" customModule="Adaptive_1838" customModuleProvider="target" sceneMemberID="viewController">
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="Bx2-1S-7f9">
+                        <rect key="frame" x="0.0" y="20" width="375" height="44"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                    <connections>
+                        <segue destination="8D7-26-KxZ" kind="relationship" relationship="rootViewController" id="0oe-z3-tDG"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="RwC-vH-xlh" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-431" y="134"/>
+        </scene>
+        <!--Explore View Controller-->
+        <scene sceneID="0BJ-UV-kMQ">
+            <objects>
+                <viewController id="8D7-26-KxZ" customClass="ExploreViewController" customModule="Adaptive_1838" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="7W9-A9-Bnp">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <viewLayoutGuide key="safeArea" id="zWe-e7-JJJ"/>
+                    </view>
+                    <navigationItem key="navigationItem" id="PyV-Ko-NDr"/>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="8NA-eJ-ohF" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="354" y="134"/>
+        </scene>
+    </scenes>
+</document>

--- a/Stepic/ExplorePresenter.swift
+++ b/Stepic/ExplorePresenter.swift
@@ -12,10 +12,14 @@ import PromiseKit
 protocol ExploreView: class {
     func presentBlocks(blocks: [CourseListBlock])
 
-    func show(vc: UIViewController)
     func setLanguages(withLanguages: [ContentLanguage], initialLanguage: ContentLanguage, onSelected: @escaping (ContentLanguage) -> Void)
-//    func setTagsWidget()
     func updateCourseCount(to: Int, forBlockWithID: String)
+
+    func updateSearchQuery(to: String)
+
+    func show(vc: UIViewController)
+    func setSearch(vc: UIViewController)
+    func setSearch(hidden: Bool)
 }
 
 class ExplorePresenter: CourseListCountDelegate {
@@ -43,6 +47,32 @@ class ExplorePresenter: CourseListCountDelegate {
                 self?.refresh()
             }
         })
+    }
+
+    var searchController: NewSearchResultsViewController?
+//    var query = ""
+
+    func queryChanged(to query: String) {
+        //TODO: Refactor this to router layer in the next releases
+        if searchController == nil {
+            guard let controller = ControllerHelper.instantiateViewController(identifier: "SearchResultsViewController", storyboardName: "Explore") as? NewSearchResultsViewController else {
+                return
+            }
+            searchController = controller
+            controller.presenter = SearchResultsPresenter(view: controller)
+            controller.presenter?.updateQueryBlock = {
+                [weak self]
+                newQuery in
+                self?.view?.updateSearchQuery(to: newQuery)
+            }
+            view?.setSearch(vc: controller)
+        }
+        searchController?.presenter?.queryChanged(to: query)
+        view?.setSearch(hidden: false)
+    }
+
+    func searchCancelled() {
+        view?.setSearch(hidden: true)
     }
 
     private func getId(forList list: CourseList) -> String {

--- a/Stepic/ExplorePresenter.swift
+++ b/Stepic/ExplorePresenter.swift
@@ -32,7 +32,6 @@ class ExplorePresenter: CourseListCountDelegate {
         self.view = view
         self.courseListsAPI = courseListsAPI
         self.courseListsCache = courseListsCache
-
     }
 
     func initLanguagesWidget() {
@@ -120,4 +119,8 @@ class ExplorePresenter: CourseListCountDelegate {
     func updateCourseCount(to: Int, forListID: String) {
         view?.updateCourseCount(to: to, forBlockWithID: forListID)
     }
+}
+
+enum SearchState {
+    case noSearch, suggestions, results
 }

--- a/Stepic/ExplorePresenter.swift
+++ b/Stepic/ExplorePresenter.swift
@@ -71,6 +71,10 @@ class ExplorePresenter: CourseListCountDelegate {
         view?.setSearch(hidden: false)
     }
 
+    func search(query: String) {
+        searchController?.presenter?.search(query: query)
+    }
+
     func searchCancelled() {
         view?.setSearch(hidden: true)
     }

--- a/Stepic/ExplorePresenter.swift
+++ b/Stepic/ExplorePresenter.swift
@@ -52,7 +52,6 @@ class ExplorePresenter: CourseListCountDelegate {
     }
 
     var searchController: NewSearchResultsViewController?
-//    var query = ""
 
     func queryChanged(to query: String) {
         //TODO: Refactor this to router layer in the next releases
@@ -161,7 +160,6 @@ class ExplorePresenter: CourseListCountDelegate {
             guard let strongSelf = self else {
                 return
             }
-
         }
     }
 

--- a/Stepic/ExplorePresenter.swift
+++ b/Stepic/ExplorePresenter.swift
@@ -17,6 +17,8 @@ protocol ExploreView: class {
 
     func updateSearchQuery(to: String)
 
+    func hideKeyboard()
+
     func show(vc: UIViewController)
     func setSearch(vc: UIViewController)
     func setSearch(hidden: Bool)
@@ -60,6 +62,10 @@ class ExplorePresenter: CourseListCountDelegate {
             }
             searchController = controller
             controller.presenter = SearchResultsPresenter(view: controller)
+            controller.presenter?.hideKeyboardBlock = {
+                [weak self] in
+                self?.view?.hideKeyboard()
+            }
             controller.presenter?.updateQueryBlock = {
                 [weak self]
                 newQuery in
@@ -75,8 +81,17 @@ class ExplorePresenter: CourseListCountDelegate {
         searchController?.presenter?.search(query: query)
     }
 
+    func searchStarted() {
+        if searchController == nil {
+            queryChanged(to: "")
+        } else {
+            searchController?.presenter?.searchStarted()
+        }
+    }
+
     func searchCancelled() {
         view?.setSearch(hidden: true)
+        searchController?.presenter?.searchCancelled()
     }
 
     private func getId(forList list: CourseList) -> String {

--- a/Stepic/ExplorePresenter.swift
+++ b/Stepic/ExplorePresenter.swift
@@ -1,0 +1,110 @@
+//
+//  ExplorePresenter.swift
+//  Stepic
+//
+//  Created by Ostrenkiy on 10.11.2017.
+//  Copyright © 2017 Alex Karpov. All rights reserved.
+//
+
+import Foundation
+import PromiseKit
+
+protocol ExploreView: class {
+    func presentBlocks(blocks: [CourseListBlock])
+
+    func show(vc: UIViewController)
+
+//    func setLanguagesWidget()
+//    func setTagsWidget()
+    func updateCourseCount(to: Int, forBlockWithID: String)
+}
+
+class ExplorePresenter: CourseListCountDelegate {
+    private weak var view: ExploreView?
+    private var courseListsAPI: CourseListsAPI
+    private var courseListsCache: CourseListsCache
+
+    private var lists: [CourseList] = []
+    private var blocks: [CourseListBlock] = []
+
+    init(view: ExploreView, courseListsAPI: CourseListsAPI, courseListsCache: CourseListsCache) {
+        self.view = view
+        self.courseListsAPI = courseListsAPI
+        self.courseListsCache = courseListsCache
+    }
+
+    private func getId(forList list: CourseList) -> String {
+        return "collection_\(list.id)"
+    }
+
+    private func buildBlocks(forLists lists: [CourseList], onlyLocal: Bool) -> [CourseListBlock] {
+        let showController: (UIViewController) -> Void = {
+            [weak self]
+            vc in
+            self?.view?.show(vc: vc)
+        }
+
+        return lists.map {
+            CourseListBlock(
+                listType: .collection(ids: $0.coursesArray),
+                ID: getId(forList: $0),
+                horizontalLimit: 6,
+                title: $0.title,
+                colorMode: .light,
+                shouldShowCount: true,
+                showControllerBlock: showController,
+                courseListCountDelegate: self,
+                onlyLocal: onlyLocal
+            )
+        }
+    }
+
+    private func getCachedLists(forLanguage language: ContentLanguage) -> [CourseList] {
+        let recoveredIds = courseListsCache.get(forLanguage: language)
+        return CourseList.recover(ids: recoveredIds).sorted { $0.0.position < $0.1.position }
+    }
+
+    func refresh() {
+        let listLanguage = ContentLanguage.sharedContentLanguage
+        refreshFromLocal(forLanguage: listLanguage)
+        refreshFromRemote(forLanguage: listLanguage)
+    }
+
+    private func refreshFromLocal(forLanguage language: ContentLanguage) {
+        lists = getCachedLists(forLanguage: language)
+        blocks = buildBlocks(forLists: lists, onlyLocal: true)
+        view?.presentBlocks(blocks: blocks)
+    }
+
+    private func refreshFromRemote(forLanguage language: ContentLanguage) {
+        checkToken().then {
+            [weak self]
+            () -> Promise<([CourseList], Meta)> in
+            guard let strongSelf = self else {
+                throw WeakSelfError.noStrong
+            }
+            return strongSelf.courseListsAPI.retrieve(language: language, page: 1)
+        }.then {
+            [weak self]
+            lists, _ -> Void in
+            guard let strongSelf = self else {
+                throw WeakSelfError.noStrong
+            }
+            strongSelf.courseListsCache.set(ids: lists.map { $0.id }, forLanguage: language)
+            strongSelf.lists = lists.sorted { $0.0.position < $0.1.position }
+            strongSelf.blocks = strongSelf.buildBlocks(forLists: strongSelf.lists, onlyLocal: false)
+            strongSelf.view?.presentBlocks(blocks: strongSelf.blocks)
+        }.catch {
+            [weak self]
+            _ in
+            guard let strongSelf = self else {
+                return
+            }
+
+        }
+    }
+
+    func updateCourseCount(to: Int, forListID: String) {
+        view?.updateCourseCount(to: to, forBlockWithID: forListID)
+    }
+}

--- a/Stepic/ExplorePresenter.swift
+++ b/Stepic/ExplorePresenter.swift
@@ -13,8 +13,7 @@ protocol ExploreView: class {
     func presentBlocks(blocks: [CourseListBlock])
 
     func show(vc: UIViewController)
-
-//    func setLanguagesWidget()
+    func setLanguages(withLanguages: [ContentLanguage], initialLanguage: ContentLanguage, onSelected: @escaping (ContentLanguage) -> Void)
 //    func setTagsWidget()
     func updateCourseCount(to: Int, forBlockWithID: String)
 }
@@ -27,10 +26,24 @@ class ExplorePresenter: CourseListCountDelegate {
     private var lists: [CourseList] = []
     private var blocks: [CourseListBlock] = []
 
+    let supportedLanguages : [ContentLanguage] = [.russian, .english]
+
     init(view: ExploreView, courseListsAPI: CourseListsAPI, courseListsCache: CourseListsCache) {
         self.view = view
         self.courseListsAPI = courseListsAPI
         self.courseListsCache = courseListsCache
+
+    }
+
+    func initLanguagesWidget() {
+        view?.setLanguages(withLanguages: supportedLanguages, initialLanguage: ContentLanguage.sharedContentLanguage, onSelected: {
+            [weak self]
+            selectedLanguage in
+            if selectedLanguage != ContentLanguage.sharedContentLanguage {
+                ContentLanguage.sharedContentLanguage = selectedLanguage
+                self?.refresh()
+            }
+        })
     }
 
     private func getId(forList list: CourseList) -> String {

--- a/Stepic/ExploreViewController.swift
+++ b/Stepic/ExploreViewController.swift
@@ -20,7 +20,6 @@ class ExploreViewController: UIViewController, ExploreView {
         self.presenter = ExplorePresenter(view: self, courseListsAPI: CourseListsAPI(), courseListsCache: CourseListsCache())
         setupSearch()
         setupStackView()
-//        setupSearchResults()
         (navigationController as? StyledNavigationViewController)?.customShadowView?.alpha = 0
         presenter?.refresh()
         self.title = NSLocalizedString("Explore", comment: "")

--- a/Stepic/ExploreViewController.swift
+++ b/Stepic/ExploreViewController.swift
@@ -122,6 +122,10 @@ class ExploreViewController: UIViewController, ExploreView {
         searchBar.text = query
     }
 
+    func hideKeyboard() {
+        self.hideKeyboardIfNeeded()
+    }
+
     var searchController: UIViewController?
 
     func setSearch(vc: UIViewController) {
@@ -146,14 +150,10 @@ class ExploreViewController: UIViewController, ExploreView {
     }()
 
     func hideKeyboardIfNeeded() {
-        searchBar.resignFirstResponder()
+        searchBar.textField.resignFirstResponder()
     }
 
     private func setupSearch() {
-//        searchResultsVC.hideKeyboardBlock = {
-//            [weak self] in
-//            self?.hideKeyboardIfNeeded()
-//        }
         searchBar.delegate = self
         searchBar.barTintColor = navigationController?.navigationBar.barTintColor
 
@@ -195,7 +195,7 @@ extension ExploreViewController : CustomSearchBarDelegate {
     }
 
     func startedEditing(in searchBar: CustomSearchBar) {
-        self.presenter?.queryChanged(to: "")
+        self.presenter?.searchStarted()
     }
 
     func returnPressed(in searchBar: CustomSearchBar) {

--- a/Stepic/ExploreViewController.swift
+++ b/Stepic/ExploreViewController.swift
@@ -280,6 +280,7 @@ extension ExploreViewController : CustomSearchBarDelegate {
     }
 
     func startedEditing(in searchBar: CustomSearchBar) {
+        self.presenter?.queryChanged(to: "")
 //        darkOverlayView.isHidden = false
 //        darkOverlayView.alpha = 0
 //        UIView.animate(withDuration: 0.3, animations: {

--- a/Stepic/ExploreViewController.swift
+++ b/Stepic/ExploreViewController.swift
@@ -9,7 +9,6 @@
 import Foundation
 
 class ExploreViewController: UIViewController, ExploreView {
-
     var presenter: ExplorePresenter?
 
     var scrollView: UIScrollView = UIScrollView()
@@ -26,6 +25,7 @@ class ExploreViewController: UIViewController, ExploreView {
                 scrollView.contentInsetAdjustmentBehavior = UIScrollViewContentInsetAdjustmentBehavior.never
             }
         #endif
+        presenter?.initLanguagesWidget()
     }
 
     private func setupStackView() {
@@ -63,7 +63,6 @@ class ExploreViewController: UIViewController, ExploreView {
             stackView.addArrangedSubview(courseListView)
             courseListView.alignLeading("0", trailing: "0", toView: self.view)
             removeBlockForId[block.ID] = {
-                [weak self] in
                 courseListView.isHidden = true
                 courseListView.removeFromSuperview()
                 block.horizontalController.removeFromParentViewController()
@@ -85,6 +84,22 @@ class ExploreViewController: UIViewController, ExploreView {
 
     func getNavigation() -> UINavigationController? {
         return self.navigationController
+    }
+
+    func setLanguages(withLanguages languages: [ContentLanguage], initialLanguage: ContentLanguage, onSelected: @escaping (ContentLanguage) -> Void) {
+        let languagesWidget = ContentLanguagesView(frame: CGRect.zero)
+        languagesWidget.languages = languages
+        languagesWidget.languageSelectedAction = onSelected
+        languagesWidget.initialLanguage = initialLanguage
+
+        let widgetBackgroundView = UIView()
+        widgetBackgroundView.backgroundColor = UIColor.white
+        widgetBackgroundView.addSubview(languagesWidget)
+        languagesWidget.alignTop("16", bottom: "-8", toView: widgetBackgroundView)
+        languagesWidget.alignLeading("16", trailing: "-16", toView: widgetBackgroundView)
+        widgetBackgroundView.isHidden = false
+        stackView.insertArrangedSubview(widgetBackgroundView, at: 0)
+        widgetBackgroundView.alignLeading("0", trailing: "0", toView: self.view)
     }
 
     func updateCourseCount(to count: Int, forBlockWithID ID: String) {

--- a/Stepic/ExploreViewController.swift
+++ b/Stepic/ExploreViewController.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import FLKAutoLayout
 
 class ExploreViewController: UIViewController, ExploreView {
     var presenter: ExplorePresenter?
@@ -19,7 +20,7 @@ class ExploreViewController: UIViewController, ExploreView {
         self.presenter = ExplorePresenter(view: self, courseListsAPI: CourseListsAPI(), courseListsCache: CourseListsCache())
         setupSearch()
         setupStackView()
-        setupSearchResults()
+//        setupSearchResults()
         (navigationController as? StyledNavigationViewController)?.customShadowView?.alpha = 0
         presenter?.refresh()
         self.title = NSLocalizedString("Explore", comment: "")
@@ -117,31 +118,54 @@ class ExploreViewController: UIViewController, ExploreView {
         self.show(vc, sender: nil)
     }
 
+    func updateSearchQuery(to query: String) {
+        searchBar.text = query
+    }
+
+    var searchController: UIViewController?
+
+    func setSearch(vc: UIViewController) {
+        if let searchController = searchController {
+            searchController.removeFromParentViewController()
+            searchController.view.removeFromSuperview()
+        }
+        searchController = vc
+        self.addChildViewController(vc)
+        self.view.addSubview(vc.view)
+        vc.view.alignLeading("0", trailing: "0", toView: self.view)
+        vc.view.constrainTopSpace(toView: searchBar, predicate: "0")
+        vc.view.alignBottomEdge(withView: self.view, predicate: "0")
+    }
+
+    func setSearch(hidden: Bool) {
+        searchController?.view.isHidden = hidden
+    }
+
     // Bad code here
-    var searchResultsVC: SearchResultsCoursesViewController!
+//    var searchResultsVC: SearchResultsCoursesViewController!
     lazy var searchBar: CustomSearchBar = {
         CustomSearchBar()
     }()
 
-    lazy var darkOverlayView: UIView = {
-        let v = UIView()
-        v.backgroundColor = UIColor.black
-        let tapG = UITapGestureRecognizer(target: self, action: #selector(ExploreViewController.didTapBlackView))
-        v.addGestureRecognizer(tapG)
-        return v
-    }()
+//    lazy var darkOverlayView: UIView = {
+//        let v = UIView()
+//        v.backgroundColor = UIColor.black
+//        let tapG = UITapGestureRecognizer(target: self, action: #selector(ExploreViewController.didTapBlackView))
+//        v.addGestureRecognizer(tapG)
+//        return v
+//    }()
 
     func hideKeyboardIfNeeded() {
         searchBar.resignFirstResponder()
     }
 
     private func setupSearch() {
-        searchResultsVC = ControllerHelper.instantiateViewController(identifier: "SearchResultsCoursesViewController") as! SearchResultsCoursesViewController
-        searchResultsVC.parentVC = self
-        searchResultsVC.hideKeyboardBlock = {
-            [weak self] in
-            self?.hideKeyboardIfNeeded()
-        }
+//        searchResultsVC = ControllerHelper.instantiateViewController(identifier: "SearchResultsCoursesViewController") as! SearchResultsCoursesViewController
+//        searchResultsVC.parentVC = self
+//        searchResultsVC.hideKeyboardBlock = {
+//            [weak self] in
+//            self?.hideKeyboardIfNeeded()
+//        }
         searchBar.delegate = self
         searchBar.barTintColor = navigationController?.navigationBar.barTintColor
 
@@ -157,27 +181,27 @@ class ExploreViewController: UIViewController, ExploreView {
         searchBar.alignTopEdge(withView: self.view, predicate: "0")
         searchBar.alignLeading("0", trailing: "0", toView: self.view)
     }
-
-    private func setupSearchResults() {
-        self.view.addSubview(darkOverlayView)
-        darkOverlayView.alignLeading("0", trailing: "0", toView: self.view)
-        darkOverlayView.constrainTopSpace(toView: searchBar, predicate: "0")
-        darkOverlayView.alignBottomEdge(withView: self.view, predicate: "0")
-        darkOverlayView.isHidden = true
-
-        self.addChildViewController(searchResultsVC)
-        self.view.addSubview(searchResultsVC.view)
-        searchResultsVC.view.alignLeading("0", trailing: "0", toView: self.view)
-        searchResultsVC.view.constrainTopSpace(toView: searchBar, predicate: "0")
-        searchResultsVC.view.alignBottomEdge(withView: self.view, predicate: "0")
-        searchResultsVC.view.isHidden = true
-    }
-
-    var isDisplayingFromSuggestions: Bool = false
-
-    func didTapBlackView() {
-        searchBar.cancel()
-    }
+//
+//    private func setupSearchResults() {
+//        self.view.addSubview(darkOverlayView)
+//        darkOverlayView.alignLeading("0", trailing: "0", toView: self.view)
+//        darkOverlayView.constrainTopSpace(toView: searchBar, predicate: "0")
+//        darkOverlayView.alignBottomEdge(withView: self.view, predicate: "0")
+//        darkOverlayView.isHidden = true
+//
+//        self.addChildViewController(searchResultsVC)
+//        self.view.addSubview(searchResultsVC.view)
+//        searchResultsVC.view.alignLeading("0", trailing: "0", toView: self.view)
+//        searchResultsVC.view.constrainTopSpace(toView: searchBar, predicate: "0")
+//        searchResultsVC.view.alignBottomEdge(withView: self.view, predicate: "0")
+//        searchResultsVC.view.isHidden = true
+//    }
+//
+//    var isDisplayingFromSuggestions: Bool = false
+//
+//    func didTapBlackView() {
+//        searchBar.cancel()
+//    }
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
@@ -194,79 +218,81 @@ class ExploreViewController: UIViewController, ExploreView {
 
 extension ExploreViewController : CustomSearchBarDelegate {
     func changedText(in searchBar: CustomSearchBar, to text: String) {
-        guard let results = searchResultsVC else {
-            return
-        }
-        guard !isDisplayingFromSuggestions else {
-            isDisplayingFromSuggestions = false
-            return
-        }
-        guard text != "" else {
-            results.view.isHidden = true
-            return
-        }
-        if results.view.isHidden {
-            results.view.isHidden = false
-            results.view.alpha = 0
-            UIView.animate(withDuration: 0.3, animations: {
-                results.view.alpha = 1
-            })
-        }
-        results.state = .suggestions
-        results.query = text
-        results.updateSearchBarBlock = {
-            [weak self]
-            newQuery in
-            self?.isDisplayingFromSuggestions = true
-            self?.searchBar.text = newQuery
-            self?.searchBar.becomeFirstResponder()
-        }
-        results.countTopOffset()
+        self.presenter?.queryChanged(to: text)
+//        guard let results = searchResultsVC else {
+//            return
+//        }
+//        guard !isDisplayingFromSuggestions else {
+//            isDisplayingFromSuggestions = false
+//            return
+//        }
+//        guard text != "" else {
+//            results.view.isHidden = true
+//            return
+//        }
+//        if results.view.isHidden {
+//            results.view.isHidden = false
+//            results.view.alpha = 0
+//            UIView.animate(withDuration: 0.3, animations: {
+//                results.view.alpha = 1
+//            })
+//        }
+//        results.state = .suggestions
+//        results.query = text
+//        results.updateSearchBarBlock = {
+//            [weak self]
+//            newQuery in
+//            self?.isDisplayingFromSuggestions = true
+//            self?.searchBar.text = newQuery
+//            self?.searchBar.becomeFirstResponder()
+//        }
+//        results.countTopOffset()
     }
 
     func cancelPressed(in searchBar: CustomSearchBar) {
         searchBar.resignFirstResponder()
-        if searchBar.text == "" {
-            UIView.animate(withDuration: 0.3, animations: {
-                [weak self] in
-                self?.darkOverlayView.alpha = 0
-                }, completion: {
-                    [weak self]
-                    _ in
-                    self?.darkOverlayView.isHidden = true
-            })
-        } else {
-            self.darkOverlayView.isHidden = true
-            UIView.animate(withDuration: 0.3, animations: {
-                [weak self] in
-                self?.searchResultsVC.view.alpha = 0
-                }, completion: {
-                    [weak self]
-                    _ in
-                    self?.searchResultsVC.view.isHidden = true
-            })
-        }
-
-        guard let results = searchResultsVC else {
-            return
-        }
-        AnalyticsReporter.reportEvent(AnalyticsEvents.Search.cancelled, parameters: ["context": results.state.rawValue])
+        self.presenter?.searchCancelled()
+//        if searchBar.text == "" {
+//            UIView.animate(withDuration: 0.3, animations: {
+//                [weak self] in
+//                self?.darkOverlayView.alpha = 0
+//                }, completion: {
+//                    [weak self]
+//                    _ in
+//                    self?.darkOverlayView.isHidden = true
+//            })
+//        } else {
+//            self.darkOverlayView.isHidden = true
+//            UIView.animate(withDuration: 0.3, animations: {
+//                [weak self] in
+//                self?.searchResultsVC.view.alpha = 0
+//                }, completion: {
+//                    [weak self]
+//                    _ in
+//                    self?.searchResultsVC.view.isHidden = true
+//            })
+//        }
+//
+//        guard let results = searchResultsVC else {
+//            return
+//        }
+//        AnalyticsReporter.reportEvent(AnalyticsEvents.Search.cancelled, parameters: ["context": results.state.rawValue])
     }
 
     func startedEditing(in searchBar: CustomSearchBar) {
-        darkOverlayView.isHidden = false
-        darkOverlayView.alpha = 0
-        UIView.animate(withDuration: 0.3, animations: {
-            [weak self] in
-            self?.darkOverlayView.alpha = 0.4
-        })
+//        darkOverlayView.isHidden = false
+//        darkOverlayView.alpha = 0
+//        UIView.animate(withDuration: 0.3, animations: {
+//            [weak self] in
+//            self?.darkOverlayView.alpha = 0.4
+//        })
     }
 
     func returnPressed(in searchBar: CustomSearchBar) {
-        guard let results = searchResultsVC else {
-            return
-        }
-        results.didSelectSuggestion(suggestion: searchBar.text, position: 0)
+//        guard let results = searchResultsVC else {
+//            return
+//        }
+//        results.didSelectSuggestion(suggestion: searchBar.text, position: 0)
     }
 }
 

--- a/Stepic/ExploreViewController.swift
+++ b/Stepic/ExploreViewController.swift
@@ -141,27 +141,15 @@ class ExploreViewController: UIViewController, ExploreView {
         searchController?.view.isHidden = hidden
     }
 
-    // Bad code here
-//    var searchResultsVC: SearchResultsCoursesViewController!
     lazy var searchBar: CustomSearchBar = {
         CustomSearchBar()
     }()
-
-//    lazy var darkOverlayView: UIView = {
-//        let v = UIView()
-//        v.backgroundColor = UIColor.black
-//        let tapG = UITapGestureRecognizer(target: self, action: #selector(ExploreViewController.didTapBlackView))
-//        v.addGestureRecognizer(tapG)
-//        return v
-//    }()
 
     func hideKeyboardIfNeeded() {
         searchBar.resignFirstResponder()
     }
 
     private func setupSearch() {
-//        searchResultsVC = ControllerHelper.instantiateViewController(identifier: "SearchResultsCoursesViewController") as! SearchResultsCoursesViewController
-//        searchResultsVC.parentVC = self
 //        searchResultsVC.hideKeyboardBlock = {
 //            [weak self] in
 //            self?.hideKeyboardIfNeeded()
@@ -181,27 +169,6 @@ class ExploreViewController: UIViewController, ExploreView {
         searchBar.alignTopEdge(withView: self.view, predicate: "0")
         searchBar.alignLeading("0", trailing: "0", toView: self.view)
     }
-//
-//    private func setupSearchResults() {
-//        self.view.addSubview(darkOverlayView)
-//        darkOverlayView.alignLeading("0", trailing: "0", toView: self.view)
-//        darkOverlayView.constrainTopSpace(toView: searchBar, predicate: "0")
-//        darkOverlayView.alignBottomEdge(withView: self.view, predicate: "0")
-//        darkOverlayView.isHidden = true
-//
-//        self.addChildViewController(searchResultsVC)
-//        self.view.addSubview(searchResultsVC.view)
-//        searchResultsVC.view.alignLeading("0", trailing: "0", toView: self.view)
-//        searchResultsVC.view.constrainTopSpace(toView: searchBar, predicate: "0")
-//        searchResultsVC.view.alignBottomEdge(withView: self.view, predicate: "0")
-//        searchResultsVC.view.isHidden = true
-//    }
-//
-//    var isDisplayingFromSuggestions: Bool = false
-//
-//    func didTapBlackView() {
-//        searchBar.cancel()
-//    }
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
@@ -219,81 +186,20 @@ class ExploreViewController: UIViewController, ExploreView {
 extension ExploreViewController : CustomSearchBarDelegate {
     func changedText(in searchBar: CustomSearchBar, to text: String) {
         self.presenter?.queryChanged(to: text)
-//        guard let results = searchResultsVC else {
-//            return
-//        }
-//        guard !isDisplayingFromSuggestions else {
-//            isDisplayingFromSuggestions = false
-//            return
-//        }
-//        guard text != "" else {
-//            results.view.isHidden = true
-//            return
-//        }
-//        if results.view.isHidden {
-//            results.view.isHidden = false
-//            results.view.alpha = 0
-//            UIView.animate(withDuration: 0.3, animations: {
-//                results.view.alpha = 1
-//            })
-//        }
-//        results.state = .suggestions
-//        results.query = text
-//        results.updateSearchBarBlock = {
-//            [weak self]
-//            newQuery in
-//            self?.isDisplayingFromSuggestions = true
-//            self?.searchBar.text = newQuery
-//            self?.searchBar.becomeFirstResponder()
-//        }
-//        results.countTopOffset()
     }
 
     func cancelPressed(in searchBar: CustomSearchBar) {
         searchBar.resignFirstResponder()
         self.presenter?.searchCancelled()
-//        if searchBar.text == "" {
-//            UIView.animate(withDuration: 0.3, animations: {
-//                [weak self] in
-//                self?.darkOverlayView.alpha = 0
-//                }, completion: {
-//                    [weak self]
-//                    _ in
-//                    self?.darkOverlayView.isHidden = true
-//            })
-//        } else {
-//            self.darkOverlayView.isHidden = true
-//            UIView.animate(withDuration: 0.3, animations: {
-//                [weak self] in
-//                self?.searchResultsVC.view.alpha = 0
-//                }, completion: {
-//                    [weak self]
-//                    _ in
-//                    self?.searchResultsVC.view.isHidden = true
-//            })
-//        }
-//
-//        guard let results = searchResultsVC else {
-//            return
-//        }
-//        AnalyticsReporter.reportEvent(AnalyticsEvents.Search.cancelled, parameters: ["context": results.state.rawValue])
+        AnalyticsReporter.reportEvent(AnalyticsEvents.Search.cancelled)
     }
 
     func startedEditing(in searchBar: CustomSearchBar) {
         self.presenter?.queryChanged(to: "")
-//        darkOverlayView.isHidden = false
-//        darkOverlayView.alpha = 0
-//        UIView.animate(withDuration: 0.3, animations: {
-//            [weak self] in
-//            self?.darkOverlayView.alpha = 0.4
-//        })
     }
 
     func returnPressed(in searchBar: CustomSearchBar) {
-//        guard let results = searchResultsVC else {
-//            return
-//        }
-//        results.didSelectSuggestion(suggestion: searchBar.text, position: 0)
+        self.presenter?.search(query: searchBar.text)
     }
 }
 

--- a/Stepic/ExploreViewController.swift
+++ b/Stepic/ExploreViewController.swift
@@ -22,7 +22,7 @@ class ExploreViewController: UIViewController, ExploreView {
         setupStackView()
         (navigationController as? StyledNavigationViewController)?.customShadowView?.alpha = 0
         presenter?.refresh()
-        self.title = NSLocalizedString("Explore", comment: "")
+        self.title = NSLocalizedString("Catalog", comment: "")
         #if swift(>=3.2)
             if #available(iOS 11.0, *) {
                 scrollView.contentInsetAdjustmentBehavior = UIScrollViewContentInsetAdjustmentBehavior.never
@@ -150,6 +150,32 @@ class ExploreViewController: UIViewController, ExploreView {
 
     func hideKeyboardIfNeeded() {
         searchBar.textField.resignFirstResponder()
+    }
+
+    lazy var emptyPlaceholder: UIView = {
+        let v = UIView()
+        let placeholder = CourseListEmptyPlaceholder(frame: CGRect.zero)
+        v.addSubview(placeholder)
+        placeholder.alignTop("16", leading: "0", bottom: "0", trailing: "0", toView: v)
+        placeholder.constrainHeight("100")
+        placeholder.isHidden = false
+        placeholder.text = "No connection. Touch to retry"
+        placeholder.onTap = {
+            [weak self] in
+            self?.presenter?.refresh()
+        }
+        v.isHidden = true
+        return v
+    }()
+
+    func setConnectionProblemsPlaceholder(hidden: Bool) {
+        if !hidden {
+            stackView.addArrangedSubview(emptyPlaceholder)
+            emptyPlaceholder.isHidden = false
+        } else {
+            emptyPlaceholder.isHidden = true
+            stackView.removeArrangedSubview(emptyPlaceholder)
+        }
     }
 
     private func setupSearch() {

--- a/Stepic/HomeScreenPresenter.swift
+++ b/Stepic/HomeScreenPresenter.swift
@@ -10,7 +10,6 @@ import Foundation
 
 protocol HomeScreenView: class {
     func presentBlocks(blocks: [CourseListBlock])
-
     func presentContinueLearningWidget(widget: ContinueLearningWidgetView)
     func hideCountinueLearningWidget()
 

--- a/Stepic/HomeScreenPresenter.swift
+++ b/Stepic/HomeScreenPresenter.swift
@@ -33,8 +33,8 @@ class HomeScreenPresenter: LastStepWidgetDataSource, CourseListCountDelegate {
         }
 
         let blocks = [
-            CourseListBlock(listType: .enrolled, ID: "enrolled", horizontalLimit: 6, title: NSLocalizedString("Enrolled", comment: ""), colorMode: .light, shouldShowCount: true, showControllerBlock: showController, lastStepWidgetDataSource: self, courseListCountDelegate: self),
-            CourseListBlock(listType: .popular, ID: "popular", horizontalLimit: 6, title: NSLocalizedString("Popular", comment: ""), colorMode: .dark, shouldShowCount: false, showControllerBlock: showController, courseListCountDelegate: self)
+            CourseListBlock(listType: .enrolled, ID: "enrolled", horizontalLimit: 6, title: NSLocalizedString("Enrolled", comment: ""), colorMode: .light, shouldShowCount: true, showControllerBlock: showController, lastStepWidgetDataSource: self, courseListCountDelegate: self, onlyLocal: false),
+            CourseListBlock(listType: .popular, ID: "popular", horizontalLimit: 6, title: NSLocalizedString("Popular", comment: ""), colorMode: .dark, shouldShowCount: false, showControllerBlock: showController, courseListCountDelegate: self, onlyLocal: false)
         ]
 
         view?.presentBlocks(blocks: blocks)
@@ -119,20 +119,22 @@ struct CourseListBlock {
     let horizontalController: CourseListHorizontalViewController
     let shouldShowCount: Bool
     let showVerticalBlock: () -> Void
+    let onlyLocal: Bool
 
-    init(listType: CourseListType, ID: String, horizontalLimit: Int, title: String, colorMode: CourseListColorMode, shouldShowCount: Bool, showControllerBlock: @escaping (UIViewController) -> Void, lastStepWidgetDataSource: LastStepWidgetDataSource? = nil, courseListCountDelegate: CourseListCountDelegate? = nil) {
+    init(listType: CourseListType, ID: String, horizontalLimit: Int, title: String, colorMode: CourseListColorMode, shouldShowCount: Bool, showControllerBlock: @escaping (UIViewController) -> Void, lastStepWidgetDataSource: LastStepWidgetDataSource? = nil, courseListCountDelegate: CourseListCountDelegate? = nil, onlyLocal: Bool = false) {
         self.title = title
         self.colorMode = colorMode
         self.ID = ID
         self.shouldShowCount = shouldShowCount
+        self.onlyLocal = onlyLocal
         self.horizontalController = ControllerHelper.instantiateViewController(identifier: "CourseListHorizontalViewController", storyboardName: "CourseLists") as! CourseListHorizontalViewController
-        self.horizontalController.presenter = CourseListPresenter(view: horizontalController, ID: ID, limit: horizontalLimit, listType: listType, colorMode: colorMode, coursesAPI: CoursesAPI(), progressesAPI: ProgressesAPI(), reviewSummariesAPI: CourseReviewSummariesAPI())
+        self.horizontalController.presenter = CourseListPresenter(view: horizontalController, ID: ID, limit: horizontalLimit, listType: listType, colorMode: colorMode, onlyLocal: onlyLocal, coursesAPI: CoursesAPI(), progressesAPI: ProgressesAPI(), reviewSummariesAPI: CourseReviewSummariesAPI())
         self.horizontalController.presenter?.lastStepDataSource = lastStepWidgetDataSource
         self.horizontalController.presenter?.couseListCountDelegate = courseListCountDelegate
         self.showVerticalBlock = {
             let verticalController = ControllerHelper.instantiateViewController(identifier: "CourseListVerticalViewController", storyboardName: "CourseLists") as! CourseListVerticalViewController
             verticalController.title = title
-            verticalController.presenter = CourseListPresenter(view: verticalController, ID: ID, limit: nil, listType: listType, colorMode: colorMode, coursesAPI: CoursesAPI(), progressesAPI: ProgressesAPI(), reviewSummariesAPI: CourseReviewSummariesAPI())
+            verticalController.presenter = CourseListPresenter(view: verticalController, ID: ID, limit: nil, listType: listType, colorMode: colorMode, onlyLocal: onlyLocal, coursesAPI: CoursesAPI(), progressesAPI: ProgressesAPI(), reviewSummariesAPI: CourseReviewSummariesAPI())
             showControllerBlock(verticalController)
         }
     }

--- a/Stepic/HomeScreenPresenter.swift
+++ b/Stepic/HomeScreenPresenter.swift
@@ -128,13 +128,13 @@ struct CourseListBlock {
         self.shouldShowCount = shouldShowCount
         self.onlyLocal = onlyLocal
         self.horizontalController = ControllerHelper.instantiateViewController(identifier: "CourseListHorizontalViewController", storyboardName: "CourseLists") as! CourseListHorizontalViewController
-        self.horizontalController.presenter = CourseListPresenter(view: horizontalController, ID: ID, limit: horizontalLimit, listType: listType, colorMode: colorMode, onlyLocal: onlyLocal, coursesAPI: CoursesAPI(), progressesAPI: ProgressesAPI(), reviewSummariesAPI: CourseReviewSummariesAPI())
+        self.horizontalController.presenter = CourseListPresenter(view: horizontalController, ID: ID, limit: horizontalLimit, listType: listType, colorMode: colorMode, onlyLocal: onlyLocal, coursesAPI: CoursesAPI(), progressesAPI: ProgressesAPI(), reviewSummariesAPI: CourseReviewSummariesAPI(), searchResultsAPI: SearchResultsAPI())
         self.horizontalController.presenter?.lastStepDataSource = lastStepWidgetDataSource
         self.horizontalController.presenter?.couseListCountDelegate = courseListCountDelegate
         self.showVerticalBlock = {
             let verticalController = ControllerHelper.instantiateViewController(identifier: "CourseListVerticalViewController", storyboardName: "CourseLists") as! CourseListVerticalViewController
             verticalController.title = title
-            verticalController.presenter = CourseListPresenter(view: verticalController, ID: ID, limit: nil, listType: listType, colorMode: colorMode, onlyLocal: onlyLocal, coursesAPI: CoursesAPI(), progressesAPI: ProgressesAPI(), reviewSummariesAPI: CourseReviewSummariesAPI())
+            verticalController.presenter = CourseListPresenter(view: verticalController, ID: ID, limit: nil, listType: listType, colorMode: colorMode, onlyLocal: onlyLocal, coursesAPI: CoursesAPI(), progressesAPI: ProgressesAPI(), reviewSummariesAPI: CourseReviewSummariesAPI(), searchResultsAPI: SearchResultsAPI())
             showControllerBlock(verticalController)
         }
     }

--- a/Stepic/HomeScreenPresenter.swift
+++ b/Stepic/HomeScreenPresenter.swift
@@ -128,13 +128,13 @@ struct CourseListBlock {
         self.shouldShowCount = shouldShowCount
         self.onlyLocal = onlyLocal
         self.horizontalController = ControllerHelper.instantiateViewController(identifier: "CourseListHorizontalViewController", storyboardName: "CourseLists") as! CourseListHorizontalViewController
-        self.horizontalController.presenter = CourseListPresenter(view: horizontalController, ID: ID, limit: horizontalLimit, listType: listType, colorMode: colorMode, onlyLocal: onlyLocal, coursesAPI: CoursesAPI(), progressesAPI: ProgressesAPI(), reviewSummariesAPI: CourseReviewSummariesAPI(), searchResultsAPI: SearchResultsAPI())
+        self.horizontalController.presenter = CourseListPresenter(view: horizontalController, ID: ID, limit: horizontalLimit, listType: listType, colorMode: colorMode, onlyLocal: onlyLocal, subscriptionManager: CourseSubscriptionManager(), coursesAPI: CoursesAPI(), progressesAPI: ProgressesAPI(), reviewSummariesAPI: CourseReviewSummariesAPI(), searchResultsAPI: SearchResultsAPI())
         self.horizontalController.presenter?.lastStepDataSource = lastStepWidgetDataSource
         self.horizontalController.presenter?.couseListCountDelegate = courseListCountDelegate
         self.showVerticalBlock = {
             let verticalController = ControllerHelper.instantiateViewController(identifier: "CourseListVerticalViewController", storyboardName: "CourseLists") as! CourseListVerticalViewController
             verticalController.title = title
-            verticalController.presenter = CourseListPresenter(view: verticalController, ID: ID, limit: nil, listType: listType, colorMode: colorMode, onlyLocal: onlyLocal, coursesAPI: CoursesAPI(), progressesAPI: ProgressesAPI(), reviewSummariesAPI: CourseReviewSummariesAPI(), searchResultsAPI: SearchResultsAPI())
+            verticalController.presenter = CourseListPresenter(view: verticalController, ID: ID, limit: nil, listType: listType, colorMode: colorMode, onlyLocal: onlyLocal, subscriptionManager: CourseSubscriptionManager(), coursesAPI: CoursesAPI(), progressesAPI: ProgressesAPI(), reviewSummariesAPI: CourseReviewSummariesAPI(), searchResultsAPI: SearchResultsAPI())
             showControllerBlock(verticalController)
         }
     }

--- a/Stepic/HorizontalCoursesView.xib
+++ b/Stepic/HorizontalCoursesView.xib
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13196" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13173"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13527"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -23,18 +23,18 @@
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Dcl-eV-vHu">
-                    <rect key="frame" x="356" y="17" width="40" height="33"/>
+                    <rect key="frame" x="356" y="8.5" width="40" height="36"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="40" id="0aa-dd-8yJ"/>
                     </constraints>
-                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                    <fontDescription key="fontDescription" type="system" pointSize="20"/>
                     <state key="normal" title="Все"/>
                     <connections>
                         <action selector="showAllPressed:" destination="-1" eventType="touchUpInside" id="Ed0-Y1-uhk"/>
                     </connections>
                 </button>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="QOq-O1-Td8" customClass="StepikLabel" customModule="Adaptive_1838" customModuleProvider="target">
-                    <rect key="frame" x="16" y="54" width="377" height="0.0"/>
+                    <rect key="frame" x="16" y="38" width="377" height="0.0"/>
                     <fontDescription key="fontDescription" type="system" pointSize="14"/>
                     <nil key="textColor"/>
                     <nil key="highlightedColor"/>
@@ -43,14 +43,14 @@
                     </userDefinedRuntimeAttributes>
                 </label>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="My courses" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qU3-ni-m1D" customClass="StepikLabel" customModule="Adaptive_1838" customModuleProvider="target">
-                    <rect key="frame" x="16" y="16" width="332" height="34"/>
-                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                    <rect key="frame" x="16" y="16" width="332" height="20"/>
+                    <fontDescription key="fontDescription" type="system" pointSize="20"/>
                     <nil key="textColor"/>
                     <nil key="highlightedColor"/>
                 </label>
                 <view contentMode="scaleToFill" horizontalHuggingPriority="249" verticalHuggingPriority="249" horizontalCompressionResistancePriority="751" verticalCompressionResistancePriority="751" translatesAutoresizingMaskIntoConstraints="NO" id="ySn-PK-nVa">
                     <rect key="frame" x="0.0" y="62" width="409" height="210"/>
-                    <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                    <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="210" id="tW6-4l-Iwl"/>
                     </constraints>
@@ -58,11 +58,12 @@
             </subviews>
             <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
             <constraints>
-                <constraint firstItem="QOq-O1-Td8" firstAttribute="top" secondItem="qU3-ni-m1D" secondAttribute="bottom" constant="4" id="5lx-e0-Igr"/>
+                <constraint firstItem="QOq-O1-Td8" firstAttribute="top" secondItem="qU3-ni-m1D" secondAttribute="bottom" constant="2" id="5lx-e0-Igr"/>
                 <constraint firstItem="QOq-O1-Td8" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="16" id="9Y1-OF-RuY"/>
                 <constraint firstItem="qU3-ni-m1D" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" constant="16" id="Dyp-Ua-fiC"/>
                 <constraint firstItem="Dcl-eV-vHu" firstAttribute="leading" secondItem="qU3-ni-m1D" secondAttribute="trailing" constant="8" id="I01-6D-4Cq"/>
                 <constraint firstItem="Dcl-eV-vHu" firstAttribute="leading" secondItem="qU3-ni-m1D" secondAttribute="trailing" constant="8" id="Je0-Jn-uKD"/>
+                <constraint firstItem="ySn-PK-nVa" firstAttribute="top" secondItem="qU3-ni-m1D" secondAttribute="bottom" constant="26" id="KWW-mk-xAK"/>
                 <constraint firstItem="Dcl-eV-vHu" firstAttribute="centerY" secondItem="qU3-ni-m1D" secondAttribute="centerY" id="Kis-wy-dt2"/>
                 <constraint firstAttribute="trailing" secondItem="Dcl-eV-vHu" secondAttribute="trailing" constant="13" id="LUs-Dy-KQZ"/>
                 <constraint firstAttribute="bottom" secondItem="ySn-PK-nVa" secondAttribute="bottom" constant="16" id="Mm7-8Y-FjM"/>
@@ -71,7 +72,6 @@
                 <constraint firstAttribute="trailing" secondItem="ySn-PK-nVa" secondAttribute="trailing" id="a3Y-qJ-8nY"/>
                 <constraint firstItem="qU3-ni-m1D" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="16" id="i92-aV-yCA"/>
                 <constraint firstItem="ySn-PK-nVa" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="qIQ-y1-i3A"/>
-                <constraint firstItem="ySn-PK-nVa" firstAttribute="top" secondItem="QOq-O1-Td8" secondAttribute="bottom" priority="999" constant="8" id="utt-t9-Vqd"/>
             </constraints>
             <nil key="simulatedTopBarMetrics"/>
             <nil key="simulatedBottomBarMetrics"/>

--- a/Stepic/Model.xcdatamodeld/.xccurrentversion
+++ b/Stepic/Model.xcdatamodeld/.xccurrentversion
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>_XCCurrentVersionName</key>
-	<string>Model_progress_activities_v20.xcdatamodel</string>
+	<string>Model_courselists_v21.xcdatamodel</string>
 </dict>
 </plist>

--- a/Stepic/Model.xcdatamodeld/Model_courselists_v21.xcdatamodel/contents
+++ b/Stepic/Model.xcdatamodeld/Model_courselists_v21.xcdatamodel/contents
@@ -75,7 +75,7 @@
         <relationship name="managedReviewSummary" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="CourseReviewSummary" inverseName="managedCourse" inverseEntity="CourseReviewSummary" syncable="YES"/>
         <relationship name="managedSections" optional="YES" toMany="YES" deletionRule="Cascade" ordered="YES" destinationEntity="Section" inverseName="managedCourse" inverseEntity="Section" syncable="YES"/>
     </entity>
-    <entity name="CourseList" syncable="YES">
+    <entity name="CourseList" representedClassName=".CourseList" syncable="YES">
         <attribute name="managedCoursesArray" optional="YES" attributeType="Transformable" syncable="YES"/>
         <attribute name="managedDescription" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="managedId" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
@@ -227,6 +227,7 @@
         <element name="CodeSample" positionX="-36" positionY="135" width="128" height="90"/>
         <element name="CodeTemplate" positionX="-45" positionY="135" width="128" height="105"/>
         <element name="Course" positionX="-63" positionY="-18" width="128" height="510"/>
+        <element name="CourseList" positionX="-36" positionY="135" width="128" height="135"/>
         <element name="CourseReviewSummary" positionX="-36" positionY="135" width="128" height="120"/>
         <element name="LastStep" positionX="-45" positionY="135" width="128" height="105"/>
         <element name="Lesson" positionX="-36" positionY="153" width="128" height="180"/>
@@ -240,6 +241,5 @@
         <element name="User" positionX="-63" positionY="99" width="128" height="195"/>
         <element name="Video" positionX="-45" positionY="135" width="128" height="165"/>
         <element name="VideoURL" positionX="-36" positionY="144" width="128" height="90"/>
-        <element name="CourseList" positionX="-36" positionY="135" width="128" height="135"/>
     </elements>
 </model>

--- a/Stepic/Model.xcdatamodeld/Model_courselists_v21.xcdatamodel/contents
+++ b/Stepic/Model.xcdatamodeld/Model_courselists_v21.xcdatamodel/contents
@@ -1,0 +1,245 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="13533" systemVersion="" minimumToolsVersion="Xcode 7.0" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+    <entity name="Assignment" representedClassName=".Assignment" syncable="YES">
+        <attribute name="managedId" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedStepId" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedUnitId" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <relationship name="managedUnit" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Unit" inverseName="managedAssignments" inverseEntity="Unit" syncable="YES"/>
+    </entity>
+    <entity name="Block" representedClassName=".Block" syncable="YES">
+        <attribute name="managedAnimation" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="managedName" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="managedText" optional="YES" attributeType="String" syncable="YES"/>
+        <relationship name="managedStep" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Step" inverseName="managedBlock" inverseEntity="Step" syncable="YES"/>
+        <relationship name="managedVideo" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="Video" inverseName="managedBlock" inverseEntity="Video" syncable="YES"/>
+    </entity>
+    <entity name="Certificate" representedClassName=".Certificate" syncable="YES">
+        <attribute name="managedCourseId" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedGrade" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedId" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedisPublic" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedIssueDate" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedType" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="managedUpdateDate" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedURL" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="managedUserId" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <relationship name="managedCourse" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Course" inverseName="managedCertificateEntity" inverseEntity="Course" syncable="YES"/>
+    </entity>
+    <entity name="CodeLimit" representedClassName=".CodeLimit" syncable="YES">
+        <attribute name="managedLanguage" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="managedMemory" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedTime" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="NO" syncable="YES"/>
+        <relationship name="managedOptions" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="StepOptions" inverseName="managedLimits" inverseEntity="StepOptions" syncable="YES"/>
+    </entity>
+    <entity name="CodeSample" representedClassName=".CodeSample" syncable="YES">
+        <attribute name="managedInput" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="managedOutput" optional="YES" attributeType="String" syncable="YES"/>
+        <relationship name="managedOptions" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="StepOptions" inverseName="managedSamples" inverseEntity="StepOptions" syncable="YES"/>
+    </entity>
+    <entity name="CodeTemplate" representedClassName=".CodeTemplate" syncable="YES">
+        <attribute name="managedIsUserGenerated" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedLanguage" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="managedTemplateString" optional="YES" attributeType="String" syncable="YES"/>
+        <relationship name="managedOptions" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="StepOptions" inverseName="managedTemplates" inverseEntity="StepOptions" syncable="YES"/>
+    </entity>
+    <entity name="Course" representedClassName=".Course" syncable="YES">
+        <attribute name="managedAudience" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="managedBeginDate" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedCertificate" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="managedCourseDescription" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="managedEndDate" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedEnrolled" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedFeatured" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedFormat" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="managedId" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedImageURL" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="managedInstructorsArray" optional="YES" attributeType="Transformable" syncable="YES"/>
+        <attribute name="managedIntroURL" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="managedLastStepId" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="managedLearnersCount" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedProgressId" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="managedPublic" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedRequirements" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="managedReviewSummaryId" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedScheduleType" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="managedSectionsArray" optional="YES" attributeType="Transformable" syncable="YES"/>
+        <attribute name="managedSlug" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="managedSummary" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="managedTitle" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="managedWorkload" optional="YES" attributeType="String" syncable="YES"/>
+        <relationship name="managedCertificateEntity" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Certificate" inverseName="managedCourse" inverseEntity="Certificate" syncable="YES"/>
+        <relationship name="managedInstructors" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="User" inverseName="managedInstructedCourses" inverseEntity="User" syncable="YES"/>
+        <relationship name="managedIntroVideo" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Video" syncable="YES"/>
+        <relationship name="managedLastStep" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="LastStep" inverseName="managedCourse" inverseEntity="LastStep" syncable="YES"/>
+        <relationship name="managedProgress" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Progress" inverseName="managedCourse" inverseEntity="Progress" syncable="YES"/>
+        <relationship name="managedReviewSummary" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="CourseReviewSummary" inverseName="managedCourse" inverseEntity="CourseReviewSummary" syncable="YES"/>
+        <relationship name="managedSections" optional="YES" toMany="YES" deletionRule="Cascade" ordered="YES" destinationEntity="Section" inverseName="managedCourse" inverseEntity="Section" syncable="YES"/>
+    </entity>
+    <entity name="CourseList" syncable="YES">
+        <attribute name="managedCoursesArray" optional="YES" attributeType="Transformable" syncable="YES"/>
+        <attribute name="managedDescription" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="managedId" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedLanguage" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="managedPosition" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedTitle" optional="YES" attributeType="String" syncable="YES"/>
+    </entity>
+    <entity name="CourseReviewSummary" representedClassName=".CourseReviewSummary" syncable="YES">
+        <attribute name="managedAverage" optional="YES" attributeType="Float" defaultValueString="0.0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedCount" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedDistribution" optional="YES" attributeType="Transformable" syncable="YES"/>
+        <attribute name="managedId" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <relationship name="managedCourse" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Course" inverseName="managedReviewSummary" inverseEntity="Course" syncable="YES"/>
+    </entity>
+    <entity name="LastStep" representedClassName=".LastStep" syncable="YES">
+        <attribute name="managedId" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="managedStepId" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedUnitId" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <relationship name="managedCourse" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Course" inverseName="managedLastStep" inverseEntity="Course" syncable="YES"/>
+    </entity>
+    <entity name="Lesson" representedClassName=".Lesson" syncable="YES">
+        <attribute name="managedCoverURL" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="managedFeatured" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedId" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedPublic" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedSlug" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="managedStepsArray" optional="YES" attributeType="Transformable" syncable="YES"/>
+        <attribute name="managedTitle" optional="YES" attributeType="String" syncable="YES"/>
+        <relationship name="managedSteps" optional="YES" toMany="YES" deletionRule="Cascade" ordered="YES" destinationEntity="Step" inverseName="managedLesson" inverseEntity="Step" syncable="YES"/>
+        <relationship name="managedUnit" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Unit" inverseName="managedLesson" inverseEntity="Unit" syncable="YES"/>
+    </entity>
+    <entity name="Notification" representedClassName=".Notification" syncable="YES">
+        <attribute name="managedAction" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="managedHtmlText" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="managedId" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedIsFavorite" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedIsMuted" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedLevel" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="managedPriority" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="managedStatus" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="managedTime" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedType" optional="YES" attributeType="String" syncable="YES"/>
+    </entity>
+    <entity name="Profile" representedClassName=".Profile" syncable="YES">
+        <attribute name="managedFirstName" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="managedId" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedLastName" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="managedSubscribedForMail" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+    </entity>
+    <entity name="Progress" representedClassName=".Progress" syncable="YES">
+        <attribute name="managedCost" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedId" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="managedIsPassed" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedLastViewed" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedNumberOfSteps" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedNumberOfStepsPassed" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedScore" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <relationship name="managedCourse" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Course" inverseName="managedProgress" inverseEntity="Course" syncable="YES"/>
+        <relationship name="managedSection" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Section" inverseName="managedProgress" inverseEntity="Section" syncable="YES"/>
+        <relationship name="managedStep" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Step" inverseName="managedProgress" inverseEntity="Step" syncable="YES"/>
+        <relationship name="managedUnit" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Unit" inverseName="managedProgress" inverseEntity="Unit" syncable="YES"/>
+    </entity>
+    <entity name="Section" representedClassName=".Section" syncable="YES">
+        <attribute name="managedActive" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedBeginDate" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedHardDeadline" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedId" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedIsCached" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedIsExam" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedPosition" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedProgressId" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="managedSoftDeadline" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedTestSectionAction" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="managedTitle" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="managedUnitsArray" optional="YES" attributeType="Transformable" syncable="YES"/>
+        <relationship name="managedCourse" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Course" inverseName="managedSections" inverseEntity="Course" syncable="YES"/>
+        <relationship name="managedProgress" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Progress" inverseName="managedSection" inverseEntity="Progress" syncable="YES"/>
+        <relationship name="managedUnits" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="Unit" inverseName="managedSection" inverseEntity="Unit" syncable="YES"/>
+    </entity>
+    <entity name="Step" representedClassName=".Step" syncable="YES">
+        <attribute name="managedDiscussionProxy" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="managedDiscussionsCount" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedHasSubmissionRestrictions" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedId" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedLessonId" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedMaxSubmissionsCount" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedPosition" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedProgressId" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="managedStatus" optional="YES" attributeType="String" syncable="YES"/>
+        <relationship name="managedBlock" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="Block" inverseName="managedStep" inverseEntity="Block" syncable="YES"/>
+        <relationship name="managedLesson" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Lesson" inverseName="managedSteps" inverseEntity="Lesson" syncable="YES"/>
+        <relationship name="managedOptions" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="StepOptions" inverseName="managedStep" inverseEntity="StepOptions" syncable="YES"/>
+        <relationship name="managedProgress" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Progress" inverseName="managedStep" inverseEntity="Progress" syncable="YES"/>
+    </entity>
+    <entity name="StepOptions" representedClassName=".StepOptions" syncable="YES">
+        <relationship name="managedLimits" optional="YES" toMany="YES" deletionRule="Cascade" ordered="YES" destinationEntity="CodeLimit" inverseName="managedOptions" inverseEntity="CodeLimit" syncable="YES"/>
+        <relationship name="managedSamples" optional="YES" toMany="YES" deletionRule="Cascade" ordered="YES" destinationEntity="CodeSample" inverseName="managedOptions" inverseEntity="CodeSample" syncable="YES"/>
+        <relationship name="managedStep" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Step" inverseName="managedOptions" inverseEntity="Step" syncable="YES"/>
+        <relationship name="managedTemplates" optional="YES" toMany="YES" deletionRule="Cascade" ordered="YES" destinationEntity="CodeTemplate" inverseName="managedOptions" inverseEntity="CodeTemplate" syncable="YES"/>
+    </entity>
+    <entity name="Unit" representedClassName=".Unit" syncable="YES">
+        <attribute name="managedActive" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedAssignmentsArray" optional="YES" attributeType="Transformable" syncable="YES"/>
+        <attribute name="managedBeginDate" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedHardDeadline" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedId" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedLessonId" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedPosition" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedProgressId" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="managedSectionId" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedSoftDeadline" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <relationship name="managedAssignments" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="Assignment" inverseName="managedUnit" inverseEntity="Assignment" syncable="YES"/>
+        <relationship name="managedLesson" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Lesson" inverseName="managedUnit" inverseEntity="Lesson" syncable="YES"/>
+        <relationship name="managedProgress" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="Progress" inverseName="managedUnit" inverseEntity="Progress" syncable="YES"/>
+        <relationship name="managedSection" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Section" inverseName="managedUnits" inverseEntity="Section" syncable="YES"/>
+    </entity>
+    <entity name="User" representedClassName=".User" syncable="YES">
+        <attribute name="managedAvatarURL" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="managedBio" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="managedDetails" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="managedFirstName" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="managedId" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedLastName" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="managedLevel" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedPrivate" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedProfile" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <relationship name="managedInstructedCourses" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Course" inverseName="managedInstructors" inverseEntity="Course" syncable="YES"/>
+    </entity>
+    <entity name="Video" representedClassName=".Video" syncable="YES">
+        <attribute name="managedCachedPath" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="managedCachedQuality" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedId" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedPlayTime" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedStatus" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="managedThumbnailURL" optional="YES" attributeType="String" syncable="YES"/>
+        <relationship name="managedBlock" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Block" inverseName="managedVideo" inverseEntity="Block" syncable="YES"/>
+        <relationship name="managedURLs" optional="YES" toMany="YES" deletionRule="Cascade" ordered="YES" destinationEntity="VideoURL" inverseName="managedVideo" inverseEntity="VideoURL" syncable="YES"/>
+    </entity>
+    <entity name="VideoURL" representedClassName=".VideoURL" syncable="YES">
+        <attribute name="managedQuality" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="managedURL" optional="YES" attributeType="String" syncable="YES"/>
+        <relationship name="managedVideo" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Video" inverseName="managedURLs" inverseEntity="Video" syncable="YES"/>
+    </entity>
+    <elements>
+        <element name="Assignment" positionX="-45" positionY="135" width="128" height="105"/>
+        <element name="Block" positionX="-36" positionY="144" width="128" height="120"/>
+        <element name="Certificate" positionX="-45" positionY="135" width="128" height="195"/>
+        <element name="CodeLimit" positionX="-36" positionY="144" width="128" height="105"/>
+        <element name="CodeSample" positionX="-36" positionY="135" width="128" height="90"/>
+        <element name="CodeTemplate" positionX="-45" positionY="135" width="128" height="105"/>
+        <element name="Course" positionX="-63" positionY="-18" width="128" height="510"/>
+        <element name="CourseReviewSummary" positionX="-36" positionY="135" width="128" height="120"/>
+        <element name="LastStep" positionX="-45" positionY="135" width="128" height="105"/>
+        <element name="Lesson" positionX="-36" positionY="153" width="128" height="180"/>
+        <element name="Notification" positionX="-18" positionY="153" width="128" height="195"/>
+        <element name="Profile" positionX="-36" positionY="135" width="128" height="105"/>
+        <element name="Progress" positionX="-45" positionY="135" width="128" height="210"/>
+        <element name="Section" positionX="-54" positionY="126" width="128" height="270"/>
+        <element name="Step" positionX="-45" positionY="135" width="128" height="240"/>
+        <element name="StepOptions" positionX="-27" positionY="153" width="128" height="105"/>
+        <element name="Unit" positionX="-45" positionY="144" width="128" height="255"/>
+        <element name="User" positionX="-63" positionY="99" width="128" height="195"/>
+        <element name="Video" positionX="-45" positionY="135" width="128" height="165"/>
+        <element name="VideoURL" positionX="-36" positionY="144" width="128" height="90"/>
+        <element name="CourseList" positionX="-36" positionY="135" width="128" height="135"/>
+    </elements>
+</model>

--- a/Stepic/NewSearchResultsViewController.swift
+++ b/Stepic/NewSearchResultsViewController.swift
@@ -15,6 +15,15 @@ class NewSearchResultsViewController: UIViewController, SearchResultsView {
 
     var state: CoursesSearchResultsState = CoursesSearchResultsState.waiting {
         didSet {
+            switch state {
+            case .courses:
+                removeController(forState: .suggestions)
+            case .suggestions:
+                removeController(forState: .courses)
+            case .waiting:
+                removeController(forState: .courses)
+                removeController(forState: .suggestions)
+            }
             updateUIForCurrentState()
         }
     }
@@ -22,16 +31,17 @@ class NewSearchResultsViewController: UIViewController, SearchResultsView {
     private func updateUIForCurrentState() {
         switch state {
         case .courses:
+            self.view.isHidden = false
             coursesVC?.view.isHidden = false
             suggestionsVC?.view.isHidden = true
             self.view.alpha = 1
-            break
         case .suggestions:
+            self.view.isHidden = false
             suggestionsVC?.view.isHidden = false
             coursesVC?.view.isHidden = true
             self.view.alpha = 1
-            break
         case .waiting:
+            self.view.isHidden = false
             suggestionsVC?.view.isHidden = true
             coursesVC?.view.isHidden = true
             self.view.backgroundColor = UIColor.mainDark
@@ -39,7 +49,6 @@ class NewSearchResultsViewController: UIViewController, SearchResultsView {
             UIView.animate(withDuration: 0.2, animations: {
                 self.view.alpha = 0.6
             })
-            break
         }
     }
 
@@ -50,15 +59,6 @@ class NewSearchResultsViewController: UIViewController, SearchResultsView {
 
     func set(state: CoursesSearchResultsState) {
         self.state = state
-        switch state {
-        case .courses:
-            removeController(forState: .suggestions)
-        case .suggestions:
-            removeController(forState: .courses)
-        case .waiting:
-            removeController(forState: .courses)
-            removeController(forState: .suggestions)
-        }
     }
 
     func set(controller: UIViewController, forState: CoursesSearchResultsState) {

--- a/Stepic/NewSearchResultsViewController.swift
+++ b/Stepic/NewSearchResultsViewController.swift
@@ -13,8 +13,6 @@ class NewSearchResultsViewController: UIViewController, SearchResultsView {
     var suggestionsVC: UIViewController?
     var coursesVC: UIViewController?
 
-    private let backgroundColor = UIColor(red: 0.0, green: 0.0, blue: 0.0, alpha: 1)
-
     var state: CoursesSearchResultsState = CoursesSearchResultsState.waiting {
         didSet {
             updateUIForCurrentState()
@@ -26,15 +24,21 @@ class NewSearchResultsViewController: UIViewController, SearchResultsView {
         case .courses:
             coursesVC?.view.isHidden = false
             suggestionsVC?.view.isHidden = true
+            self.view.alpha = 1
             break
         case .suggestions:
             suggestionsVC?.view.isHidden = false
             coursesVC?.view.isHidden = true
+            self.view.alpha = 1
             break
         case .waiting:
             suggestionsVC?.view.isHidden = true
             coursesVC?.view.isHidden = true
-            self.view.backgroundColor = backgroundColor
+            self.view.backgroundColor = UIColor.mainDark
+            self.view.alpha = 0
+            UIView.animate(withDuration: 0.2, animations: {
+                self.view.alpha = 0.6
+            })
             break
         }
     }

--- a/Stepic/NewSearchResultsViewController.swift
+++ b/Stepic/NewSearchResultsViewController.swift
@@ -50,6 +50,15 @@ class NewSearchResultsViewController: UIViewController, SearchResultsView {
 
     func set(state: CoursesSearchResultsState) {
         self.state = state
+        switch state {
+        case .courses:
+            removeController(forState: .suggestions)
+        case .suggestions:
+            removeController(forState: .courses)
+        case .waiting:
+            removeController(forState: .courses)
+            removeController(forState: .suggestions)
+        }
     }
 
     func set(controller: UIViewController, forState: CoursesSearchResultsState) {
@@ -65,5 +74,20 @@ class NewSearchResultsViewController: UIViewController, SearchResultsView {
         self.view.addSubview(controller.view)
         controller.view.isHidden = true
         controller.view.align(toView: self.view)
+    }
+
+    func removeController(forState: CoursesSearchResultsState) {
+        switch forState {
+        case .courses:
+            coursesVC?.removeFromParentViewController()
+            coursesVC?.view.removeFromSuperview()
+            coursesVC = nil
+        case .suggestions:
+            suggestionsVC?.removeFromParentViewController()
+            suggestionsVC?.view.removeFromSuperview()
+            suggestionsVC = nil
+        case .waiting:
+            break
+        }
     }
 }

--- a/Stepic/NewSearchResultsViewController.swift
+++ b/Stepic/NewSearchResultsViewController.swift
@@ -1,0 +1,65 @@
+//
+//  NewSearchResultsViewController.swift
+//  Stepic
+//
+//  Created by Ostrenkiy on 13.11.2017.
+//  Copyright © 2017 Alex Karpov. All rights reserved.
+//
+
+import Foundation
+
+class NewSearchResultsViewController: UIViewController, SearchResultsView {
+    var presenter: SearchResultsPresenter?
+    var suggestionsVC: UIViewController?
+    var coursesVC: UIViewController?
+
+    private let backgroundColor = UIColor(red: 0.0, green: 0.0, blue: 0.0, alpha: 1)
+
+    var state: CoursesSearchResultsState = CoursesSearchResultsState.waiting {
+        didSet {
+            updateUIForCurrentState()
+        }
+    }
+
+    private func updateUIForCurrentState() {
+        switch state {
+        case .courses:
+            coursesVC?.view.isHidden = false
+            suggestionsVC?.view.isHidden = true
+            break
+        case .suggestions:
+            suggestionsVC?.view.isHidden = false
+            coursesVC?.view.isHidden = true
+            break
+        case .waiting:
+            suggestionsVC?.view.isHidden = true
+            coursesVC?.view.isHidden = true
+            self.view.backgroundColor = backgroundColor
+            break
+        }
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        updateUIForCurrentState()
+    }
+
+    func set(state: CoursesSearchResultsState) {
+        self.state = state
+    }
+
+    func set(controller: UIViewController, forState: CoursesSearchResultsState) {
+        switch forState {
+        case .courses:
+            coursesVC = controller
+        case .suggestions:
+            suggestionsVC = controller
+        default:
+            return
+        }
+        self.addChildViewController(controller)
+        self.view.addSubview(controller.view)
+        controller.view.isHidden = true
+        controller.view.align(toView: self.view)
+    }
+}

--- a/Stepic/SearchResultsAPI.swift
+++ b/Stepic/SearchResultsAPI.swift
@@ -14,6 +14,7 @@ import PromiseKit
 class SearchResultsAPI: APIEndpoint {
     override var name: String { return "search-results" }
 
+    @available(*, deprecated, message: "Use searchCourse() -> Promise<([SearchResult], Meta)> instead")
     @discardableResult func search(query: String, type: String?, language: ContentLanguage? = nil, page: Int?, headers: [String: String] = AuthInfo.shared.initialHTTPHeaders, success: @escaping ([SearchResult], Meta) -> Void, error errorHandler: @escaping (NSError) -> Void) -> Request? {
         var params: Parameters = [:]
 
@@ -59,7 +60,7 @@ class SearchResultsAPI: APIEndpoint {
         })
     }
 
-    @discardableResult func searchCourse(query: String, language: ContentLanguage?, page: Int, headers: [String: String] = AuthInfo.shared.initialHTTPHeaders) -> Promise<([SearchResult], Meta)> {
+    func searchCourse(query: String, language: ContentLanguage?, page: Int, headers: [String: String] = AuthInfo.shared.initialHTTPHeaders) -> Promise<([SearchResult], Meta)> {
         return Promise<([SearchResult], Meta)> {
             fulfill, reject in
             search(query: query, type: "course", language: language, page: page, headers: headers, success: {

--- a/Stepic/SearchResultsAPI.swift
+++ b/Stepic/SearchResultsAPI.swift
@@ -14,7 +14,7 @@ import PromiseKit
 class SearchResultsAPI: APIEndpoint {
     override var name: String { return "search-results" }
 
-    @discardableResult func search(query: String, type: String?, page: Int?, headers: [String: String] = AuthInfo.shared.initialHTTPHeaders, success: @escaping ([SearchResult], Meta) -> Void, error errorHandler: @escaping (NSError) -> Void) -> Request? {
+    @discardableResult func search(query: String, type: String?, language: ContentLanguage? = nil, page: Int?, headers: [String: String] = AuthInfo.shared.initialHTTPHeaders, success: @escaping ([SearchResult], Meta) -> Void, error errorHandler: @escaping (NSError) -> Void) -> Request? {
         var params: Parameters = [:]
 
         params["access_token"] = AuthInfo.shared.token?.accessToken as NSObject?
@@ -25,6 +25,9 @@ class SearchResultsAPI: APIEndpoint {
         }
         if let t = type {
             params["type"] = t
+        }
+        if let l = language {
+            params["language"] = l.languageString
         }
 
         return Alamofire.request("\(StepicApplicationsInfo.apiURL)/search-results", method: .get, parameters: params, encoding: URLEncoding.default, headers: headers).responseSwiftyJSON({
@@ -56,10 +59,10 @@ class SearchResultsAPI: APIEndpoint {
         })
     }
 
-    @discardableResult func searchCourse(query: String, page: Int, headers: [String: String] = AuthInfo.shared.initialHTTPHeaders) -> Promise<([SearchResult], Meta)> {
+    @discardableResult func searchCourse(query: String, language: ContentLanguage?, page: Int, headers: [String: String] = AuthInfo.shared.initialHTTPHeaders) -> Promise<([SearchResult], Meta)> {
         return Promise<([SearchResult], Meta)> {
             fulfill, reject in
-            search(query: query, type: "course", page: page, headers: headers, success: {
+            search(query: query, type: "course", language: language, page: page, headers: headers, success: {
                 searchResults, meta in
                 fulfill((searchResults, meta))
             }, error: {

--- a/Stepic/SearchResultsAPI.swift
+++ b/Stepic/SearchResultsAPI.swift
@@ -9,6 +9,7 @@
 import Foundation
 import Alamofire
 import SwiftyJSON
+import PromiseKit
 
 class SearchResultsAPI: APIEndpoint {
     override var name: String { return "search-results" }
@@ -53,5 +54,18 @@ class SearchResultsAPI: APIEndpoint {
 
             success(results, meta)
         })
+    }
+
+    @discardableResult func searchCourse(query: String, page: Int, headers: [String: String] = AuthInfo.shared.initialHTTPHeaders) -> Promise<([SearchResult], Meta)> {
+        return Promise<([SearchResult], Meta)> {
+            fulfill, reject in
+            search(query: query, type: "course", page: page, headers: headers, success: {
+                searchResults, meta in
+                fulfill((searchResults, meta))
+            }, error: {
+                error in
+                reject(RetrieveError(error: error))
+            })
+        }
     }
 }

--- a/Stepic/SearchResultsPresenter.swift
+++ b/Stepic/SearchResultsPresenter.swift
@@ -53,7 +53,7 @@ class SearchResultsPresenter {
         if resultsVC == nil {
             resultsVC = ControllerHelper.instantiateViewController(identifier: "CourseListVerticalViewController", storyboardName: "CourseLists") as? CourseListVerticalViewController
             if let resultsVC = resultsVC {
-                resultsVC.presenter = CourseListPresenter(view: resultsVC, ID: "SearchCourses", limit: nil, listType: .search(query: query), colorMode: .light, onlyLocal: false, coursesAPI: CoursesAPI(), progressesAPI: ProgressesAPI(), reviewSummariesAPI: CourseReviewSummariesAPI(), searchResultsAPI: SearchResultsAPI())
+                resultsVC.presenter = CourseListPresenter(view: resultsVC, ID: "SearchCourses", limit: nil, listType: .search(query: query), colorMode: .light, onlyLocal: false, subscriptionManager: CourseSubscriptionManager(), coursesAPI: CoursesAPI(), progressesAPI: ProgressesAPI(), reviewSummariesAPI: CourseReviewSummariesAPI(), searchResultsAPI: SearchResultsAPI())
                 self.view?.set(controller: resultsVC, forState: .courses)
             }
         } else {

--- a/Stepic/SearchResultsPresenter.swift
+++ b/Stepic/SearchResultsPresenter.swift
@@ -55,8 +55,8 @@ class SearchResultsPresenter {
             }
         } else {
             resultsVC?.presenter?.listType = .search(query: query)
+            resultsVC?.presenter?.refresh()
         }
-        resultsVC?.presenter?.refresh()
         view?.set(state: .courses)
         suggestionsVC = nil
     }

--- a/Stepic/SearchResultsPresenter.swift
+++ b/Stepic/SearchResultsPresenter.swift
@@ -1,0 +1,69 @@
+//
+//  SearchResultsPresenter.swift
+//  Stepic
+//
+//  Created by Ostrenkiy on 13.11.2017.
+//  Copyright © 2017 Alex Karpov. All rights reserved.
+//
+
+import Foundation
+
+protocol SearchResultsView: class {
+    func set(state: CoursesSearchResultsState)
+    func set(controller: UIViewController, forState: CoursesSearchResultsState)
+}
+
+class SearchResultsPresenter {
+    weak var view: SearchResultsView?
+
+    var state: CoursesSearchResultsState = .waiting
+
+    var updateQueryBlock: ((String) -> Void)?
+
+    //TODO: Somehow refactor this
+    private var suggestionsVC: SearchQueriesViewController?
+    private var resultsVC: CourseListVerticalViewController?
+
+    var query: String = ""
+
+    init(view: SearchResultsView) {
+        self.view = view
+    }
+
+    func queryChanged(to query: String) {
+        if suggestionsVC == nil {
+            suggestionsVC = SearchQueriesViewController()
+            suggestionsVC?.delegate = self
+            self.view?.set(controller: suggestionsVC!, forState: .suggestions)
+        }
+        suggestionsVC?.query = query
+        self.query = query
+        view?.set(state: .suggestions)
+    }
+
+    func search(query: String) {
+        if resultsVC == nil {
+            resultsVC = ControllerHelper.instantiateViewController(identifier: "CourseListVerticalViewController", storyboardName: "CourseLists") as? CourseListVerticalViewController
+            if let resultsVC = resultsVC {
+                resultsVC.presenter = CourseListPresenter(view: resultsVC, ID: "SearchCourses", limit: nil, listType: .search(query: query), colorMode: .light, onlyLocal: false, coursesAPI: CoursesAPI(), progressesAPI: ProgressesAPI(), reviewSummariesAPI: CourseReviewSummariesAPI(), searchResultsAPI: SearchResultsAPI())
+                self.view?.set(controller: resultsVC, forState: .courses)
+            }
+        } else {
+            resultsVC?.presenter?.listType = .search(query: query)
+        }
+        resultsVC?.presenter?.refresh()
+        view?.set(state: .courses)
+    }
+}
+
+extension SearchResultsPresenter: SearchQueriesViewControllerDelegate {
+    func didSelectSuggestion(suggestion: String, position: Int) {
+        AnalyticsReporter.reportEvent(AnalyticsEvents.Search.selected, parameters: ["query": self.query.lowercased(), "position": position, "suggestion": suggestion])
+        search(query: suggestion)
+        updateQueryBlock?(suggestion)
+    }
+}
+
+enum CoursesSearchResultsState {
+    case waiting, suggestions, courses
+}

--- a/Stepic/SearchResultsPresenter.swift
+++ b/Stepic/SearchResultsPresenter.swift
@@ -29,6 +29,12 @@ class SearchResultsPresenter {
     }
 
     func queryChanged(to query: String) {
+        guard query != "" else {
+            view?.set(state: .waiting)
+            resultsVC = nil
+            suggestionsVC = nil
+            return
+        }
         if suggestionsVC == nil {
             suggestionsVC = SearchQueriesViewController()
             suggestionsVC?.delegate = self

--- a/Stepic/SearchResultsPresenter.swift
+++ b/Stepic/SearchResultsPresenter.swift
@@ -16,8 +16,6 @@ protocol SearchResultsView: class {
 class SearchResultsPresenter {
     weak var view: SearchResultsView?
 
-    var state: CoursesSearchResultsState = .waiting
-
     var updateQueryBlock: ((String) -> Void)?
 
     //TODO: Somehow refactor this
@@ -39,6 +37,7 @@ class SearchResultsPresenter {
         suggestionsVC?.query = query
         self.query = query
         view?.set(state: .suggestions)
+        resultsVC = nil
     }
 
     func search(query: String) {
@@ -53,6 +52,7 @@ class SearchResultsPresenter {
         }
         resultsVC?.presenter?.refresh()
         view?.set(state: .courses)
+        suggestionsVC = nil
     }
 }
 

--- a/Stepic/StyledTabBarViewController.swift
+++ b/Stepic/StyledTabBarViewController.swift
@@ -105,6 +105,7 @@ enum TabController: String {
     case profile = "Profile"
     case home = "Home"
     case notifications = "Notifications"
+    case explore = "Explore"
 
     var itemInfo: TabBarItemInfo {
         switch self {
@@ -120,6 +121,8 @@ enum TabController: String {
             return TabBarItemInfo(title: NSLocalizedString("Home", comment: ""), controller: ControllerHelper.instantiateViewController(identifier: "HomeNavigation", storyboardName: "Main"), clickEventName: AnalyticsEvents.Tabs.profileClicked, image: #imageLiteral(resourceName: "tab-home"))
         case .notifications:
             return TabBarItemInfo(title: NSLocalizedString("Notifications", comment: ""), controller: ControllerHelper.instantiateViewController(identifier: "NotificationsNavigation", storyboardName: "Main"), clickEventName: AnalyticsEvents.Tabs.notificationsClicked, image: #imageLiteral(resourceName: "tab-notifications"))
+        case .explore:
+            return TabBarItemInfo(title: NSLocalizedString("Explore", comment: ""), controller: ControllerHelper.instantiateViewController(identifier: "ExploreNavigation", storyboardName: "Explore"), clickEventName: AnalyticsEvents.Tabs.notificationsClicked, image: #imageLiteral(resourceName: "tab-notifications"))
         }
     }
 }

--- a/Stepic/StyledTabBarViewController.swift
+++ b/Stepic/StyledTabBarViewController.swift
@@ -105,7 +105,7 @@ enum TabController: String {
     case profile = "Profile"
     case home = "Home"
     case notifications = "Notifications"
-    case explore = "Explore"
+    case explore = "Catalog"
 
     var itemInfo: TabBarItemInfo {
         switch self {
@@ -122,7 +122,7 @@ enum TabController: String {
         case .notifications:
             return TabBarItemInfo(title: NSLocalizedString("Notifications", comment: ""), controller: ControllerHelper.instantiateViewController(identifier: "NotificationsNavigation", storyboardName: "Main"), clickEventName: AnalyticsEvents.Tabs.notificationsClicked, image: #imageLiteral(resourceName: "tab-notifications"))
         case .explore:
-            return TabBarItemInfo(title: NSLocalizedString("Explore", comment: ""), controller: ControllerHelper.instantiateViewController(identifier: "ExploreNavigation", storyboardName: "Explore"), clickEventName: AnalyticsEvents.Tabs.notificationsClicked, image: #imageLiteral(resourceName: "tab-explore"))
+            return TabBarItemInfo(title: NSLocalizedString("Catalog", comment: ""), controller: ControllerHelper.instantiateViewController(identifier: "ExploreNavigation", storyboardName: "Explore"), clickEventName: AnalyticsEvents.Tabs.catalogClicked, image: #imageLiteral(resourceName: "tab-explore"))
         }
     }
 }

--- a/Stepic/StyledTabBarViewController.swift
+++ b/Stepic/StyledTabBarViewController.swift
@@ -122,7 +122,7 @@ enum TabController: String {
         case .notifications:
             return TabBarItemInfo(title: NSLocalizedString("Notifications", comment: ""), controller: ControllerHelper.instantiateViewController(identifier: "NotificationsNavigation", storyboardName: "Main"), clickEventName: AnalyticsEvents.Tabs.notificationsClicked, image: #imageLiteral(resourceName: "tab-notifications"))
         case .explore:
-            return TabBarItemInfo(title: NSLocalizedString("Explore", comment: ""), controller: ControllerHelper.instantiateViewController(identifier: "ExploreNavigation", storyboardName: "Explore"), clickEventName: AnalyticsEvents.Tabs.notificationsClicked, image: #imageLiteral(resourceName: "tab-notifications"))
+            return TabBarItemInfo(title: NSLocalizedString("Explore", comment: ""), controller: ControllerHelper.instantiateViewController(identifier: "ExploreNavigation", storyboardName: "Explore"), clickEventName: AnalyticsEvents.Tabs.notificationsClicked, image: #imageLiteral(resourceName: "tab-explore"))
         }
     }
 }

--- a/Stepic/en.lproj/Localizable.strings
+++ b/Stepic/en.lproj/Localizable.strings
@@ -348,6 +348,7 @@ courses234 = "courses";
 courses567890 = "courses";
 SearchPlaceholderEmpty = "<b>Sorry</b>, we didn't find any courses matching your request";
 SearchPlaceholderError = "Error while searching courses. <b>Press</b> to try again";
+ChooseSearchLanguage = "Choose search language";
 
 /* Arts */
 ArtCustomizeLearningProcess = "art_customize_learning_process_en";

--- a/Stepic/en.lproj/Localizable.strings
+++ b/Stepic/en.lproj/Localizable.strings
@@ -349,6 +349,7 @@ courses567890 = "courses";
 SearchPlaceholderEmpty = "<b>Sorry</b>, we didn't find any courses matching your request";
 SearchPlaceholderError = "Error while searching courses. <b>Press</b> to try again";
 ChooseSearchLanguage = "Choose search language";
+Catalog = "Catalog";
 
 /* Arts */
 ArtCustomizeLearningProcess = "art_customize_learning_process_en";

--- a/Stepic/en.lproj/Localizable.strings
+++ b/Stepic/en.lproj/Localizable.strings
@@ -346,6 +346,8 @@ HomePlaceholderErrorPopular = "Looks like we failed loading popular courses. <b>
 courses1 = "course";
 courses234 = "courses";
 courses567890 = "courses";
+SearchPlaceholderEmpty = "<b>Sorry</b>, we didn't find any courses matching your request";
+SearchPlaceholderError = "Error while searching courses. <b>Press</b> to try again";
 
 /* Arts */
 ArtCustomizeLearningProcess = "art_customize_learning_process_en";

--- a/Stepic/ru.lproj/Localizable.strings
+++ b/Stepic/ru.lproj/Localizable.strings
@@ -350,6 +350,7 @@ courses567890 = "курсов";
 SearchPlaceholderEmpty = "<b>Упс</b>, мы не нашли ни одного курса по запросу";
 SearchPlaceholderError = "Ошибка при поиске курсов. <b>Нажмите</b>, чтобы попробовать еще раз";
 ChooseSearchLanguage = "Выберите язык поиска";
+Catalog = "Каталог";
 
 /* Arts */
 ArtCustomizeLearningProcess = "art_customize_learning_process_ru";

--- a/Stepic/ru.lproj/Localizable.strings
+++ b/Stepic/ru.lproj/Localizable.strings
@@ -349,6 +349,7 @@ courses234 = "курса";
 courses567890 = "курсов";
 SearchPlaceholderEmpty = "<b>Упс</b>, мы не нашли ни одного курса по запросу";
 SearchPlaceholderError = "Ошибка при поиске курсов. <b>Нажмите</b>, чтобы попробовать еще раз";
+ChooseSearchLanguage = "Выберите язык поиска";
 
 /* Arts */
 ArtCustomizeLearningProcess = "art_customize_learning_process_ru";

--- a/Stepic/ru.lproj/Localizable.strings
+++ b/Stepic/ru.lproj/Localizable.strings
@@ -347,6 +347,8 @@ HomePlaceholderErrorPopular = "Кажется, мы не смогли загру
 courses1 = "курс";
 courses234 = "курса";
 courses567890 = "курсов";
+SearchPlaceholderEmpty = "<b>Упс</b>, мы не нашли ни одного курса по запросу";
+SearchPlaceholderError = "Ошибка при поиске курсов. <b>Нажмите</b>, чтобы попробовать еще раз";
 
 /* Arts */
 ArtCustomizeLearningProcess = "art_customize_learning_process_ru";


### PR DESCRIPTION
**Задача**: [#APPS-1571](https://vyahhi.myjetbrains.com/youtrack/issue/APPS-1571)

**Коротко для Release Notes, в формате «Сделали/Добавили/Исправили N»**: 

Добавили экран с подборками

**Описание**:

- Добавлен `ExplorePresenter`, подгружающий и отображающий все подборки в `ExploreViewController` и управляющий фильтрами
- Переделан поиск. Если раньше поиск находился в `FindCoursesViewController` и было мало понятного, теперь он находится в `SearchResultsPresenter`-е. Результаты поиска отображаются как `CourseList` с типом `.search(query: String)`.
- Добавлена поддержка языков. Теперь в `request()` пихаем еще `ContentLanguage`. 
- Теперь у `CourseListPresenter` есть флаг `onlyLocal` означающий, что список рефрешится только с курсами, доступными локально. Это сделано для того, чтобы при перезагрузке Explore экрана не кидались запросы на обновление списков по id-шкам, но при этом отображался закешированный контент.

Знаю, что есть проблемы с роутингом, который находится в `Presenter`-ах. Когда-нибудь потом в отдельный слой вынесем.

**TODO:**

- [x] Анимация появления поиска
- [x] Локализации
- [x] Убирать клавиатуру при скролле в поиске
- [x] Поиск по нажатию на return