### PR TITLE
Fix section retrieve for last step

### DIFF
--- a/Stepic/LastStepRouter.swift
+++ b/Stepic/LastStepRouter.swift
@@ -114,7 +114,19 @@ class LastStepRouter {
                 }
             }, error: { err in
                 print("last step router: error while loading section, error = \(err)")
-                openSyllabus()
+
+                // Fallback: use cached section 
+                guard let section = sectionForUpdate else {
+                    openSyllabus()
+                    return
+                }
+
+                print("last step router: using cached section")
+                if section.isReachable {
+                    navigateToStep()
+                } else {
+                    openSyllabus()
+                }
             })
         }
 


### PR DESCRIPTION
**Коротко для Release Notes, в формате «Сделали/Добавили/Исправили N»**: 
Исправили подгрузку секции, когда осуществляется переход к последнему степу

**Описание**:
При переходе к последнему степу у нас может не быть данных о юните/секции (например, первый запуск) – теперь подгружаем их, если нужно.