### PR TITLE
Fix auth layout issues

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -16,7 +16,6 @@ end
 def all_pods
 
     shared_pods
-    pod 'TextFieldEffects'
     pod "DownloadButton"
     pod 'SVProgressHUD'
     pod 'FLKAutoLayout', '1.0.1'

--- a/Stepic/Base.lproj/Auth.storyboard
+++ b/Stepic/Base.lproj/Auth.storyboard
@@ -6,7 +6,6 @@
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13173"/>
-        <capability name="Alignment constraints with different attributes" minToolsVersion="5.1"/>
         <capability name="Aspect ratio constraints" minToolsVersion="5.1"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -20,11 +19,11 @@
                         <viewControllerLayoutGuide type="bottom" id="qOI-QY-ky4"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="599"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="603"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" scrollEnabled="NO" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="xtI-yF-JBK">
-                                <rect key="frame" x="0.0" y="190" width="375" height="125"/>
+                                <rect key="frame" x="0.0" y="192" width="375" height="125"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="125" id="Wq4-Ni-nrn"/>
@@ -59,7 +58,7 @@
                                 </collectionReusableView>
                             </collectionView>
                             <button opaque="NO" contentMode="scaleToFill" verticalCompressionResistancePriority="751" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="UyI-UL-4R6">
-                                <rect key="frame" x="168.5" y="345" width="38" height="32"/>
+                                <rect key="frame" x="168.5" y="347" width="38" height="32"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                 <state key="normal" title="More">
                                     <color key="titleColor" red="0.40000000000000002" green="0.80000000000000004" blue="0.40000000000000002" alpha="1" colorSpace="calibratedRGB"/>
@@ -69,7 +68,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="right" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="o00-ed-SpF">
-                                <rect key="frame" x="24" y="551" width="134" height="32"/>
+                                <rect key="frame" x="24" y="555" width="134" height="32"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                 <state key="normal" title="Sign In with e-mail">
                                     <color key="titleColor" red="0.32549019610000002" green="0.32549019610000002" blue="0.40000000000000002" alpha="1" colorSpace="calibratedRGB"/>
@@ -78,7 +77,7 @@
                                     <action selector="onSignInWithEmailClick:" destination="BYZ-38-t0r" eventType="touchUpInside" id="an0-r8-Exn"/>
                                 </connections>
                             </button>
-                            <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="stepik_auth_logo" translatesAutoresizingMaskIntoConstraints="NO" id="gb0-7l-u82">
+                            <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" image="stepik_auth_logo" translatesAutoresizingMaskIntoConstraints="NO" id="gb0-7l-u82">
                                 <rect key="frame" x="163.5" y="50" width="48" height="48"/>
                                 <constraints>
                                     <constraint firstAttribute="height" relation="lessThanOrEqual" constant="48" id="LNn-gH-wZx"/>
@@ -89,7 +88,7 @@
                                 </constraints>
                             </imageView>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="C3e-7n-JkS">
-                                <rect key="frame" x="293" y="551" width="58" height="32"/>
+                                <rect key="frame" x="293" y="555" width="58" height="32"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                 <state key="normal" title="Sign Up">
                                     <color key="titleColor" red="0.32549019610000002" green="0.32549019610000002" blue="0.40000000000000002" alpha="1" colorSpace="calibratedRGB"/>
@@ -119,10 +118,10 @@
                         </constraints>
                         <variation key="default">
                             <mask key="constraints">
-                                <exclude reference="xcD-X5-Vei"/>
                                 <exclude reference="1cB-te-TSm"/>
                                 <exclude reference="l5A-cT-1TG"/>
                                 <exclude reference="9eB-BB-J1N"/>
+                                <exclude reference="xcD-X5-Vei"/>
                             </mask>
                         </variation>
                         <variation key="heightClass=compact">
@@ -132,8 +131,8 @@
                         </variation>
                         <variation key="widthClass=compact">
                             <mask key="constraints">
-                                <include reference="xcD-X5-Vei"/>
                                 <include reference="1cB-te-TSm"/>
+                                <include reference="xcD-X5-Vei"/>
                             </mask>
                         </variation>
                         <variation key="widthClass=regular">
@@ -147,7 +146,7 @@
                     <navigationItem key="navigationItem" largeTitleDisplayMode="never" id="Q9d-gC-NfY">
                         <barButtonItem key="leftBarButtonItem" style="plain" id="sFt-p5-h5c">
                             <button key="customView" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="bottom" lineBreakMode="middleTruncation" id="Tb4-mS-Y6z">
-                                <rect key="frame" x="16" y="13" width="17" height="22"/>
+                                <rect key="frame" x="16" y="11" width="17" height="22"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="20" id="0bm-Lk-Njn"/>
@@ -182,11 +181,11 @@
                         <viewControllerLayoutGuide type="bottom" id="Lsp-SO-0Mq"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="ecb-mE-jfH">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="599"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="603"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <button opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" contentHorizontalAlignment="left" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="vQR-hv-GBW">
-                                <rect key="frame" x="24" y="551" width="130" height="32"/>
+                                <rect key="frame" x="24" y="555" width="130" height="32"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                 <state key="normal" title="Sign In with social">
                                     <color key="titleColor" red="0.32549019610000002" green="0.32549019610000002" blue="0.40000000000000002" alpha="1" colorSpace="calibratedRGB"/>
@@ -195,7 +194,7 @@
                                     <action selector="onSignInWithSocialClick:" destination="lqO-CD-A0H" eventType="touchUpInside" id="w96-HN-Xxv"/>
                                 </connections>
                             </button>
-                            <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="stepik_auth_logo" translatesAutoresizingMaskIntoConstraints="NO" id="Seg-dF-9x8">
+                            <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" image="stepik_auth_logo" translatesAutoresizingMaskIntoConstraints="NO" id="Seg-dF-9x8">
                                 <rect key="frame" x="163.5" y="50" width="48" height="48"/>
                                 <constraints>
                                     <constraint firstAttribute="height" relation="lessThanOrEqual" constant="48" id="RDE-UM-mDV"/>
@@ -206,7 +205,7 @@
                                 </constraints>
                             </imageView>
                             <button opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" contentHorizontalAlignment="right" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Vrc-hu-CrF">
-                                <rect key="frame" x="293" y="551" width="58" height="32"/>
+                                <rect key="frame" x="293" y="555" width="58" height="32"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                 <state key="normal" title="Sign Up">
                                     <color key="titleColor" red="0.32549019610000002" green="0.32549019610000002" blue="0.40000000000000002" alpha="1" colorSpace="calibratedRGB"/>
@@ -222,7 +221,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <view clipsSubviews="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="hcs-d4-W7U">
-                                <rect key="frame" x="24" y="231" width="327" height="105"/>
+                                <rect key="frame" x="24" y="231" width="327" height="109"/>
                                 <color key="backgroundColor" red="0.78431372549019607" green="0.15686274509803921" blue="0.31372549019607843" alpha="0.0" colorSpace="calibratedRGB"/>
                                 <userDefinedRuntimeAttributes>
                                     <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
@@ -231,13 +230,13 @@
                                 </userDefinedRuntimeAttributes>
                             </view>
                             <stackView opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="YSS-sQ-UuC">
-                                <rect key="frame" x="24" y="231" width="327" height="105"/>
+                                <rect key="frame" x="24" y="231" width="327" height="109"/>
                                 <subviews>
                                     <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Email" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="NCY-px-UvI" customClass="AuthTextField" customModule="Stepic" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="0.0" width="327" height="52"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="327" height="54"/>
                                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                         <constraints>
-                                            <constraint firstAttribute="height" constant="52" id="tWg-4k-CUe">
+                                            <constraint firstAttribute="height" constant="54" id="tWg-4k-CUe">
                                                 <variation key="heightClass=compact" constant="45"/>
                                             </constraint>
                                         </constraints>
@@ -246,17 +245,17 @@
                                         <textInputTraits key="textInputTraits" autocorrectionType="no" keyboardType="emailAddress" returnKeyType="next"/>
                                     </textField>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="syM-4D-gnF">
-                                        <rect key="frame" x="0.0" y="52" width="327" height="1"/>
+                                        <rect key="frame" x="0.0" y="54" width="327" height="1"/>
                                         <color key="backgroundColor" red="0.59215686274509804" green="0.59215686274509804" blue="0.59215686274509804" alpha="1" colorSpace="calibratedRGB"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="1" id="baT-yf-3Zs"/>
                                         </constraints>
                                     </view>
                                     <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Password" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="umg-9h-bV9" customClass="AuthTextField" customModule="Stepic" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="53" width="327" height="52"/>
+                                        <rect key="frame" x="0.0" y="55" width="327" height="54"/>
                                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                         <constraints>
-                                            <constraint firstAttribute="height" constant="52" id="JBt-Z0-ScN">
+                                            <constraint firstAttribute="height" constant="54" id="JBt-Z0-ScN">
                                                 <variation key="heightClass=compact" constant="45"/>
                                             </constraint>
                                         </constraints>
@@ -270,7 +269,7 @@
                                 </constraints>
                             </stackView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" text="Whoops! The e-mail address and/or password you specified are not correct." textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" minimumFontSize="12" translatesAutoresizingMaskIntoConstraints="NO" id="55E-Yo-HFU">
-                                <rect key="frame" x="24" y="352" width="327" height="0.0"/>
+                                <rect key="frame" x="24" y="356" width="327" height="0.0"/>
                                 <constraints>
                                     <constraint firstAttribute="height" id="cj6-hM-VuZ"/>
                                 </constraints>
@@ -279,7 +278,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <button opaque="NO" contentMode="scaleToFill" enabled="NO" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Fnt-qB-XZx" customClass="AuthButton" customModule="Stepic" customModuleProvider="target">
-                                <rect key="frame" x="24" y="352" width="327" height="44"/>
+                                <rect key="frame" x="24" y="356" width="327" height="44"/>
                                 <color key="backgroundColor" red="0.40000000000000002" green="0.80000000000000004" blue="0.40000000000000002" alpha="0.10000000000000001" colorSpace="calibratedRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="44" id="tX0-AL-jlM"/>
@@ -301,7 +300,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" verticalCompressionResistancePriority="751" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="cic-9n-m9H">
-                                <rect key="frame" x="24" y="404" width="327" height="40"/>
+                                <rect key="frame" x="24" y="408" width="327" height="40"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="40" id="Z2G-ri-lD3"/>
@@ -372,7 +371,7 @@
                     <navigationItem key="navigationItem" largeTitleDisplayMode="never" id="lpD-Ep-HVB">
                         <barButtonItem key="leftBarButtonItem" style="plain" id="F0p-Ac-pDB">
                             <button key="customView" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="bottom" lineBreakMode="middleTruncation" id="3zQ-WS-dr9">
-                                <rect key="frame" x="16" y="13" width="17" height="22"/>
+                                <rect key="frame" x="16" y="11" width="17" height="22"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="20" id="oAe-YO-ram"/>
@@ -415,10 +414,10 @@
                         <viewControllerLayoutGuide type="bottom" id="w2K-bm-ZPQ"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="GB8-Gv-9Jd">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="599"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="603"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="stepik_auth_logo" translatesAutoresizingMaskIntoConstraints="NO" id="jBI-hh-W9h">
+                            <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" image="stepik_auth_logo" translatesAutoresizingMaskIntoConstraints="NO" id="jBI-hh-W9h">
                                 <rect key="frame" x="163.5" y="50" width="48" height="48"/>
                                 <constraints>
                                     <constraint firstAttribute="width" relation="lessThanOrEqual" constant="48" id="Hm7-Zv-6Lk"/>
@@ -429,13 +428,13 @@
                                 </constraints>
                             </imageView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" text="Sign Up" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="KmT-i0-02l" customClass="StepikLabel" customModule="Stepic" customModuleProvider="target">
-                                <rect key="frame" x="24" y="160.5" width="327" height="24"/>
+                                <rect key="frame" x="24" y="159.5" width="327" height="24"/>
                                 <fontDescription key="fontDescription" type="system" weight="light" pointSize="20"/>
                                 <color key="textColor" red="0.32549019610000002" green="0.32549019610000002" blue="0.40000000000000002" alpha="1" colorSpace="calibratedRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <view clipsSubviews="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="1Cu-FO-mN5">
-                                <rect key="frame" x="24" y="204.5" width="327" height="158"/>
+                                <rect key="frame" x="24" y="203.5" width="327" height="164"/>
                                 <color key="backgroundColor" red="0.7843137255" green="0.15686274510000001" blue="0.31372549020000001" alpha="0.0" colorSpace="calibratedRGB"/>
                                 <userDefinedRuntimeAttributes>
                                     <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
@@ -444,13 +443,13 @@
                                 </userDefinedRuntimeAttributes>
                             </view>
                             <stackView opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="3wd-if-3To">
-                                <rect key="frame" x="24" y="204.5" width="327" height="158"/>
+                                <rect key="frame" x="24" y="203.5" width="327" height="164"/>
                                 <subviews>
                                     <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Name" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="c81-1U-sKd" userLabel="Name" customClass="AuthTextField" customModule="Stepic" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="0.0" width="327" height="52"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="327" height="54"/>
                                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                         <constraints>
-                                            <constraint firstAttribute="height" constant="52" id="NsB-Dn-Qrw">
+                                            <constraint firstAttribute="height" constant="54" id="NsB-Dn-Qrw">
                                                 <variation key="heightClass=compact" constant="45"/>
                                             </constraint>
                                         </constraints>
@@ -459,17 +458,17 @@
                                         <textInputTraits key="textInputTraits" autocorrectionType="no" returnKeyType="next"/>
                                     </textField>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Q8c-XX-pMK">
-                                        <rect key="frame" x="0.0" y="52" width="327" height="1"/>
+                                        <rect key="frame" x="0.0" y="54" width="327" height="1"/>
                                         <color key="backgroundColor" red="0.59215686270000001" green="0.59215686270000001" blue="0.59215686270000001" alpha="1" colorSpace="calibratedRGB"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="1" id="gRU-SW-zdr"/>
                                         </constraints>
                                     </view>
                                     <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Email" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="dPv-EY-XCL" customClass="AuthTextField" customModule="Stepic" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="53" width="327" height="52"/>
+                                        <rect key="frame" x="0.0" y="55" width="327" height="54"/>
                                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                         <constraints>
-                                            <constraint firstAttribute="height" constant="52" id="6TR-dW-sh0">
+                                            <constraint firstAttribute="height" constant="54" id="6TR-dW-sh0">
                                                 <variation key="heightClass=compact" constant="45"/>
                                             </constraint>
                                         </constraints>
@@ -478,17 +477,17 @@
                                         <textInputTraits key="textInputTraits" autocorrectionType="no" keyboardType="emailAddress" returnKeyType="next"/>
                                     </textField>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="rPV-1V-faR">
-                                        <rect key="frame" x="0.0" y="105" width="327" height="1"/>
+                                        <rect key="frame" x="0.0" y="109" width="327" height="1"/>
                                         <color key="backgroundColor" red="0.59215686270000001" green="0.59215686270000001" blue="0.59215686270000001" alpha="1" colorSpace="calibratedRGB"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="1" id="ga1-FK-AYK"/>
                                         </constraints>
                                     </view>
                                     <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Password" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="gng-wJ-E02" customClass="AuthTextField" customModule="Stepic" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="106" width="327" height="52"/>
+                                        <rect key="frame" x="0.0" y="110" width="327" height="54"/>
                                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                         <constraints>
-                                            <constraint firstAttribute="height" constant="52" id="dna-xZ-5h5">
+                                            <constraint firstAttribute="height" constant="54" id="dna-xZ-5h5">
                                                 <variation key="heightClass=compact" constant="45"/>
                                             </constraint>
                                         </constraints>
@@ -502,7 +501,7 @@
                                 </constraints>
                             </stackView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" text="Whoops! The e-mail address and/or password you specified are not correct." textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" minimumFontSize="12" translatesAutoresizingMaskIntoConstraints="NO" id="Sks-5y-rKN">
-                                <rect key="frame" x="24" y="378.5" width="327" height="0.0"/>
+                                <rect key="frame" x="24" y="383.5" width="327" height="0.0"/>
                                 <constraints>
                                     <constraint firstAttribute="height" id="y9u-6u-PKO"/>
                                 </constraints>
@@ -511,7 +510,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <button opaque="NO" contentMode="scaleToFill" enabled="NO" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="gfh-2r-iUJ" customClass="AuthButton" customModule="Stepic" customModuleProvider="target">
-                                <rect key="frame" x="24" y="378.5" width="327" height="44"/>
+                                <rect key="frame" x="24" y="383.5" width="327" height="44"/>
                                 <color key="backgroundColor" red="0.40000000000000002" green="0.80000000000000004" blue="0.40000000000000002" alpha="0.10000000000000001" colorSpace="calibratedRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="44" id="MYS-WM-Iw2"/>
@@ -533,7 +532,7 @@
                                 </connections>
                             </button>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="By registering you agree to the Terms of service and Privacy policy." textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Cqa-AS-4te" customClass="TTTAttributedLabel">
-                                <rect key="frame" x="24" y="544.5" width="327" height="38.5"/>
+                                <rect key="frame" x="24" y="548.5" width="327" height="38.5"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                 <color key="textColor" red="0.32549019610000002" green="0.32549019610000002" blue="0.40000000000000002" alpha="1" colorSpace="calibratedRGB"/>
                                 <nil key="highlightedColor"/>
@@ -591,7 +590,7 @@
                     <navigationItem key="navigationItem" id="VBR-hH-yzY">
                         <barButtonItem key="leftBarButtonItem" style="plain" id="LZL-zC-DDt">
                             <button key="customView" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="bottom" lineBreakMode="middleTruncation" id="Tlk-tX-Vkq">
-                                <rect key="frame" x="16" y="13" width="17" height="22"/>
+                                <rect key="frame" x="16" y="11" width="17" height="22"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="20" id="JpU-Um-0qu"/>
@@ -633,7 +632,7 @@
                     <extendedEdge key="edgesForExtendedLayout"/>
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" misplaced="YES" id="peF-Iz-JYA">
-                        <rect key="frame" x="0.0" y="20" width="375" height="48"/>
+                        <rect key="frame" x="0.0" y="20" width="375" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <nil name="viewControllers"/>

--- a/Stepic/Base.lproj/Auth.storyboard
+++ b/Stepic/Base.lproj/Auth.storyboard
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13196" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
-    <device id="retina4_7" orientation="portrait">
+    <device id="retina3_5" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
@@ -19,11 +19,11 @@
                         <viewControllerLayoutGuide type="bottom" id="qOI-QY-ky4"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="603"/>
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="416"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" scrollEnabled="NO" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="xtI-yF-JBK">
-                                <rect key="frame" x="0.0" y="192" width="375" height="125"/>
+                                <rect key="frame" x="0.0" y="98.5" width="320" height="125"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="125" id="Wq4-Ni-nrn"/>
@@ -36,11 +36,11 @@
                                 </collectionViewFlowLayout>
                                 <cells/>
                                 <collectionReusableView key="sectionHeaderView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="socialAuthHeaderView" id="e75-eK-LDk" customClass="SocialAuthHeaderView" customModule="Stepic" customModuleProvider="target">
-                                    <rect key="frame" x="0.0" y="0.0" width="375" height="47"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="320" height="47"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" text="Sign In with social account" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="GlJ-ad-nLa" customClass="StepikLabel" customModule="Stepic" customModuleProvider="target">
-                                            <rect key="frame" x="0.0" y="0.0" width="375" height="27"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="320" height="27"/>
                                             <fontDescription key="fontDescription" type="system" weight="light" pointSize="20"/>
                                             <color key="textColor" red="0.32549019610000002" green="0.32549019610000002" blue="0.40000000000000002" alpha="1" colorSpace="calibratedRGB"/>
                                             <nil key="highlightedColor"/>
@@ -58,7 +58,7 @@
                                 </collectionReusableView>
                             </collectionView>
                             <button opaque="NO" contentMode="scaleToFill" verticalCompressionResistancePriority="751" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="UyI-UL-4R6">
-                                <rect key="frame" x="168.5" y="347" width="38" height="32"/>
+                                <rect key="frame" x="141" y="253.5" width="38" height="32"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                 <state key="normal" title="More">
                                     <color key="titleColor" red="0.40000000000000002" green="0.80000000000000004" blue="0.40000000000000002" alpha="1" colorSpace="calibratedRGB"/>
@@ -68,7 +68,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="right" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="o00-ed-SpF">
-                                <rect key="frame" x="24" y="555" width="134" height="32"/>
+                                <rect key="frame" x="24" y="368" width="134" height="32"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                 <state key="normal" title="Sign In with e-mail">
                                     <color key="titleColor" red="0.32549019610000002" green="0.32549019610000002" blue="0.40000000000000002" alpha="1" colorSpace="calibratedRGB"/>
@@ -78,17 +78,14 @@
                                 </connections>
                             </button>
                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" image="stepik_auth_logo" translatesAutoresizingMaskIntoConstraints="NO" id="gb0-7l-u82">
-                                <rect key="frame" x="163.5" y="50" width="48" height="48"/>
+                                <rect key="frame" x="136" y="17.5" width="48" height="48"/>
                                 <constraints>
-                                    <constraint firstAttribute="height" relation="lessThanOrEqual" constant="48" id="LNn-gH-wZx"/>
-                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="33" id="SSI-qD-EBL"/>
-                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="33" id="Ueh-Tb-Cqc"/>
-                                    <constraint firstAttribute="width" secondItem="gb0-7l-u82" secondAttribute="height" multiplier="1:1" id="cqT-EV-RmX"/>
-                                    <constraint firstAttribute="width" relation="lessThanOrEqual" constant="48" id="hYO-WO-PsW"/>
+                                    <constraint firstAttribute="width" secondItem="gb0-7l-u82" secondAttribute="height" multiplier="1:1" id="I6g-zO-JT0"/>
+                                    <constraint firstAttribute="height" constant="48" id="LNn-gH-wZx"/>
                                 </constraints>
                             </imageView>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="C3e-7n-JkS">
-                                <rect key="frame" x="293" y="555" width="58" height="32"/>
+                                <rect key="frame" x="238" y="368" width="58" height="32"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                 <state key="normal" title="Sign Up">
                                     <color key="titleColor" red="0.32549019610000002" green="0.32549019610000002" blue="0.40000000000000002" alpha="1" colorSpace="calibratedRGB"/>
@@ -110,11 +107,10 @@
                             <constraint firstAttribute="trailing" secondItem="xtI-yF-JBK" secondAttribute="trailing" id="SJn-MR-LGn"/>
                             <constraint firstItem="qOI-QY-ky4" firstAttribute="top" secondItem="C3e-7n-JkS" secondAttribute="bottom" constant="16" id="W9t-qf-1WH"/>
                             <constraint firstItem="xtI-yF-JBK" firstAttribute="leading" secondItem="8bC-Xf-vdC" secondAttribute="leading" id="WlV-zC-UWM"/>
-                            <constraint firstItem="xtI-yF-JBK" firstAttribute="top" relation="greaterThanOrEqual" secondItem="gb0-7l-u82" secondAttribute="bottom" constant="24" id="kIz-vR-HVq"/>
+                            <constraint firstItem="xtI-yF-JBK" firstAttribute="top" secondItem="gb0-7l-u82" secondAttribute="bottom" constant="33" id="kIz-vR-HVq"/>
                             <constraint firstItem="o00-ed-SpF" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" constant="-180" id="l5A-cT-1TG"/>
                             <constraint firstItem="qOI-QY-ky4" firstAttribute="top" secondItem="o00-ed-SpF" secondAttribute="bottom" constant="16" id="nuu-Nb-Ccd"/>
                             <constraint firstAttribute="trailing" secondItem="C3e-7n-JkS" secondAttribute="trailing" constant="24" id="xcD-X5-Vei"/>
-                            <constraint firstItem="gb0-7l-u82" firstAttribute="top" secondItem="834-nm-s3Q" secondAttribute="bottom" priority="999" constant="50" id="zAj-7G-ZFf"/>
                         </constraints>
                         <variation key="default">
                             <mask key="constraints">
@@ -166,6 +162,7 @@
                         <outlet property="moreButton" destination="UyI-UL-4R6" id="iSt-8U-hj2"/>
                         <outlet property="signInButton" destination="o00-ed-SpF" id="Ytv-t6-9qj"/>
                         <outlet property="signUpButton" destination="C3e-7n-JkS" id="uN9-Of-r1B"/>
+                        <outlet property="stepikLogoHeightConstraint" destination="LNn-gH-wZx" id="MuK-oC-wyc"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
@@ -181,11 +178,11 @@
                         <viewControllerLayoutGuide type="bottom" id="Lsp-SO-0Mq"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="ecb-mE-jfH">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="603"/>
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="416"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <button opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" contentHorizontalAlignment="left" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="vQR-hv-GBW">
-                                <rect key="frame" x="24" y="555" width="130" height="32"/>
+                                <rect key="frame" x="24" y="368" width="130" height="32"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                 <state key="normal" title="Sign In with social">
                                     <color key="titleColor" red="0.32549019610000002" green="0.32549019610000002" blue="0.40000000000000002" alpha="1" colorSpace="calibratedRGB"/>
@@ -195,17 +192,14 @@
                                 </connections>
                             </button>
                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" image="stepik_auth_logo" translatesAutoresizingMaskIntoConstraints="NO" id="Seg-dF-9x8">
-                                <rect key="frame" x="163.5" y="50" width="48" height="48"/>
+                                <rect key="frame" x="136" y="12.5" width="48" height="48"/>
                                 <constraints>
-                                    <constraint firstAttribute="height" relation="lessThanOrEqual" constant="48" id="RDE-UM-mDV"/>
-                                    <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="33" id="c22-HP-B0F"/>
-                                    <constraint firstAttribute="width" relation="lessThanOrEqual" constant="48" id="hJm-nv-PgV"/>
-                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="33" id="mTu-yA-dje"/>
-                                    <constraint firstAttribute="width" secondItem="Seg-dF-9x8" secondAttribute="height" multiplier="1:1" id="noz-DY-ZEz"/>
+                                    <constraint firstAttribute="height" constant="48" id="RDE-UM-mDV"/>
+                                    <constraint firstAttribute="width" secondItem="Seg-dF-9x8" secondAttribute="height" multiplier="1:1" id="jLs-94-Jtc"/>
                                 </constraints>
                             </imageView>
                             <button opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" contentHorizontalAlignment="right" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Vrc-hu-CrF">
-                                <rect key="frame" x="293" y="555" width="58" height="32"/>
+                                <rect key="frame" x="238" y="368" width="58" height="32"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                 <state key="normal" title="Sign Up">
                                     <color key="titleColor" red="0.32549019610000002" green="0.32549019610000002" blue="0.40000000000000002" alpha="1" colorSpace="calibratedRGB"/>
@@ -215,13 +209,13 @@
                                 </connections>
                             </button>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" text="Sign In with email" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Rqj-F6-Q1k" customClass="StepikLabel" customModule="Stepic" customModuleProvider="target">
-                                <rect key="frame" x="24" y="187" width="327" height="24"/>
+                                <rect key="frame" x="24" y="93.5" width="272" height="24"/>
                                 <fontDescription key="fontDescription" type="system" weight="light" pointSize="20"/>
                                 <color key="textColor" red="0.32549019610000002" green="0.32549019610000002" blue="0.40000000000000002" alpha="1" colorSpace="calibratedRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <view clipsSubviews="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="hcs-d4-W7U">
-                                <rect key="frame" x="24" y="231" width="327" height="109"/>
+                                <rect key="frame" x="24" y="137.5" width="272" height="109"/>
                                 <color key="backgroundColor" red="0.78431372549019607" green="0.15686274509803921" blue="0.31372549019607843" alpha="0.0" colorSpace="calibratedRGB"/>
                                 <userDefinedRuntimeAttributes>
                                     <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
@@ -230,10 +224,10 @@
                                 </userDefinedRuntimeAttributes>
                             </view>
                             <stackView opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="YSS-sQ-UuC">
-                                <rect key="frame" x="24" y="231" width="327" height="109"/>
+                                <rect key="frame" x="24" y="137.5" width="272" height="109"/>
                                 <subviews>
                                     <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Email" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="NCY-px-UvI" customClass="AuthTextField" customModule="Stepic" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="0.0" width="327" height="54"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="272" height="54"/>
                                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="54" id="tWg-4k-CUe">
@@ -245,14 +239,14 @@
                                         <textInputTraits key="textInputTraits" autocorrectionType="no" keyboardType="emailAddress" returnKeyType="next"/>
                                     </textField>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="syM-4D-gnF">
-                                        <rect key="frame" x="0.0" y="54" width="327" height="1"/>
+                                        <rect key="frame" x="0.0" y="54" width="272" height="1"/>
                                         <color key="backgroundColor" red="0.59215686274509804" green="0.59215686274509804" blue="0.59215686274509804" alpha="1" colorSpace="calibratedRGB"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="1" id="baT-yf-3Zs"/>
                                         </constraints>
                                     </view>
                                     <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Password" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="umg-9h-bV9" customClass="AuthTextField" customModule="Stepic" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="55" width="327" height="54"/>
+                                        <rect key="frame" x="0.0" y="55" width="272" height="54"/>
                                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="54" id="JBt-Z0-ScN">
@@ -269,7 +263,7 @@
                                 </constraints>
                             </stackView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" text="Whoops! The e-mail address and/or password you specified are not correct." textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" minimumFontSize="12" translatesAutoresizingMaskIntoConstraints="NO" id="55E-Yo-HFU">
-                                <rect key="frame" x="24" y="356" width="327" height="0.0"/>
+                                <rect key="frame" x="24" y="262.5" width="272" height="0.0"/>
                                 <constraints>
                                     <constraint firstAttribute="height" id="cj6-hM-VuZ"/>
                                 </constraints>
@@ -278,7 +272,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <button opaque="NO" contentMode="scaleToFill" enabled="NO" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Fnt-qB-XZx" customClass="AuthButton" customModule="Stepic" customModuleProvider="target">
-                                <rect key="frame" x="24" y="356" width="327" height="44"/>
+                                <rect key="frame" x="24" y="256.5" width="272" height="44"/>
                                 <color key="backgroundColor" red="0.40000000000000002" green="0.80000000000000004" blue="0.40000000000000002" alpha="0.10000000000000001" colorSpace="calibratedRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="44" id="tX0-AL-jlM"/>
@@ -300,7 +294,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" verticalCompressionResistancePriority="751" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="cic-9n-m9H">
-                                <rect key="frame" x="24" y="408" width="327" height="40"/>
+                                <rect key="frame" x="24" y="308.5" width="272" height="40"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="40" id="Z2G-ri-lD3"/>
@@ -322,8 +316,8 @@
                             <constraint firstItem="vQR-hv-GBW" firstAttribute="leading" secondItem="NCY-px-UvI" secondAttribute="leading" id="71d-Se-0s5"/>
                             <constraint firstItem="Rqj-F6-Q1k" firstAttribute="top" secondItem="6Oh-wg-Nki" secondAttribute="bottom" constant="6" id="97v-ha-oG6"/>
                             <constraint firstItem="55E-Yo-HFU" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="ecb-mE-jfH" secondAttribute="leading" constant="24" id="Aat-eW-N7o"/>
-                            <constraint firstItem="Fnt-qB-XZx" firstAttribute="top" secondItem="55E-Yo-HFU" secondAttribute="bottom" id="FMb-Ob-Zlz"/>
-                            <constraint firstItem="Rqj-F6-Q1k" firstAttribute="top" relation="greaterThanOrEqual" secondItem="Seg-dF-9x8" secondAttribute="bottom" priority="999" constant="24" id="H5c-PC-5ea"/>
+                            <constraint firstItem="Fnt-qB-XZx" firstAttribute="top" secondItem="55E-Yo-HFU" secondAttribute="bottom" constant="-6" id="FMb-Ob-Zlz"/>
+                            <constraint firstItem="Rqj-F6-Q1k" firstAttribute="top" secondItem="Seg-dF-9x8" secondAttribute="bottom" constant="33" id="H5c-PC-5ea"/>
                             <constraint firstItem="hcs-d4-W7U" firstAttribute="leading" secondItem="YSS-sQ-UuC" secondAttribute="leading" id="KHO-no-Z2p"/>
                             <constraint firstItem="Rqj-F6-Q1k" firstAttribute="leading" secondItem="ecb-mE-jfH" secondAttribute="leading" constant="24" id="Kef-Ch-oSy"/>
                             <constraint firstItem="hcs-d4-W7U" firstAttribute="bottom" secondItem="YSS-sQ-UuC" secondAttribute="bottom" id="MA0-wr-ijX"/>
@@ -336,7 +330,6 @@
                             <constraint firstItem="Vrc-hu-CrF" firstAttribute="top" relation="greaterThanOrEqual" secondItem="cic-9n-m9H" secondAttribute="bottom" id="dzP-Qn-5d4"/>
                             <constraint firstItem="YSS-sQ-UuC" firstAttribute="leading" secondItem="ecb-mE-jfH" secondAttribute="leading" priority="999" constant="24" id="fBR-Cs-mC0"/>
                             <constraint firstItem="cic-9n-m9H" firstAttribute="width" secondItem="Fnt-qB-XZx" secondAttribute="width" id="fQF-Sb-ve9"/>
-                            <constraint firstItem="Seg-dF-9x8" firstAttribute="top" secondItem="6Oh-wg-Nki" secondAttribute="bottom" priority="998" constant="50" id="fd9-KH-5zg"/>
                             <constraint firstItem="Rqj-F6-Q1k" firstAttribute="centerX" secondItem="ecb-mE-jfH" secondAttribute="centerX" id="fhG-Zw-aFa"/>
                             <constraint firstItem="hcs-d4-W7U" firstAttribute="trailing" secondItem="YSS-sQ-UuC" secondAttribute="trailing" id="gYx-Q5-B70"/>
                             <constraint firstItem="hcs-d4-W7U" firstAttribute="top" secondItem="YSS-sQ-UuC" secondAttribute="top" id="jVX-jM-0lt"/>
@@ -398,6 +391,7 @@
                         <outlet property="separatorHeight" destination="baT-yf-3Zs" id="lpB-3y-RYz"/>
                         <outlet property="signInButton" destination="vQR-hv-GBW" id="J5U-5D-Qyf"/>
                         <outlet property="signUpButton" destination="Vrc-hu-CrF" id="fex-5G-aFw"/>
+                        <outlet property="stepikLogoHeightConstraint" destination="RDE-UM-mDV" id="Myk-Jx-hTv"/>
                         <outlet property="titleLabel" destination="Rqj-F6-Q1k" id="VYa-u8-tey"/>
                     </connections>
                 </viewController>
@@ -414,27 +408,24 @@
                         <viewControllerLayoutGuide type="bottom" id="w2K-bm-ZPQ"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="GB8-Gv-9Jd">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="603"/>
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="416"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" image="stepik_auth_logo" translatesAutoresizingMaskIntoConstraints="NO" id="jBI-hh-W9h">
-                                <rect key="frame" x="163.5" y="50" width="48" height="48"/>
+                            <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="252" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" image="stepik_auth_logo" translatesAutoresizingMaskIntoConstraints="NO" id="jBI-hh-W9h">
+                                <rect key="frame" x="136" y="-15" width="48" height="48"/>
                                 <constraints>
-                                    <constraint firstAttribute="width" relation="lessThanOrEqual" constant="48" id="Hm7-Zv-6Lk"/>
-                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="33" id="IyK-Fv-hv1"/>
-                                    <constraint firstAttribute="height" relation="lessThanOrEqual" constant="48" id="PFF-U7-liF"/>
-                                    <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="33" id="cHT-Ii-1AK"/>
-                                    <constraint firstAttribute="width" secondItem="jBI-hh-W9h" secondAttribute="height" multiplier="1:1" id="hAZ-l1-vg9"/>
+                                    <constraint firstAttribute="width" secondItem="jBI-hh-W9h" secondAttribute="height" multiplier="1:1" id="748-HO-h5Q"/>
+                                    <constraint firstAttribute="height" constant="48" id="PFF-U7-liF"/>
                                 </constraints>
                             </imageView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" text="Sign Up" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="KmT-i0-02l" customClass="StepikLabel" customModule="Stepic" customModuleProvider="target">
-                                <rect key="frame" x="24" y="159.5" width="327" height="24"/>
+                                <rect key="frame" x="24" y="66" width="272" height="24"/>
                                 <fontDescription key="fontDescription" type="system" weight="light" pointSize="20"/>
                                 <color key="textColor" red="0.32549019610000002" green="0.32549019610000002" blue="0.40000000000000002" alpha="1" colorSpace="calibratedRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <view clipsSubviews="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="1Cu-FO-mN5">
-                                <rect key="frame" x="24" y="203.5" width="327" height="164"/>
+                                <rect key="frame" x="24" y="110" width="272" height="164"/>
                                 <color key="backgroundColor" red="0.7843137255" green="0.15686274510000001" blue="0.31372549020000001" alpha="0.0" colorSpace="calibratedRGB"/>
                                 <userDefinedRuntimeAttributes>
                                     <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
@@ -443,10 +434,10 @@
                                 </userDefinedRuntimeAttributes>
                             </view>
                             <stackView opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="3wd-if-3To">
-                                <rect key="frame" x="24" y="203.5" width="327" height="164"/>
+                                <rect key="frame" x="24" y="110" width="272" height="164"/>
                                 <subviews>
                                     <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Name" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="c81-1U-sKd" userLabel="Name" customClass="AuthTextField" customModule="Stepic" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="0.0" width="327" height="54"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="272" height="54"/>
                                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="54" id="NsB-Dn-Qrw">
@@ -458,14 +449,14 @@
                                         <textInputTraits key="textInputTraits" autocorrectionType="no" returnKeyType="next"/>
                                     </textField>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Q8c-XX-pMK">
-                                        <rect key="frame" x="0.0" y="54" width="327" height="1"/>
+                                        <rect key="frame" x="0.0" y="54" width="272" height="1"/>
                                         <color key="backgroundColor" red="0.59215686270000001" green="0.59215686270000001" blue="0.59215686270000001" alpha="1" colorSpace="calibratedRGB"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="1" id="gRU-SW-zdr"/>
                                         </constraints>
                                     </view>
                                     <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Email" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="dPv-EY-XCL" customClass="AuthTextField" customModule="Stepic" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="55" width="327" height="54"/>
+                                        <rect key="frame" x="0.0" y="55" width="272" height="54"/>
                                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="54" id="6TR-dW-sh0">
@@ -477,14 +468,14 @@
                                         <textInputTraits key="textInputTraits" autocorrectionType="no" keyboardType="emailAddress" returnKeyType="next"/>
                                     </textField>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="rPV-1V-faR">
-                                        <rect key="frame" x="0.0" y="109" width="327" height="1"/>
+                                        <rect key="frame" x="0.0" y="109" width="272" height="1"/>
                                         <color key="backgroundColor" red="0.59215686270000001" green="0.59215686270000001" blue="0.59215686270000001" alpha="1" colorSpace="calibratedRGB"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="1" id="ga1-FK-AYK"/>
                                         </constraints>
                                     </view>
                                     <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Password" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="gng-wJ-E02" customClass="AuthTextField" customModule="Stepic" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="110" width="327" height="54"/>
+                                        <rect key="frame" x="0.0" y="110" width="272" height="54"/>
                                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="54" id="dna-xZ-5h5">
@@ -501,7 +492,7 @@
                                 </constraints>
                             </stackView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" text="Whoops! The e-mail address and/or password you specified are not correct." textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" minimumFontSize="12" translatesAutoresizingMaskIntoConstraints="NO" id="Sks-5y-rKN">
-                                <rect key="frame" x="24" y="383.5" width="327" height="0.0"/>
+                                <rect key="frame" x="24" y="290" width="272" height="0.0"/>
                                 <constraints>
                                     <constraint firstAttribute="height" id="y9u-6u-PKO"/>
                                 </constraints>
@@ -510,7 +501,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <button opaque="NO" contentMode="scaleToFill" enabled="NO" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="gfh-2r-iUJ" customClass="AuthButton" customModule="Stepic" customModuleProvider="target">
-                                <rect key="frame" x="24" y="383.5" width="327" height="44"/>
+                                <rect key="frame" x="24" y="284" width="272" height="44"/>
                                 <color key="backgroundColor" red="0.40000000000000002" green="0.80000000000000004" blue="0.40000000000000002" alpha="0.10000000000000001" colorSpace="calibratedRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="44" id="MYS-WM-Iw2"/>
@@ -532,7 +523,7 @@
                                 </connections>
                             </button>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="By registering you agree to the Terms of service and Privacy policy." textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Cqa-AS-4te" customClass="TTTAttributedLabel">
-                                <rect key="frame" x="24" y="548.5" width="327" height="38.5"/>
+                                <rect key="frame" x="24" y="361.5" width="272" height="38.5"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                 <color key="textColor" red="0.32549019610000002" green="0.32549019610000002" blue="0.40000000000000002" alpha="1" colorSpace="calibratedRGB"/>
                                 <nil key="highlightedColor"/>
@@ -548,15 +539,14 @@
                             <constraint firstItem="Sks-5y-rKN" firstAttribute="width" secondItem="3wd-if-3To" secondAttribute="width" id="6Iz-Qt-JdO"/>
                             <constraint firstItem="KmT-i0-02l" firstAttribute="centerX" secondItem="GB8-Gv-9Jd" secondAttribute="centerX" id="9Ca-P1-FwA"/>
                             <constraint firstItem="1Cu-FO-mN5" firstAttribute="top" secondItem="3wd-if-3To" secondAttribute="top" id="JBU-s0-UdL"/>
-                            <constraint firstItem="gfh-2r-iUJ" firstAttribute="top" secondItem="Sks-5y-rKN" secondAttribute="bottom" id="KNy-3m-2zg"/>
+                            <constraint firstItem="gfh-2r-iUJ" firstAttribute="top" secondItem="Sks-5y-rKN" secondAttribute="bottom" constant="-6" id="KNy-3m-2zg"/>
                             <constraint firstItem="3wd-if-3To" firstAttribute="centerY" secondItem="GB8-Gv-9Jd" secondAttribute="centerY" priority="999" constant="-16" id="Kj2-02-YgU"/>
                             <constraint firstItem="Cqa-AS-4te" firstAttribute="leading" secondItem="GB8-Gv-9Jd" secondAttribute="leading" constant="24" id="Ohr-am-xyM"/>
                             <constraint firstItem="jBI-hh-W9h" firstAttribute="centerX" secondItem="GB8-Gv-9Jd" secondAttribute="centerX" id="PIk-Hl-dUb"/>
                             <constraint firstItem="Sks-5y-rKN" firstAttribute="centerX" secondItem="GB8-Gv-9Jd" secondAttribute="centerX" id="QNg-7c-kdH"/>
                             <constraint firstItem="Sks-5y-rKN" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="GB8-Gv-9Jd" secondAttribute="leading" constant="24" id="Sc5-AD-R4u"/>
-                            <constraint firstItem="jBI-hh-W9h" firstAttribute="top" secondItem="eac-RL-2NS" secondAttribute="bottom" priority="998" constant="50" id="UDz-fX-BlH"/>
                             <constraint firstAttribute="trailing" secondItem="KmT-i0-02l" secondAttribute="trailing" constant="24" id="Vma-ry-Hbm"/>
-                            <constraint firstItem="KmT-i0-02l" firstAttribute="top" relation="greaterThanOrEqual" secondItem="jBI-hh-W9h" secondAttribute="bottom" priority="999" constant="24" id="XT0-RL-Wf1"/>
+                            <constraint firstItem="KmT-i0-02l" firstAttribute="top" secondItem="jBI-hh-W9h" secondAttribute="bottom" constant="33" id="XT0-RL-Wf1"/>
                             <constraint firstItem="1Cu-FO-mN5" firstAttribute="leading" secondItem="3wd-if-3To" secondAttribute="leading" id="ZXi-5Y-SBb"/>
                             <constraint firstItem="3wd-if-3To" firstAttribute="leading" secondItem="GB8-Gv-9Jd" secondAttribute="leading" priority="999" constant="24" id="art-Si-m0y"/>
                             <constraint firstItem="Sks-5y-rKN" firstAttribute="top" secondItem="3wd-if-3To" secondAttribute="bottom" constant="16" id="gCH-53-W7h"/>
@@ -617,6 +607,7 @@
                         <outlet property="registerButton" destination="gfh-2r-iUJ" id="kf8-1A-SID"/>
                         <outlet property="separatorFirstHeight" destination="gRU-SW-zdr" id="cJI-Oq-dT5"/>
                         <outlet property="separatorSecondHeight" destination="ga1-FK-AYK" id="ubA-cq-B3z"/>
+                        <outlet property="stepikLogoHeightConstraint" destination="PFF-U7-liF" id="9By-At-pmX"/>
                         <outlet property="titleLabel" destination="KmT-i0-02l" id="QdI-WC-E8d"/>
                         <outlet property="tosLabel" destination="Cqa-AS-4te" id="uiS-cE-WJv"/>
                     </connections>
@@ -632,7 +623,7 @@
                     <extendedEdge key="edgesForExtendedLayout"/>
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" misplaced="YES" id="peF-Iz-JYA">
-                        <rect key="frame" x="0.0" y="20" width="375" height="44"/>
+                        <rect key="frame" x="0.0" y="20" width="320" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <nil name="viewControllers"/>

--- a/Stepic/EmailAuthViewController.swift
+++ b/Stepic/EmailAuthViewController.swift
@@ -38,6 +38,7 @@ class EmailAuthViewController: UIViewController {
 
     var prefilledEmail: String?
 
+    @IBOutlet weak var stepikLogoHeightConstraint: NSLayoutConstraint!
     @IBOutlet var alertLabelHeightConstraint: NSLayoutConstraint!
     @IBOutlet weak var alertBottomLabelConstraint: NSLayoutConstraint!
 
@@ -89,7 +90,7 @@ class EmailAuthViewController: UIViewController {
                     self.view.layoutIfNeeded()
                 })
             } else {
-                alertBottomLabelConstraint.constant = 0
+                alertBottomLabelConstraint.constant = -6
                 alertLabelHeightConstraint.isActive = true
                 UIView.animate(withDuration: 0.1, animations: {
                     self.view.layoutIfNeeded()
@@ -191,6 +192,11 @@ class EmailAuthViewController: UIViewController {
         inputGroupPad.layer.borderWidth = 0.5
         inputGroupPad.layer.borderColor = UIColor(red: 151 / 255, green: 151 / 255, blue: 151 / 255, alpha: 1.0).cgColor
         passwordTextField.fieldType = .password
+
+        // Small logo for small screens
+        if DeviceInfo.current.diagonal <= 4 {
+            stepikLogoHeightConstraint.constant = 38
+        }
     }
 
     private func prefill() {

--- a/Stepic/RegistrationViewController.swift
+++ b/Stepic/RegistrationViewController.swift
@@ -37,6 +37,7 @@ class RegistrationViewController: UIViewController {
 
     @IBOutlet weak var alertBottomLabelConstraint: NSLayoutConstraint!
     @IBOutlet var alertLabelHeightConstraint: NSLayoutConstraint!
+    @IBOutlet weak var stepikLogoHeightConstraint: NSLayoutConstraint!
 
     @IBOutlet weak var alertLabel: UILabel!
     @IBOutlet weak var registerButton: AuthButton!
@@ -62,7 +63,7 @@ class RegistrationViewController: UIViewController {
                     self.view.layoutIfNeeded()
                 })
             } else {
-                alertBottomLabelConstraint.constant = 0
+                alertBottomLabelConstraint.constant = -6
                 alertLabelHeightConstraint.isActive = true
                 UIView.animate(withDuration: 0.1, animations: {
                     self.view.layoutIfNeeded()
@@ -167,6 +168,11 @@ class RegistrationViewController: UIViewController {
         inputGroupPad.layer.borderWidth = 0.5
         inputGroupPad.layer.borderColor = UIColor(red: 151 / 255, green: 151 / 255, blue: 151 / 255, alpha: 1.0).cgColor
         passwordTextField.fieldType = .password
+
+        // Small logo for small screens
+        if DeviceInfo.current.diagonal <= 4 {
+            stepikLogoHeightConstraint.constant = 38
+        }
     }
 
     private func localize() {

--- a/Stepic/SocialAuthViewController.swift
+++ b/Stepic/SocialAuthViewController.swift
@@ -63,6 +63,7 @@ class SocialAuthViewController: UIViewController {
     @IBOutlet weak var moreButton: UIButton!
     @IBOutlet weak var collectionViewHeight: NSLayoutConstraint!
     @IBOutlet weak var collectionView: UICollectionView!
+    @IBOutlet weak var stepikLogoHeightConstraint: NSLayoutConstraint!
 
     fileprivate var providers: [SocialProviderViewData] = []
 
@@ -128,6 +129,11 @@ class SocialAuthViewController: UIViewController {
         let collectionViewLayout = SocialCollectionViewFlowLayout()
         collectionViewLayout.numberOfColumns = numberOfColumns
         collectionView.collectionViewLayout = collectionViewLayout
+
+        // Small logo for small screens
+        if DeviceInfo.current.diagonal <= 4 {
+            stepikLogoHeightConstraint.constant = 38
+        }
     }
 
     override func viewDidAppear(_ animated: Bool) {


### PR DESCRIPTION
**Коротко для Release Notes, в формате «Сделали/Добавили/Исправили N»**: 
Мелкие фиксы вёрстки авторизации

**Описание**:
Некоторые мелкие фиксы с которыми, на мой взгляд, всё выглядит лучше:
* Высота кнопки и текстовых полей (пропорционально макету, но чуть меньше)
* Выпилен под `TextFieldEffects`, который юзался в старой авторизации
* Отступ до кнопки "Войти"/"Зарегистрироваться" 
* Логотип не прыгает при появлении клавиатуры – теперь он прибит к лейблу над текстовыми полями
  * На маленьких экранах (4 и меньше дюйма) логотип 48x48 кажется слишком большим. Сделать авто-лейаут, который работает **всегда** и не ломается при этом клавиатурой у меня не получилось – из кода выставляем высоту для таких случаев