### PR TITLE
Explore fixes

### DIFF
--- a/Stepic/CourseListPresenter.swift
+++ b/Stepic/CourseListPresenter.swift
@@ -758,7 +758,7 @@ enum CourseListType {
 
         switch self {
         case .popular:
-            return coursesAPI.retrieve(featured: true, excludeEnded: true, isPublic: true, order: "-activity", language: requestedLanguage, page: page)
+            return coursesAPI.retrieve(excludeEnded: true, isPublic: true, order: "-activity", language: requestedLanguage, page: page)
         case .enrolled:
             return requestAllEnrolled(coursesAPI: coursesAPI, progressesAPI: progressesAPI)
         case let .search(query: query):

--- a/Stepic/CourseListViewController.swift
+++ b/Stepic/CourseListViewController.swift
@@ -146,6 +146,7 @@ class CourseListViewController: UIViewController, CourseListView {
             setPlaceholder(visible: false)
             break
         case .empty:
+            delegate?.reloadData()
             emptyPlaceholder.onTap = nil
             if let listType = presenter?.listType {
                 switch listType {
@@ -163,6 +164,7 @@ class CourseListViewController: UIViewController, CourseListView {
             setPlaceholder(visible: true)
             break
         case .emptyError:
+            delegate?.reloadData()
             emptyPlaceholder.onTap = {
                 [weak self] in
                 self?.presenter?.refresh()
@@ -188,6 +190,7 @@ class CourseListViewController: UIViewController, CourseListView {
             delegate?.setUserInteraction(enabled: false)
             break
         case .emptyAnonymous:
+            delegate?.reloadData()
             emptyPlaceholder.text = NSLocalizedString("HomePlaceholderAnonymous", comment: "")
             emptyPlaceholder.onTap = {
                 [weak self] in

--- a/Stepic/ExplorePresenter.swift
+++ b/Stepic/ExplorePresenter.swift
@@ -112,7 +112,7 @@ class ExplorePresenter: CourseListCountDelegate {
                 CourseListBlock(
                     listType: .collection(ids: $0.coursesArray),
                     ID: getId(forList: $0),
-                    horizontalLimit: nil,
+                    horizontalLimit: 14,
                     title: $0.title,
                     colorMode: .light,
                     shouldShowCount: true,
@@ -125,7 +125,7 @@ class ExplorePresenter: CourseListCountDelegate {
                 CourseListBlock(
                     listType: .popular,
                     ID: "Popular",
-                    horizontalLimit: nil,
+                    horizontalLimit: 14,
                     title: NSLocalizedString("Popular", comment: ""),
                     colorMode: .dark,
                     shouldShowCount: false,

--- a/Stepic/ExplorePresenter.swift
+++ b/Stepic/ExplorePresenter.swift
@@ -218,10 +218,6 @@ class ExplorePresenter: CourseListCountDelegate {
     }
 }
 
-//enum ExploreState {
-//    case emptyRefreshing, empty, error, showing
-//}
-
 enum SearchState {
     case noSearch, suggestions, results
 }

--- a/Stepic/ExplorePresenter.swift
+++ b/Stepic/ExplorePresenter.swift
@@ -107,19 +107,28 @@ class ExplorePresenter: CourseListCountDelegate {
             self?.view?.show(vc: vc)
         }
 
-        return lists.map {
-            CourseListBlock(
-                listType: .collection(ids: $0.coursesArray),
-                ID: getId(forList: $0),
-                horizontalLimit: 6,
-                title: $0.title,
-                colorMode: .light,
-                shouldShowCount: true,
-                showControllerBlock: showController,
-                courseListCountDelegate: self,
-                onlyLocal: onlyLocal
-            )
-        }
+        return
+            [CourseListBlock(
+                listType: .popular,
+                ID: "Explore_Popular",
+                horizontalLimit: nil,
+                title: NSLocalizedString("Popular", comment: ""),
+                colorMode: .dark,
+                shouldShowCount: false,
+                showControllerBlock: showController)] +
+            lists.map {
+                CourseListBlock(
+                    listType: .collection(ids: $0.coursesArray),
+                    ID: getId(forList: $0),
+                    horizontalLimit: nil,
+                    title: $0.title,
+                    colorMode: .light,
+                    shouldShowCount: true,
+                    showControllerBlock: showController,
+                    courseListCountDelegate: self,
+                    onlyLocal: onlyLocal
+                )
+            }
     }
 
     private func getCachedLists(forLanguage language: ContentLanguage) -> [CourseList] {
@@ -204,6 +213,10 @@ class ExplorePresenter: CourseListCountDelegate {
         view?.updateCourseCount(to: to, forBlockWithID: forListID)
     }
 }
+
+//enum ExploreState {
+//    case emptyRefreshing, empty, error, showing
+//}
 
 enum SearchState {
     case noSearch, suggestions, results

--- a/Stepic/ExplorePresenter.swift
+++ b/Stepic/ExplorePresenter.swift
@@ -140,6 +140,7 @@ class ExplorePresenter: CourseListCountDelegate {
     }
 
     func refresh() {
+        view?.setConnectionProblemsPlaceholder(hidden: true)
         let listLanguage = ContentLanguage.sharedContentLanguage
         refreshFromLocal(forLanguage: listLanguage)
         refreshFromRemote(forLanguage: listLanguage)

--- a/Stepic/ExplorePresenter.swift
+++ b/Stepic/ExplorePresenter.swift
@@ -108,14 +108,6 @@ class ExplorePresenter: CourseListCountDelegate {
         }
 
         return
-            [CourseListBlock(
-                listType: .popular,
-                ID: "Explore_Popular",
-                horizontalLimit: nil,
-                title: NSLocalizedString("Popular", comment: ""),
-                colorMode: .dark,
-                shouldShowCount: false,
-                showControllerBlock: showController)] +
             lists.map {
                 CourseListBlock(
                     listType: .collection(ids: $0.coursesArray),
@@ -128,7 +120,18 @@ class ExplorePresenter: CourseListCountDelegate {
                     courseListCountDelegate: self,
                     onlyLocal: onlyLocal
                 )
-            }
+            } +
+            [
+                CourseListBlock(
+                    listType: .popular,
+                    ID: "Popular",
+                    horizontalLimit: nil,
+                    title: NSLocalizedString("Popular", comment: ""),
+                    colorMode: .dark,
+                    shouldShowCount: false,
+                    showControllerBlock: showController
+                )
+            ]
     }
 
     private func getCachedLists(forLanguage language: ContentLanguage) -> [CourseList] {

--- a/Stepic/ExploreViewController.swift
+++ b/Stepic/ExploreViewController.swift
@@ -159,7 +159,7 @@ class ExploreViewController: UIViewController, ExploreView {
         placeholder.alignTop("16", leading: "0", bottom: "0", trailing: "0", toView: v)
         placeholder.constrainHeight("100")
         placeholder.isHidden = false
-        placeholder.text = "No connection. Touch to retry"
+        placeholder.text = NSLocalizedString("CatalogPlaceholderError", comment: "")
         placeholder.onTap = {
             [weak self] in
             self?.presenter?.refresh()

--- a/Stepic/HomeScreenPresenter.swift
+++ b/Stepic/HomeScreenPresenter.swift
@@ -32,8 +32,8 @@ class HomeScreenPresenter: LastStepWidgetDataSource, CourseListCountDelegate {
         }
 
         let blocks = [
-            CourseListBlock(listType: .enrolled, ID: "enrolled", horizontalLimit: nil, title: NSLocalizedString("Enrolled", comment: ""), colorMode: .light, shouldShowCount: true, showControllerBlock: showController, lastStepWidgetDataSource: self, courseListCountDelegate: self, onlyLocal: false),
-            CourseListBlock(listType: .popular, ID: "popular", horizontalLimit: nil, title: NSLocalizedString("Popular", comment: ""), colorMode: .dark, shouldShowCount: false, showControllerBlock: showController, courseListCountDelegate: self, onlyLocal: false)
+            CourseListBlock(listType: .enrolled, ID: "enrolled", horizontalLimit: 14, title: NSLocalizedString("Enrolled", comment: ""), colorMode: .light, shouldShowCount: true, showControllerBlock: showController, lastStepWidgetDataSource: self, courseListCountDelegate: self, onlyLocal: false),
+            CourseListBlock(listType: .popular, ID: "popular", horizontalLimit: 14, title: NSLocalizedString("Popular", comment: ""), colorMode: .dark, shouldShowCount: false, showControllerBlock: showController, courseListCountDelegate: self, onlyLocal: false)
         ]
 
         view?.presentBlocks(blocks: blocks)

--- a/Stepic/HomeScreenPresenter.swift
+++ b/Stepic/HomeScreenPresenter.swift
@@ -32,8 +32,8 @@ class HomeScreenPresenter: LastStepWidgetDataSource, CourseListCountDelegate {
         }
 
         let blocks = [
-            CourseListBlock(listType: .enrolled, ID: "enrolled", horizontalLimit: 6, title: NSLocalizedString("Enrolled", comment: ""), colorMode: .light, shouldShowCount: true, showControllerBlock: showController, lastStepWidgetDataSource: self, courseListCountDelegate: self, onlyLocal: false),
-            CourseListBlock(listType: .popular, ID: "popular", horizontalLimit: 6, title: NSLocalizedString("Popular", comment: ""), colorMode: .dark, shouldShowCount: false, showControllerBlock: showController, courseListCountDelegate: self, onlyLocal: false)
+            CourseListBlock(listType: .enrolled, ID: "enrolled", horizontalLimit: nil, title: NSLocalizedString("Enrolled", comment: ""), colorMode: .light, shouldShowCount: true, showControllerBlock: showController, lastStepWidgetDataSource: self, courseListCountDelegate: self, onlyLocal: false),
+            CourseListBlock(listType: .popular, ID: "popular", horizontalLimit: nil, title: NSLocalizedString("Popular", comment: ""), colorMode: .dark, shouldShowCount: false, showControllerBlock: showController, courseListCountDelegate: self, onlyLocal: false)
         ]
 
         view?.presentBlocks(blocks: blocks)
@@ -120,7 +120,7 @@ struct CourseListBlock {
     let showVerticalBlock: () -> Void
     let onlyLocal: Bool
 
-    init(listType: CourseListType, ID: String, horizontalLimit: Int, title: String, colorMode: CourseListColorMode, shouldShowCount: Bool, showControllerBlock: @escaping (UIViewController) -> Void, lastStepWidgetDataSource: LastStepWidgetDataSource? = nil, courseListCountDelegate: CourseListCountDelegate? = nil, onlyLocal: Bool = false) {
+    init(listType: CourseListType, ID: String, horizontalLimit: Int?, title: String, colorMode: CourseListColorMode, shouldShowCount: Bool, showControllerBlock: @escaping (UIViewController) -> Void, lastStepWidgetDataSource: LastStepWidgetDataSource? = nil, courseListCountDelegate: CourseListCountDelegate? = nil, onlyLocal: Bool = false) {
         self.title = title
         self.colorMode = colorMode
         self.ID = ID

--- a/Stepic/en.lproj/Localizable.strings
+++ b/Stepic/en.lproj/Localizable.strings
@@ -346,6 +346,7 @@ SearchPlaceholderEmpty = "<b>Sorry</b>, we didn't find any courses matching your
 SearchPlaceholderError = "Error while searching courses. <b>Press</b> to try again";
 ChooseSearchLanguage = "Choose search language";
 Catalog = "Catalog";
+CatalogPlaceholderError = "Could not load catalog. <b>Press</b> to retry."
 
 WidgetButtonJoin = "Join";
 WidgetButtonInfo = "Info";

--- a/Stepic/en.lproj/Localizable.strings
+++ b/Stepic/en.lproj/Localizable.strings
@@ -346,7 +346,7 @@ SearchPlaceholderEmpty = "<b>Sorry</b>, we didn't find any courses matching your
 SearchPlaceholderError = "Error while searching courses. <b>Press</b> to try again";
 ChooseSearchLanguage = "Choose search language";
 Catalog = "Catalog";
-CatalogPlaceholderError = "Could not load catalog. <b>Press</b> to retry."
+CatalogPlaceholderError = "Could not load catalog. <b>Press</b> to retry.";
 
 WidgetButtonJoin = "Join";
 WidgetButtonInfo = "Info";

--- a/Stepic/ru.lproj/Localizable.strings
+++ b/Stepic/ru.lproj/Localizable.strings
@@ -347,6 +347,7 @@ SearchPlaceholderEmpty = "<b>Упс</b>, мы не нашли ни одного 
 SearchPlaceholderError = "Ошибка при поиске курсов. <b>Нажмите</b>, чтобы попробовать еще раз";
 ChooseSearchLanguage = "Выберите язык поиска";
 Catalog = "Каталог";
+CatalogPlaceholderError = "Не удалось загрузить каталог. <b>Нажмите</b> чтобы попробовать еще раз"
 
 WidgetButtonJoin = "Поступить";
 WidgetButtonInfo = "Инфо";

--- a/Stepic/ru.lproj/Localizable.strings
+++ b/Stepic/ru.lproj/Localizable.strings
@@ -347,7 +347,7 @@ SearchPlaceholderEmpty = "<b>Упс</b>, мы не нашли ни одного 
 SearchPlaceholderError = "Ошибка при поиске курсов. <b>Нажмите</b>, чтобы попробовать еще раз";
 ChooseSearchLanguage = "Выберите язык поиска";
 Catalog = "Каталог";
-CatalogPlaceholderError = "Не удалось загрузить каталог. <b>Нажмите</b> чтобы попробовать еще раз"
+CatalogPlaceholderError = "Не удалось загрузить каталог. <b>Нажмите</b> чтобы попробовать еще раз";
 
 WidgetButtonJoin = "Поступить";
 WidgetButtonInfo = "Инфо";


### PR DESCRIPTION
**Описание**:

- Фиксы для пустых состояний в Explore и для списков курсов (вылезающие артефакты на черном фоне)

- Добавили Popular в Explore

- Убрали лимиты в горизонтальной карусели (работает даже с пагинацией)

- Теперь для popular запрашиваем все курсы, а не только featured