### PR TITLE
Notifications analytics

### DIFF
--- a/Stepic/AnalyticsEvents.swift
+++ b/Stepic/AnalyticsEvents.swift
@@ -222,4 +222,9 @@ struct AnalyticsEvents {
             static let clickBanner = "settings_click_banner"
         }
     }
+
+    struct Notifications {
+        static let markAllAsRead = "notifications_mark_all_as_read"
+        static let markAsRead = "notifications_mark_as_read"
+    }
 }

--- a/Stepic/NotificationsViewController.swift
+++ b/Stepic/NotificationsViewController.swift
@@ -184,6 +184,8 @@ extension NotificationsViewController: UITableViewDelegate, UITableViewDataSourc
 extension NotificationsViewController: NotificationsTableViewCellDelegate {
     func statusButtonClicked(inCell cell: NotificationsTableViewCell, withNotificationId id: Int) {
         presenter?.updateNotification(with: id, status: .read)
+        AnalyticsReporter.reportEvent(AnalyticsEvents.Notifications.markAsRead, parameters: ["action": "button"])
+
         cell.status = .read
     }
 
@@ -193,6 +195,8 @@ extension NotificationsViewController: NotificationsTableViewCellDelegate {
             DeepLinkRouter.routeFromDeepLink(url: deepLinkingUrl, showAlertForUnsupported: false)
 
             presenter?.updateNotification(with: id, status: .read)
+            AnalyticsReporter.reportEvent(AnalyticsEvents.Notifications.markAsRead, parameters: ["action": "link"])
+
             cell.status = .read
         }
     }


### PR DESCRIPTION
**Коротко для Release Notes, в формате «Сделали/Добавили/Исправили N»**: 
Добавили аналитику для уведомлений

**Описание**:
События:
* `notifications_mark_all_as_read` – нажатие на кнопку "Отметить прочитанными все", параметр `badge` – значение бейджа (= кол-во непрочитанных)
* `notifications_mark_as_read` – отметка уведомления прочитанным, параметр `action` – в зависимости от того, открыли уведомление (`link`) или нажали на кнопку с конвертом (`button`)