### PR TITLE
Fixed Code Quiz smart quotes

### DIFF
--- a/Stepic/CodeQuizViewController.swift
+++ b/Stepic/CodeQuizViewController.swift
@@ -155,7 +155,11 @@ class CodeQuizViewController: QuizViewController {
         codeTextView.autoresizingMask = [.flexibleHeight, .flexibleWidth]
         codeTextView.autocorrectionType = UITextAutocorrectionType.no
         codeTextView.autocapitalizationType = UITextAutocapitalizationType.none
-        codeTextView.keyboardType = UIKeyboardType.asciiCapable
+        #if swift(>=3.2)
+            if #available(iOS 11.0, *) {
+                codeTextView.smartQuotesType = .no
+            }
+        #endif
         codeTextView.textColor = UIColor(white: 0.8, alpha: 1.0)
         highlightr = textStorage.highlightr
         highlightr.setTheme(to: "Androidstudio")

--- a/Stepic/FullscreenCodeQuizViewController.swift
+++ b/Stepic/FullscreenCodeQuizViewController.swift
@@ -109,7 +109,11 @@ class FullscreenCodeQuizViewController: UIViewController {
         codeTextView.autoresizingMask = [.flexibleHeight, .flexibleWidth]
         codeTextView.autocorrectionType = UITextAutocorrectionType.no
         codeTextView.autocapitalizationType = UITextAutocapitalizationType.none
-        codeTextView.keyboardType = UIKeyboardType.asciiCapable
+        #if swift(>=3.2)
+            if #available(iOS 11.0, *) {
+                codeTextView.smartQuotesType = .no
+            }
+        #endif
         codeTextView.textColor = UIColor(white: 0.8, alpha: 1.0)
         highlightr = textStorage.highlightr
         highlightr.setTheme(to: "Androidstudio")


### PR DESCRIPTION
**Задача**: [#APPS-1711](https://vyahhi.myjetbrains.com/youtrack/issue/APPS-1711)

**Коротко для Release Notes, в формате «Сделали/Добавили/Исправили N»**: 
Теперь можно переключить клавиатуру на локальный язык

**Описание**:
Раньше для фикса проблемы с автоматической автокоррекцией для `UITextView` в код квизе был переделан `UIKeyboardType` на `.asciiCapable` [#117](https://github.com/StepicOrg/stepik-ios/pull/117).
Сейчас для iOS 11 просто ставим `smartQuotesType = .no`. 