### PR TITLE
Fix deeplinks crash

### DIFF
--- a/Stepic/NotificationsAPI.swift
+++ b/Stepic/NotificationsAPI.swift
@@ -81,13 +81,17 @@ class NotificationsAPI: APIEndpoint {
                     reject(error)
                 case .success(_):
                     if response.response?.statusCode != 204 {
-                        reject(NSError()) // raw error here
+                        reject(NotificationsAPIError.invalidStatus)
                     } else {
                         fulfill()
                     }
                 }
-
             }
         }
     }
+}
+
+// TODO: replace this class by generic error class
+enum NotificationsAPIError: Error {
+    case invalidStatus
 }

--- a/Stepic/StepsControllerDeepLinkRouter.swift
+++ b/Stepic/StepsControllerDeepLinkRouter.swift
@@ -67,7 +67,7 @@ class StepsControllerDeepLinkRouter: NSObject {
         func fetchOrLoadSection(for unit: Unit) -> Promise<Section> {
             return Promise { fulfill, reject in
                 if let sections = try? Section.getSections(unit.sectionId),
-                   let section = sections.first, section.courseId != -1 {
+                   let section = sections.first, section.courseId != 0 {
                     fulfill(section)
                     return
                 }
@@ -79,7 +79,7 @@ class StepsControllerDeepLinkRouter: NSObject {
 
                         fulfill(section)
                     } else {
-                        reject(NSError()) // no ideas what we should throw here...
+                        reject(NSError(domain: "", code: -1, userInfo: nil)) // no ideas what we should throw here...
                     }
                 }, error: { err in
                     reject(err)
@@ -101,7 +101,7 @@ class StepsControllerDeepLinkRouter: NSObject {
 
                         fulfill(course)
                     } else {
-                        reject(NSError())
+                        reject(NSError(domain: "", code: -1, userInfo: nil))
                     }
                 }, error: { err in
                     reject(err)


### PR DESCRIPTION
**Задача**: [#APPS-1718](https://vyahhi.myjetbrains.com/youtrack/issue/APPS-1718)

**Коротко для Release Notes, в формате «Сделали/Добавили/Исправили N»**: 
Исправлен краш при открытии степа по диплинку

**Описание**:
Вызов `reject(NSError())` приводил к крашу. Исправлено дефолтное значение после миграции (0, а не -1).

