### PR TITLE
Fix issue with deviceId

### DIFF
--- a/Stepic/AnalyticsEvents.swift
+++ b/Stepic/AnalyticsEvents.swift
@@ -168,6 +168,8 @@ struct AnalyticsEvents {
 
     struct Errors {
         static let tokenRefresh = "error_token_refresh"
+        static let unregisterDeviceInvalidCredentials = "error_unregister_device_credentials"
+        static let registerDevice = "error_register_device"
     }
 
     struct Continue {

--- a/Stepic/AuthInfo.swift
+++ b/Stepic/AuthInfo.swift
@@ -79,6 +79,7 @@ class AuthInfo: NSObject {
                         CoreDataHelper.instance.save()
 
                         AuthInfo.shared.user = nil
+                        DeviceDefaults.sharedDefaults.deviceId = nil
 
                         self.setTokenValue(nil)
                     }

--- a/Stepic/DevicesAPI.swift
+++ b/Stepic/DevicesAPI.swift
@@ -42,7 +42,7 @@ class DevicesAPI: APIEndpoint {
                         case 403, 404:
                             return reject(DeviceError.notFound)
                         default:
-                            return reject(DeviceError.other(error: nil, code: r.statusCode, message: json["detail"].string))
+                            return reject(DeviceError.other(error: nil, code: r.statusCode, message: json.rawString()))
                         }
                     }
 
@@ -73,7 +73,7 @@ class DevicesAPI: APIEndpoint {
                         case 404:
                             return reject(DeviceError.notFound)
                         default:
-                            return reject(DeviceError.other(error: nil, code: r.statusCode, message: json["detail"].string))
+                            return reject(DeviceError.other(error: nil, code: r.statusCode, message: json.rawString()))
                         }
                     }
 
@@ -98,7 +98,7 @@ class DevicesAPI: APIEndpoint {
                         case 404:
                             return reject(DeviceError.notFound)
                         default:
-                            return reject(DeviceError.other(error: nil, code: r.statusCode, message: json["detail"].string))
+                            return reject(DeviceError.other(error: nil, code: r.statusCode, message: json.rawString()))
                         }
                     }
 
@@ -121,7 +121,7 @@ class DevicesAPI: APIEndpoint {
                         case 404:
                             return reject(DeviceError.notFound)
                         default:
-                            return reject(DeviceError.other(error: nil, code: r.statusCode, message: json["detail"].string))
+                            return reject(DeviceError.other(error: nil, code: r.statusCode, message: json.rawString()))
                         }
                     }
 
@@ -144,7 +144,7 @@ class DevicesAPI: APIEndpoint {
                         case 404:
                             return reject(DeviceError.notFound)
                         default:
-                            return reject(DeviceError.other(error: nil, code: r.statusCode, message: json["detail"].string))
+                            return reject(DeviceError.other(error: nil, code: r.statusCode, message: json.rawString()))
                         }
                     }
 

--- a/Stepic/DevicesAPI.swift
+++ b/Stepic/DevicesAPI.swift
@@ -108,7 +108,7 @@ class DevicesAPI: APIEndpoint {
         }
     }
 
-    func delete(_ deviceId: Int, headers: [String: String] = AuthInfo.shared.initialHTTPHeaders) -> Promise<Void> {
+    func delete(_ deviceId: Int, headers: [String: String] = APIDefaults.headers.bearer) -> Promise<Void> {
         return Promise { fulfill, reject in
             manager.request("\(StepicApplicationsInfo.apiURL)/devices/\(deviceId)", method: .delete, headers: headers).responseSwiftyJSON { response in
                 switch response.result {

--- a/Stepic/NotificationRegistrator.swift
+++ b/Stepic/NotificationRegistrator.swift
@@ -47,16 +47,13 @@ class NotificationRegistrator {
 
         let newDevice = Device(registrationId: registrationToken, deviceDescription: DeviceInfo.current.deviceInfoString)
 
-        var updatingPromise: Promise<Device>!
-        if let savedDeviceId = DeviceDefaults.sharedDefaults.deviceId, !forceCreation {
-            print("notification registrator: retrieve device by saved deviceId = \(savedDeviceId)")
-            updatingPromise = ApiDataDownloader.devices.retrieve(deviceId: savedDeviceId)
-        } else {
-            updatingPromise = ApiDataDownloader.devices.create(newDevice)
-        }
-
         checkToken().then { _ -> Promise<Device> in
-            return updatingPromise
+            if let savedDeviceId = DeviceDefaults.sharedDefaults.deviceId, !forceCreation {
+                print("notification registrator: retrieve device by saved deviceId = \(savedDeviceId)")
+                return ApiDataDownloader.devices.retrieve(deviceId: savedDeviceId)
+            } else {
+                return ApiDataDownloader.devices.create(newDevice)
+            }
         }.then { remoteDevice -> Promise<Device> in
             if remoteDevice.isBadgesEnabled {
                 return Promise(value: remoteDevice)

--- a/Stepic/NotificationRegistrator.swift
+++ b/Stepic/NotificationRegistrator.swift
@@ -72,8 +72,12 @@ class NotificationRegistrator {
             case DeviceError.notFound:
                 print("notification registrator: device not found, create new")
                 self.registerDevice(registrationToken, forceCreation: true)
+            case DeviceError.other(_, _, let message):
+                print("notification registrator: device registration error, error = \(String(describing: message))")
+                AnalyticsReporter.reportEvent(AnalyticsEvents.Errors.registerDevice, parameters: ["message": "\(String(describing: message))"])
             default:
                 print("notification registrator: device registration error, error = \(error)")
+                AnalyticsReporter.reportEvent(AnalyticsEvents.Errors.registerDevice, parameters: ["message": "\(error.localizedDescription)"])
             }
         }
     }
@@ -107,6 +111,7 @@ class NotificationRegistrator {
                             queuePersistencyManager.writeQueue(ExecutionQueues.sharedQueues.connectionAvailableExecutionQueue, key: ExecutionQueues.sharedQueues.connectionAvailableExecutionQueueKey)
                         } else {
                             print("notification registrator: could not get current user ID or token to delete device")
+                            AnalyticsReporter.reportEvent(AnalyticsEvents.Errors.unregisterDeviceInvalidCredentials)
                         }
                     }
                     fulfill()

--- a/Stepic/NotificationRegistrator.swift
+++ b/Stepic/NotificationRegistrator.swift
@@ -84,13 +84,11 @@ class NotificationRegistrator {
             if let deviceId = DeviceDefaults.sharedDefaults.deviceId {
                 ApiDataDownloader.devices.delete(deviceId).then { () -> Void in
                     print("notification registrator: successfully delete device, id = \(deviceId)")
-                    DeviceDefaults.sharedDefaults.deviceId = nil
                     fulfill()
                 }.catch { error in
                     switch error {
                     case DeviceError.notFound:
                         print("notification registrator: device not found on deletion, id = \(deviceId)")
-                        DeviceDefaults.sharedDefaults.deviceId = nil
                     default:
                         if let userId = AuthInfo.shared.userId,
                            let token = AuthInfo.shared.token {
@@ -106,8 +104,6 @@ class NotificationRegistrator {
 
                             let queuePersistencyManager = PersistentQueueRecoveryManager(baseName: "Queues")
                             queuePersistencyManager.writeQueue(ExecutionQueues.sharedQueues.connectionAvailableExecutionQueue, key: ExecutionQueues.sharedQueues.connectionAvailableExecutionQueueKey)
-
-                            DeviceDefaults.sharedDefaults.deviceId = nil
                         } else {
                             print("notification registrator: could not get current user ID or token to delete device")
                         }

--- a/Stepic/NotificationRegistrator.swift
+++ b/Stepic/NotificationRegistrator.swift
@@ -54,7 +54,9 @@ class NotificationRegistrator {
             updatingPromise = ApiDataDownloader.devices.create(newDevice)
         }
 
-        updatingPromise.then { remoteDevice -> Promise<Device> in
+        checkToken().then { _ -> Promise<Device> in
+            return updatingPromise
+        }.then { remoteDevice -> Promise<Device> in
             if remoteDevice.isBadgesEnabled {
                 return Promise(value: remoteDevice)
             } else {

--- a/Stepic/NotificationRegistrator.swift
+++ b/Stepic/NotificationRegistrator.swift
@@ -49,6 +49,7 @@ class NotificationRegistrator {
 
         var updatingPromise: Promise<Device>!
         if let savedDeviceId = DeviceDefaults.sharedDefaults.deviceId, !forceCreation {
+            print("notification registrator: retrieve device by saved deviceId = \(savedDeviceId)")
             updatingPromise = ApiDataDownloader.devices.retrieve(deviceId: savedDeviceId)
         } else {
             updatingPromise = ApiDataDownloader.devices.create(newDevice)


### PR DESCRIPTION
**Коротко для Release Notes, в формате «Сделали/Добавили/Исправили N»**: 
Исправление проблемы с сохраненным deviceId

**Описание**:
Из-за того, что в версиях до 1.49 не удалялся сохраненный deviceId возможна ситуация, когда после обновления при каждой попытке регистрации устройства получали not found. 
Теперь если получили not found, пробуем зарегистрировать устройство. 
Также добавлен рефреш токена, без него невозможен `retrieve` и `create` в ситуации с протухшим токеном.