### PR TITLE
Fix url scheme crash

### DIFF
--- a/Stepic/WebControllerManager.swift
+++ b/Stepic/WebControllerManager.swift
@@ -59,6 +59,14 @@ class WebControllerManager: NSObject {
     }
 
     func presentWebControllerWithURL(_ url: URL, inController c: UIViewController, withKey key: String, allowsSafari: Bool, backButtonStyle: BackButtonStyle, animated: Bool = true, forceCustom: Bool = false) {
+        guard ["http", "https"].contains(url.scheme?.lowercased() ?? "") else {
+            if #available(iOS 10.0, *) {
+                UIApplication.shared.open(url, options: [:], completionHandler: nil)
+            } else {
+                UIApplication.shared.openURL(url)
+            }
+            return
+        }
 
         if !forceCustom {
             let svc = SFSafariViewController(url: url)


### PR DESCRIPTION
**Задача**: [#APPS-1707](https://vyahhi.myjetbrains.com/youtrack/issue/APPS-1707)

**Коротко для Release Notes, в формате «Сделали/Добавили/Исправили N»**: 
Исправили краш при открытии ссылок с некоторыми схемами

**Описание**:
Открываем с помощью WebViewController/SFSafariViewController только ссылки с протоколами http и https.
