### PR TITLE
AuthInit crash fix

### DIFF
--- a/Stepic/AnalyticsEvents.swift
+++ b/Stepic/AnalyticsEvents.swift
@@ -170,6 +170,7 @@ struct AnalyticsEvents {
         static let tokenRefresh = "error_token_refresh"
         static let unregisterDeviceInvalidCredentials = "error_unregister_device_credentials"
         static let registerDevice = "error_register_device"
+        static let authInfoNoUserOnInit = "error_AuthInfo_no_user_on_init"
     }
 
     struct Continue {

--- a/Stepic/AuthInfo.swift
+++ b/Stepic/AuthInfo.swift
@@ -19,31 +19,7 @@ class AuthInfo: NSObject {
         print("initializing AuthInfo with userId \(String(describing: userId))")
         if let id = userId {
             if let users = User.fetchById(id) {
-                let c = users.count
-                if c == 0 {
-                    print("No user with such id found, downloading")
-                    ApiDataDownloader.users.retrieve(ids: [id], existing: [], refreshMode: .update, success: {
-                        [weak self]
-                        users in
-                        if let user = users.first {
-                            self?.user = user
-                            return
-                        }
-                        print("downloaded user")
-                        CoreDataHelper.instance.save()
-
-                        }, error: {
-                            [weak self]
-                            _ in
-                            print("failed to fetch user")
-                            self?.userId = nil
-                    })
-                }
-
-                if c >= 1 {
-                    user = users.first
-                }
-
+                user = users.first
             }
         }
     }

--- a/Stepic/AuthInfo.swift
+++ b/Stepic/AuthInfo.swift
@@ -19,7 +19,11 @@ class AuthInfo: NSObject {
         print("initializing AuthInfo with userId \(String(describing: userId))")
         if let id = userId {
             if let users = User.fetchById(id) {
-                user = users.first
+                if users.isEmpty {
+                    AnalyticsReporter.reportEvent(AnalyticsEvents.Errors.authInfoNoUserOnInit)
+                } else {
+                    user = users.first
+                }
             }
         }
     }


### PR DESCRIPTION
**Задача**: [#APPS-1725](https://vyahhi.myjetbrains.com/youtrack/issue/APPS-1725)

**Коротко для Release Notes, в формате «Сделали/Добавили/Исправили N»**: 
Вероятно, исправлен самый популярный краш

**Описание**:
Убрал реквест в init-е для AuthInfo. Надеюсь, это все исправит. Если нет - будем искать дальше. Краш этот воспроизвести так ни разу и не удалось.