### PR TITLE
Fixed time picker crash

### DIFF
--- a/Stepic.xcodeproj/xcuserdata/Ostrenkiy.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/Stepic.xcodeproj/xcuserdata/Ostrenkiy.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -122,7 +122,7 @@
 		<key>StepikTV.xcscheme</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>90</integer>
+			<integer>92</integer>
 		</dict>
 		<key>StickerPackExtension.xcscheme</key>
 		<dict>

--- a/Stepic/CurrentBestStreakViewController.swift
+++ b/Stepic/CurrentBestStreakViewController.swift
@@ -118,7 +118,7 @@ class CurrentBestStreakViewController: UIViewController {
 
     func selectStreakNotificationTime() {
         let vc = NotificationTimePickerViewController(nibName: "PickerViewController", bundle: nil) as NotificationTimePickerViewController
-        vc.startHour = (PreferencesContainer.notifications.streaksNotificationStartHourUTC + NSTimeZone.system.secondsFromGMT() / 60 / 60 ) % 24
+        vc.startHour = PreferencesContainer.notifications.streaksNotificationStartHourLocal
         vc.cancelAction = {
             [weak self] in
             self?.receiveNotificationsSwitch.isOn = false

--- a/Stepic/NotificationPreferencesContainer.swift
+++ b/Stepic/NotificationPreferencesContainer.swift
@@ -43,4 +43,9 @@ class NotificationPreferencesContainer {
             defaults.synchronize()
         }
     }
+
+    var streaksNotificationStartHourLocal: Int {
+        let time = (PreferencesContainer.notifications.streaksNotificationStartHourUTC + NSTimeZone.system.secondsFromGMT() / 60 / 60 ) % 24
+        return time < 0 ? 24 + time : time
+    }
 }

--- a/Stepic/ProfilePresenter.swift
+++ b/Stepic/ProfilePresenter.swift
@@ -79,7 +79,8 @@ class ProfilePresenter {
     private var currentZone00UTC: String {
         let date = Date(timeIntervalSince1970: 0)
         let dateFormatter = DateFormatter()
-        dateFormatter.dateFormat = "hh:mm"
+        dateFormatter.dateStyle = .none
+        dateFormatter.timeStyle = .short
         dateFormatter.timeZone = TimeZone.current
         return dateFormatter.string(from: date)
     }
@@ -231,7 +232,7 @@ class ProfilePresenter {
     }
 
     private func presentStreakTimeSelection(forBlock block: TransitionMenuBlock) {
-        let startHour = (PreferencesContainer.notifications.streaksNotificationStartHourUTC + NSTimeZone.system.secondsFromGMT() / 60 / 60 ) % 24
+        let startHour = PreferencesContainer.notifications.streaksNotificationStartHourLocal
         view?.showStreakTimeSelectionAlert(startHour: startHour, selectedBlock: {
             [weak self] in
             block.title = "\(NSLocalizedString("NotificationTime", comment: "")): \(self?.notificationTimeString ?? "")"

--- a/Stepic/StreaksAlertPresentationManager.swift
+++ b/Stepic/StreaksAlertPresentationManager.swift
@@ -63,7 +63,7 @@ class StreaksAlertPresentationManager {
             return
         }
         let vc = NotificationTimePickerViewController(nibName: "PickerViewController", bundle: nil) as NotificationTimePickerViewController
-        vc.startHour = (PreferencesContainer.notifications.streaksNotificationStartHourUTC + NSTimeZone.system.secondsFromGMT() / 60 / 60 ) % 24
+        vc.startHour = PreferencesContainer.notifications.streaksNotificationStartHourLocal
         vc.selectedBlock = {
             [weak self] in
             if let source = self?.source?.rawValue {


### PR DESCRIPTION
**Задача**: [#APPS-1737](https://vyahhi.myjetbrains.com/youtrack/issue/APPS-1737)

**Коротко для Release Notes, в формате «Сделали/Добавили/Исправили N»**: 
Исправили краш в пикере времени стрика для отрицательных таймзон

**Описание**:
[Краш](https://fabric.io/alexander-karpovs-projects3/ios/apps/com.alexkarpov.stepic/issues/59a95c6abe077a4dccf38cc9?time=last-twenty-four-hours) возникал, если выбрать время в отрицательной таймзоне. Проверить это можно поменяв таймзону на маке на какое-нибудь американское время, а потом нажав на кнопку выбора времени стрика. 
Также исправлена ошибка, когда неверно для отрицательных таймзон отображалось время обновления стриков внутри локального часового пояса под свитчем в профиле. 