### PR TITLE
Write discussion layout fix

### DIFF
--- a/Stepic/DiscussionsStoryboard.storyboard
+++ b/Stepic/DiscussionsStoryboard.storyboard
@@ -5,7 +5,6 @@
     </device>
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13772"/>
-        <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -18,30 +17,54 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="dCz-M7-3Sb" customClass="IQTextView" customModule="IQKeyboardManagerSwift">
-                                <rect key="frame" x="16" y="20" width="343" height="647"/>
-                                <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
-                            </textView>
+                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="QDg-Gj-0a5">
+                                <rect key="frame" x="0.0" y="20" width="375" height="647"/>
+                                <subviews>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="c5P-Nm-s1b">
+                                        <rect key="frame" x="0.0" y="0.0" width="375" height="647"/>
+                                        <subviews>
+                                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="UjI-WA-3Vc" customClass="IQTextView" customModule="IQKeyboardManagerSwift">
+                                                <rect key="frame" x="0.0" y="0.0" width="375" height="647"/>
+                                                <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
+                                            </textView>
+                                        </subviews>
+                                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <constraints>
+                                            <constraint firstItem="UjI-WA-3Vc" firstAttribute="leading" secondItem="c5P-Nm-s1b" secondAttribute="leading" id="9eS-WX-GVL"/>
+                                            <constraint firstAttribute="bottom" secondItem="UjI-WA-3Vc" secondAttribute="bottom" id="Bgw-n0-PdL"/>
+                                            <constraint firstItem="UjI-WA-3Vc" firstAttribute="top" secondItem="c5P-Nm-s1b" secondAttribute="top" id="hjp-Xh-w96"/>
+                                            <constraint firstAttribute="trailing" secondItem="UjI-WA-3Vc" secondAttribute="trailing" id="tGu-dN-Hkk"/>
+                                        </constraints>
+                                    </view>
+                                </subviews>
+                                <constraints>
+                                    <constraint firstAttribute="bottom" secondItem="c5P-Nm-s1b" secondAttribute="bottom" id="49u-aV-USe"/>
+                                    <constraint firstItem="c5P-Nm-s1b" firstAttribute="leading" secondItem="QDg-Gj-0a5" secondAttribute="leading" id="N55-cd-U8a"/>
+                                    <constraint firstItem="c5P-Nm-s1b" firstAttribute="centerY" secondItem="QDg-Gj-0a5" secondAttribute="centerY" id="Pak-9Q-7e2"/>
+                                    <constraint firstItem="c5P-Nm-s1b" firstAttribute="top" secondItem="QDg-Gj-0a5" secondAttribute="top" id="if2-bM-TJo"/>
+                                    <constraint firstAttribute="trailing" secondItem="c5P-Nm-s1b" secondAttribute="trailing" id="xDq-ph-ZvF"/>
+                                </constraints>
+                            </scrollView>
                         </subviews>
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
-                            <constraint firstAttribute="bottom" secondItem="dCz-M7-3Sb" secondAttribute="bottom" id="D6T-dy-ljG"/>
-                            <constraint firstItem="tla-KX-M42" firstAttribute="trailing" secondItem="dCz-M7-3Sb" secondAttribute="trailing" constant="16" id="FhS-np-uq3"/>
-                            <constraint firstItem="dCz-M7-3Sb" firstAttribute="top" secondItem="PoY-wT-x23" secondAttribute="topMargin" placeholder="YES" id="f9d-i8-r8g"/>
-                            <constraint firstItem="dCz-M7-3Sb" firstAttribute="leading" secondItem="tla-KX-M42" secondAttribute="leading" constant="16" id="pe0-4F-KnT"/>
+                            <constraint firstItem="tla-KX-M42" firstAttribute="trailing" secondItem="QDg-Gj-0a5" secondAttribute="trailing" id="Bk7-6p-b5N"/>
+                            <constraint firstItem="QDg-Gj-0a5" firstAttribute="leading" secondItem="tla-KX-M42" secondAttribute="leading" id="NBX-RQ-Yvd"/>
+                            <constraint firstItem="c5P-Nm-s1b" firstAttribute="width" secondItem="PoY-wT-x23" secondAttribute="width" id="cXt-ee-1tV"/>
+                            <constraint firstItem="tla-KX-M42" firstAttribute="bottom" secondItem="QDg-Gj-0a5" secondAttribute="bottom" id="knv-aL-AxJ"/>
+                            <constraint firstItem="tla-KX-M42" firstAttribute="top" secondItem="QDg-Gj-0a5" secondAttribute="top" id="nvq-Xj-wkM"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="tla-KX-M42"/>
                     </view>
                     <connections>
-                        <outlet property="IQLayoutGuideConstraint" destination="D6T-dy-ljG" id="kWB-zC-O3K"/>
-                        <outlet property="commentTextView" destination="dCz-M7-3Sb" id="uXx-qF-UyN"/>
+                        <outlet property="commentTextView" destination="UjI-WA-3Vc" id="Osq-OV-G1q"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="0bX-o0-I8a" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="533" y="472"/>
+            <point key="canvasLocation" x="532" y="471.8140929535233"/>
         </scene>
     </scenes>
 </document>

--- a/Stepic/WriteCommentViewController.swift
+++ b/Stepic/WriteCommentViewController.swift
@@ -63,10 +63,6 @@ class WriteCommentViewController: UIViewController {
         print("should have never been pressed")
     }
 
-    private func setupTopConstraint() {
-//        commentTextView.alignTopEdge(withView: self.view, predicate: "0")
-    }
-
     override func viewDidLoad() {
         super.viewDidLoad()
 
@@ -78,8 +74,6 @@ class WriteCommentViewController: UIViewController {
 
         commentTextView.tintColor = UIColor.mainDark
         commentTextView.textColor = UIColor.mainText
-
-        setupTopConstraint()
 
         state = .editing
     }

--- a/Stepic/WriteCommentViewController.swift
+++ b/Stepic/WriteCommentViewController.swift
@@ -64,7 +64,7 @@ class WriteCommentViewController: UIViewController {
     }
 
     private func setupTopConstraint() {
-        commentTextView.alignTopEdge(withView: self.view, predicate: "0")
+//        commentTextView.alignTopEdge(withView: self.view, predicate: "0")
     }
 
     override func viewDidLoad() {


### PR DESCRIPTION
**Задача**: [#APPS-1776](https://vyahhi.myjetbrains.com/youtrack/issue/APPS-1776)

**Коротко для Release Notes, в формате «Сделали/Добавили/Исправили N»**: 
Исправили баг, когда лейаут при написании комментария уезжал наверх и никогда не возвращался

**Описание**:
Добавил `UIScrollView` под текствьюшку, чтобы все работало хорошо. Проблема была в `IQKeyboardManager`, который двигал вверх от клавиатуры всю вьюшку вместе с navigation-ом, а потом забывал ее возвращать.