### PR TITLE
Fixed crash in adaptive images callout

### DIFF
--- a/Stepic/CardStepViewController.swift
+++ b/Stepic/CardStepViewController.swift
@@ -146,7 +146,10 @@ extension CardStepViewController: WKNavigationDelegate {
     }
 
     func alignImages(in webView: WKWebView) -> Promise<Void> {
-        var jsCode = "document.documentElement.style.webkitTouchCallout='none'; var imgs = document.getElementsByTagName('img');"
+        // Disable WebKit callout on long press
+        var jsCode = "document.documentElement.style.webkitTouchCallout='none';"; 
+        // Center images
+        jsCode += "var imgs = document.getElementsByTagName('img');"
         jsCode += "for (var i = 0; i < imgs.length; i++){ imgs[i].style.marginLeft = (document.body.clientWidth / 2) - (imgs[i].clientWidth / 2) - 8 }"
 
         return Promise { fulfill, reject in

--- a/Stepic/CardStepViewController.swift
+++ b/Stepic/CardStepViewController.swift
@@ -146,7 +146,7 @@ extension CardStepViewController: WKNavigationDelegate {
     }
 
     func alignImages(in webView: WKWebView) -> Promise<Void> {
-        var jsCode = "var imgs = document.getElementsByTagName('img');"
+        var jsCode = "document.documentElement.style.webkitTouchCallout='none'; var imgs = document.getElementsByTagName('img');"
         jsCode += "for (var i = 0; i < imgs.length; i++){ imgs[i].style.marginLeft = (document.body.clientWidth / 2) - (imgs[i].clientWidth / 2) - 8 }"
 
         return Promise { fulfill, reject in


### PR DESCRIPTION
**Задача**: [#APPS-1780](https://vyahhi.myjetbrains.com/youtrack/issue/APPS-1780)

**Коротко для Release Notes, в формате «Сделали/Добавили/Исправили N»**: 
Исправили краш при сохранении изображения в адаптивном степе

**Описание**:
Из-за того, что используется WKWebView вместо UIWebView, доступен callout. При попытке сохранения на устройство – краш из-за недостатка прав.
Решение: исполнить js код c ```document.documentElement.style.webkitTouchCallout='none'```
