### PR TITLE
Fixed matching height reload bug

### DIFF
--- a/Stepic/MatchingQuizViewController.swift
+++ b/Stepic/MatchingQuizViewController.swift
@@ -85,7 +85,8 @@ class MatchingQuizViewController: QuizViewController {
 
         self.firstCellHeights = Array(repeating: nil, count: optionsCount)
         self.secondCellHeights = Array(repeating: nil, count: optionsCount)
-
+        self.firstUpdateFinished = false
+        self.secondUpdateFinished = false
         self.firstTableView.reloadData()
         self.secondTableView.reloadData()
 
@@ -118,6 +119,8 @@ class MatchingQuizViewController: QuizViewController {
         optionsPermutation = reply.ordering
         orderedOptions = o
 
+        self.firstUpdateFinished = false
+        self.secondUpdateFinished = false
         self.firstTableView.reloadData()
         self.secondTableView.reloadData()
     }


### PR DESCRIPTION
**Задача**: [#APPS-1781](https://vyahhi.myjetbrains.com/youtrack/issue/APPS-1781)

**Коротко для Release Notes, в формате «Сделали/Добавили/Исправили N»**: 
Исправлена ошибка с перезагрузкой высоты matching квиза

**Описание**:
Не всегда применялись апдейты высоты. Теперь всегда.