### PR TITLE
Fixed CourseList crash on deleting the only course

### DIFF
--- a/Stepic/CardStepViewController.swift
+++ b/Stepic/CardStepViewController.swift
@@ -147,7 +147,7 @@ extension CardStepViewController: WKNavigationDelegate {
 
     func alignImages(in webView: WKWebView) -> Promise<Void> {
         // Disable WebKit callout on long press
-        var jsCode = "document.documentElement.style.webkitTouchCallout='none';"; 
+        var jsCode = "document.documentElement.style.webkitTouchCallout='none';"
         // Center images
         jsCode += "var imgs = document.getElementsByTagName('img');"
         jsCode += "for (var i = 0; i < imgs.length; i++){ imgs[i].style.marginLeft = (document.body.clientWidth / 2) - (imgs[i].clientWidth / 2) - 8 }"

--- a/Stepic/CourseListPresenter.swift
+++ b/Stepic/CourseListPresenter.swift
@@ -434,6 +434,7 @@ class CourseListPresenter {
             }
             if !oldDisplayedCourses.isEmpty && newDisplayedCourses.isEmpty {
                 self.state = .empty
+                return
             }
             if oldDisplayedCourses.count - deletedIds.count + addedIds.count == newDisplayedCourses.count {
                 view?.update(deletingIds: deletedIds, insertingIds: addedIds, courses: getData(from: newDisplayedCourses))


### PR DESCRIPTION
**Задача**: [#APPS-1782](https://vyahhi.myjetbrains.com/youtrack/issue/APPS-1782)

**Коротко для Release Notes, в формате «Сделали/Добавили/Исправили N»**: 
Исправили https://fabric.io/alexander-karpovs-projects3/ios/apps/com.alexkarpov.stepic/issues/5a70728d8cb3c2fa63eaee19?time=last-ninety-days

**Описание**:
Воспроизвести баг получилось следующим образом:
* Зарегистрировать новый аккаунт
* Записаться на курс
* Отписаться от него
* Краш

Такое получалось из-за того, что при изменении стейта на `.empty` и, соответственно,  `reloadData()`, мы пытаемся еще раз анимировать изменения, что приводит к ошибке.