### PR TITLE
Auth after onboarding

### DIFF
--- a/Stepic/OnboardingViewController.swift
+++ b/Stepic/OnboardingViewController.swift
@@ -26,6 +26,10 @@ class OnboardingViewController: UIViewController {
     private var scrollView: UIScrollView!
     fileprivate var pages: [OnboardingPageView] = []
 
+    var authSource: UIViewController? {
+        return (UIApplication.shared.delegate as? AppDelegate)?.window?.rootViewController
+    }
+
     private var backgroundGradient: CAGradientLayer = CAGradientLayer(colors: [UIColor(hex: 0x3a3947), UIColor(hex: 0x5d6780)], rotationAngle: -50.0)
 
     private var titles = (1...4).map { NSLocalizedString("OnboardingTitle\($0)", comment: "")}
@@ -186,7 +190,10 @@ class OnboardingViewController: UIViewController {
             scrollView.setContentOffset(CGPoint(x: newScrollViewContentOffsetX, y: scrollView.contentOffset.y), animated: true)
         } else {
             AnalyticsReporter.reportEvent(AnalyticsEvents.Onboarding.onboardingComplete, parameters: ["screen": currentPageIndex + 1])
-            dismiss(animated: true, completion: nil)
+            self.dismiss(animated: true, completion: nil)
+            if let authSource = authSource {
+                RoutingManager.auth.routeFrom(controller: authSource, success: nil, cancel: nil)
+            }
         }
     }
 }

--- a/Stepic/OnboardingViewController.swift
+++ b/Stepic/OnboardingViewController.swift
@@ -190,7 +190,7 @@ class OnboardingViewController: UIViewController {
             scrollView.setContentOffset(CGPoint(x: newScrollViewContentOffsetX, y: scrollView.contentOffset.y), animated: true)
         } else {
             AnalyticsReporter.reportEvent(AnalyticsEvents.Onboarding.onboardingComplete, parameters: ["screen": currentPageIndex + 1])
-            self.dismiss(animated: true, completion: nil)
+            dismiss(animated: true, completion: nil)
             if let authSource = authSource {
                 RoutingManager.auth.routeFrom(controller: authSource, success: nil, cancel: nil)
             }


### PR DESCRIPTION
**Задача**: [#APPS-1794](https://vyahhi.myjetbrains.com/youtrack/issue/APPS-1794)

**Коротко для Release Notes, в формате «Сделали/Добавили/Исправили N»**: 

**Описание**:
После нажатия на кнопку Next в последнем контроллере онбординга дисмиссим онбординг и презентуем Auth.