### PR TITLE
Remove app from simulator before tests

### DIFF
--- a/Stepic.xcodeproj/project.pbxproj
+++ b/Stepic.xcodeproj/project.pbxproj
@@ -8332,6 +8332,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 085D5CE21D007F2200092060 /* Build configuration list for PBXNativeTarget "StepicTests" */;
 			buildPhases = (
+				2C47A16C206297D0003E87EC /* ShellScript */,
 				017B714BD9D996178EA110BD /* [CP] Check Pods Manifest.lock */,
 				085D5CD51D007F2100092060 /* Sources */,
 				085D5CD61D007F2100092060 /* Frameworks */,
@@ -10228,6 +10229,19 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint\nfi";
+		};
+		2C47A16C206297D0003E87EC /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "/usr/bin/xcrun simctl uninstall booted com.AlexKarpov.Stepic\n\n";
 		};
 		2C89AB331F4C289900227C3B /* Fabric Script */ = {
 			isa = PBXShellScriptBuildPhase;


### PR DESCRIPTION
**Описание**:
Исправлены падающие из-за закешированных данных тесты – в таргет `StepicTests` добавлен этап с удалением приложения с BundleId `com.AlexKarpov.Stepic` с запущенного симулятора.