### PR TITLE
Fix crash in discussions

### DIFF
--- a/Stepic/DiscussionsViewController.swift
+++ b/Stepic/DiscussionsViewController.swift
@@ -43,7 +43,7 @@ class DiscussionsViewController: UIViewController {
     var discussionProxyId: String!
     var target: Int!
 
-    // This var uses only for incrementing discussions count
+    // This var is used only for incrementing discussions count
     var step: Step?
 
     @IBOutlet weak var tableView: UITableView!

--- a/Stepic/DiscussionsViewController.swift
+++ b/Stepic/DiscussionsViewController.swift
@@ -42,7 +42,9 @@ class DiscussionsViewController: UIViewController {
 
     var discussionProxyId: String!
     var target: Int!
-    var step: Step!
+
+    // This var uses only for incrementing discussions count
+    var step: Step?
 
     @IBOutlet weak var tableView: UITableView!
 
@@ -725,7 +727,7 @@ extension DiscussionsViewController : WriteCommentDelegate {
             discussionIds.loaded.insert(comment.id, at: 0)
             discussions.insert(comment, at: 0)
             reloadTableData()
-            step.discussionsCount? += 1
+            step?.discussionsCount? += 1
         }
     }
 }

--- a/Stepic/VideoStepViewController.swift
+++ b/Stepic/VideoStepViewController.swift
@@ -165,6 +165,10 @@ class VideoStepViewController: UIViewController {
         let downloadItem = UIBarButtonItem(customView: itemView)
         let shareBarButtonItem = UIBarButtonItem(barButtonSystemItem: UIBarButtonSystemItem.action, target: self, action: #selector(VideoStepViewController.sharePressed(_:)))
         nItem.rightBarButtonItems = [shareBarButtonItem, downloadItem]
+
+        if let discussionCount = step.discussionsCount {
+            discussionCountView.commentsCount = discussionCount
+        }
     }
 
     override func didReceiveMemoryWarning() {
@@ -253,6 +257,7 @@ class VideoStepViewController: UIViewController {
             let vc = DiscussionsViewController(nibName: "DiscussionsViewController", bundle: nil)
             vc.discussionProxyId = discussionProxyId
             vc.target = self.step.id
+            vc.step = self.step
             nController?.pushViewController(vc, animated: true)
         } else {
             //TODO: Load comments here


### PR DESCRIPTION
**Задача**: [#APPS-1838](https://vyahhi.myjetbrains.com/youtrack/issue/APPS-1838)

**Коротко для Release Notes, в формате «Сделали/Добавили/Исправили N»**: 
Исправили краш при написании комментария

**Описание**:
Исправлен краш после отправки комментария в адаптивных степах и степах с видео. Кроме того, в степах с видео теперь обновляется счетчик комментариев по `viewWillAppear`.