### PR TITLE
Fix cached course lists

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ Preview.html
 Carthage/Build
 
 .DS_Store
+
+# AppCode
+.idea/

--- a/Stepic.xcodeproj/project.pbxproj
+++ b/Stepic.xcodeproj/project.pbxproj
@@ -3643,6 +3643,10 @@
 		2CF953362062ACA800B9617A /* AdaptiveCardsStepsPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CA2E70620233E28001DC410 /* AdaptiveCardsStepsPresenter.swift */; };
 		2CFDB1241F559F9A00B8035C /* AvatarImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CFDB1231F559F9A00B8035C /* AvatarImageView.swift */; };
 		452173E1842CC6913B58FD2F /* Pods_Adaptive_3149_Screenshots.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DDB4721C79C8860F955A54E7 /* Pods_Adaptive_3149_Screenshots.framework */; };
+		62E9822130C1EA241A84DED7 /* CourseListViewData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62E9865A5FE3936F4ADA7133 /* CourseListViewData.swift */; };
+		62E9831EA7A75D89A3C9EC5B /* CourseListViewData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62E9865A5FE3936F4ADA7133 /* CourseListViewData.swift */; };
+		62E986E416361591CE91DE3B /* CourseListViewData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62E9865A5FE3936F4ADA7133 /* CourseListViewData.swift */; };
+		62E98E72A85E731394868512 /* CourseListViewData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62E9865A5FE3936F4ADA7133 /* CourseListViewData.swift */; };
 		6A7DBAB7DC854F473438F007 /* Pods_Adaptive_3124.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 84B3E4DF00B221C0C4986BCE /* Pods_Adaptive_3124.framework */; };
 		6CE42CA60425E8BFDE0CC9C1 /* Pods_Adaptive_GMAT.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5D480E6140E3FF44F2E720BF /* Pods_Adaptive_GMAT.framework */; };
 		7E6ECF7D5E3928A2D8BC5789 /* Pods_StepikTVTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CB2A138F0DB9843ED42F3412 /* Pods_StepikTVTests.framework */; };
@@ -5125,6 +5129,7 @@
 		5DCCD997D895737CAC62FE20 /* Pods-StepikTV.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-StepikTV.release.xcconfig"; path = "Pods/Target Support Files/Pods-StepikTV/Pods-StepikTV.release.xcconfig"; sourceTree = "<group>"; };
 		60775FB2AF00F82D3077ABE1 /* Pods_SberbankUniversity.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_SberbankUniversity.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		611F6148D39767518C0599A3 /* Pods-Adaptive 3124 Screenshots.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Adaptive 3124 Screenshots.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Adaptive 3124 Screenshots/Pods-Adaptive 3124 Screenshots.debug.xcconfig"; sourceTree = "<group>"; };
+		62E9865A5FE3936F4ADA7133 /* CourseListViewData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CourseListViewData.swift; sourceTree = "<group>"; };
 		6407CA973D1E0DD43D7D37A6 /* Pods-Adaptive 3149 Screenshots.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Adaptive 3149 Screenshots.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Adaptive 3149 Screenshots/Pods-Adaptive 3149 Screenshots.debug.xcconfig"; sourceTree = "<group>"; };
 		659D078D6ECC6EAC850691ED /* Pods-Stepic.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Stepic.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Stepic/Pods-Stepic.debug.xcconfig"; sourceTree = "<group>"; };
 		67BC7277DBB1AB03A65BDB2C /* Pods-Stepic.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Stepic.release.xcconfig"; path = "Pods/Target Support Files/Pods-Stepic/Pods-Stepic.release.xcconfig"; sourceTree = "<group>"; };
@@ -5615,6 +5620,7 @@
 				08195A051FA00FF400E6D6CD /* CourseLists.storyboard */,
 				088FD8161FB242B3008A2953 /* CourseSubscriber.swift */,
 				089C88DD1FCF494300003B63 /* CourseListType.swift */,
+				62E9865A5FE3936F4ADA7133 /* CourseListViewData.swift */,
 			);
 			name = "Course List";
 			sourceTree = "<group>";
@@ -12288,6 +12294,7 @@
 				08AC214B1CE0DE9B00FBB9CD /* DeviceDefaults.swift in Sources */,
 				08964BCD1F3072BA00DBBCCE /* QueriesAPI.swift in Sources */,
 				084C658D1FDAD04C006A3E17 /* RemoteConfig.swift in Sources */,
+				62E9831EA7A75D89A3C9EC5B /* CourseListViewData.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -13969,6 +13976,7 @@
 				2C89AADE1F4C289900227C3B /* EmptyDatasetState.swift in Sources */,
 				086FC6AC1FE04DBD00C7DFF4 /* RangeExtension.swift in Sources */,
 				2C89AADF1F4C289900227C3B /* AdaptiveAppDelegate.swift in Sources */,
+				62E98E72A85E731394868512 /* CourseListViewData.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -14448,6 +14456,7 @@
 				2C9732911F4C38F600AC9301 /* StringHelper.swift in Sources */,
 				2C9732921F4C38F600AC9301 /* EmptyDatasetState.swift in Sources */,
 				2C9732931F4C38F600AC9301 /* AdaptiveAppDelegate.swift in Sources */,
+				62E986E416361591CE91DE3B /* CourseListViewData.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -14987,6 +14996,7 @@
 				2C03B2A41F0CD87600005383 /* StringHelper.swift in Sources */,
 				864D67341E83DE03001E8D9E /* EmptyDatasetState.swift in Sources */,
 				86EF29371E83CEA900F8D214 /* AdaptiveAppDelegate.swift in Sources */,
+				62E9822130C1EA241A84DED7 /* CourseListViewData.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Stepic/CourseListPresenter.swift
+++ b/Stepic/CourseListPresenter.swift
@@ -41,6 +41,8 @@ protocol CourseListCountDelegate: class {
 }
 
 class CourseListPresenter {
+    private weak var view: CourseListView?
+
     private var coursesAPI: CoursesAPI
     private var progressesAPI: ProgressesAPI
     private var reviewSummariesAPI: CourseReviewSummariesAPI
@@ -48,24 +50,26 @@ class CourseListPresenter {
     private var subscriptionManager: CourseSubscriptionManager
     private var adaptiveStorageManager: AdaptiveStorageManager
 
-    private var colorMode: CourseListColorMode
-    var onlyLocal: Bool
-
-    private var ID: String
-
-    private weak var view: CourseListView?
-    private var limit: Int?
+    private var id: String
     var listType: CourseListType
 
+    // Only cached courses?
+    var onlyLocal: Bool
+
+    // Pagination
     private var currentPage: Int = 1
     private var hasNextPage: Bool = false
+    private var limit: Int?
 
     private var lastUser: User?
-    private var subscriber = CourseSubscriber()
     private var lastLanguage: ContentLanguage
+
+    private var subscriber = CourseSubscriber()
 
     weak var lastStepDataSource: LastStepWidgetDataSource?
     weak var couseListCountDelegate: CourseListCountDelegate?
+
+    private var reachabilityManager: Alamofire.NetworkReachabilityManager?
 
     private var didRefreshOnce: Bool = false
 
@@ -88,13 +92,13 @@ class CourseListPresenter {
     private var courses: [Course] = [] {
         didSet {
             listType.cachedListCourseIds = courses.map({ $0.id })
-            print("\(ID): cached courses with ids: \(listType.cachedListCourseIds)")
+            print("\(id): cached courses with ids: \(listType.cachedListCourseIds)")
             if let limit = limit {
                 displayingCourses = [Course](courses.prefix(limit))
             } else {
                 displayingCourses = courses
             }
-            self.couseListCountDelegate?.updateCourseCount(to: courses.count, forListID: ID)
+            self.couseListCountDelegate?.updateCourseCount(to: courses.count, forListID: id)
         }
     }
 
@@ -109,39 +113,36 @@ class CourseListPresenter {
         return result
     }
 
-    init(view: CourseListView, ID: String, limit: Int?, listType: CourseListType, colorMode: CourseListColorMode, onlyLocal: Bool, subscriptionManager: CourseSubscriptionManager, coursesAPI: CoursesAPI, progressesAPI: ProgressesAPI, reviewSummariesAPI: CourseReviewSummariesAPI, searchResultsAPI: SearchResultsAPI, subscriber: CourseSubscriber, adaptiveStorageManager: AdaptiveStorageManager) {
+    init(view: CourseListView, id: String, limit: Int?, listType: CourseListType, onlyLocal: Bool, subscriptionManager: CourseSubscriptionManager, coursesAPI: CoursesAPI, progressesAPI: ProgressesAPI, reviewSummariesAPI: CourseReviewSummariesAPI, searchResultsAPI: SearchResultsAPI, subscriber: CourseSubscriber, adaptiveStorageManager: AdaptiveStorageManager) {
         self.view = view
-        self.ID = ID
-        self.coursesAPI = coursesAPI
-        self.progressesAPI = progressesAPI
-        self.reviewSummariesAPI = reviewSummariesAPI
+        self.id = id
+
         self.limit = limit
         self.listType = listType
-        self.colorMode = colorMode
         self.subscriber = subscriber
         self.lastUser = AuthInfo.shared.user
         self.lastLanguage = ContentLanguage.sharedContentLanguage
         self.onlyLocal = onlyLocal
+
+        self.coursesAPI = coursesAPI
+        self.progressesAPI = progressesAPI
+        self.reviewSummariesAPI = reviewSummariesAPI
         self.searchResultsAPI = searchResultsAPI
         self.subscriptionManager = subscriptionManager
         self.adaptiveStorageManager = adaptiveStorageManager
-        subscriptionManager.handleUpdatesBlock = {
-            [weak self] in
+
+        subscriptionManager.handleUpdatesBlock = { [weak self] in
             self?.handleCourseSubscriptionUpdates()
         }
         subscriptionManager.startObservingOtherSubscriptionManagers()
-        view.colorMode = colorMode
     }
 
-    private var reachabilityManager: Alamofire.NetworkReachabilityManager?
     private func setupNetworkReachabilityListener() {
         guard reachabilityManager == nil else {
             return
         }
         reachabilityManager = Alamofire.NetworkReachabilityManager(host: StepicApplicationsInfo.stepicURL)
-        reachabilityManager?.listener = {
-            [weak self]
-            status in
+        reachabilityManager?.listener = { [weak self] status in
             guard let strongSelf = self else {
                 return
             }
@@ -158,13 +159,10 @@ class CourseListPresenter {
     }
 
     func getData(from courses: [Course]) -> [CourseViewData] {
-        return courses.map {
-            course in
-            CourseViewData(course: course, action: {
-                [weak self] in
+        return courses.map { course in
+            CourseViewData(course: course, action: { [weak self] in
                 self?.actionButtonPressed(course: course)
-            }, secondaryAction: {
-                [weak self] in
+            }, secondaryAction: { [weak self] in
                 self?.secondaryActionButtonPressed(course: course)
             })
         }
@@ -172,23 +170,19 @@ class CourseListPresenter {
 
     private func subscribe(to course: Course) {
         self.view?.startProgressHUD()
-        checkToken().then {
-            [weak self]
-            () -> Promise<Course> in
+
+        checkToken().then { [weak self] () -> Promise<Course> in
             guard let strongSelf = self else {
                 throw CourseSubscriber.CourseSubscriptionError.error(status: "")
             }
             return strongSelf.subscriber.join(course: course)
-        }.then {
-            [weak self]
-            course -> Void in
+        }.then { [weak self] course -> Void in
             self?.view?.finishProgressHUD(success: true, message: "")
+
             if let controller = self?.getSectionsController(for: course, didSubscribe: true) {
                 self?.view?.show(controller: controller)
             }
-        }.catch {
-            [weak self]
-            error in
+        }.catch { [weak self] error in
             guard let error = error as? CourseSubscriber.CourseSubscriptionError else {
                 self?.view?.finishProgressHUD(success: false, message: "")
                 return
@@ -208,8 +202,7 @@ class CourseListPresenter {
                 LastStepRouter.continueLearning(for: course, using: navigation)
             }
         } else {
-            let joinBlock: (() -> Void) = {
-                [weak self] in
+            let joinBlock: (() -> Void) = { [weak self] in
                 self?.subscribe(to: course)
             }
             if !AuthInfo.shared.isAuthorized {
@@ -242,36 +235,30 @@ class CourseListPresenter {
         let selectedCourse = courses[index]
         let isAdaptiveMode = adaptiveStorageManager.canOpenInAdaptiveMode(courseId: selectedCourse.id)
 
-        if !isAdaptiveMode {
-            secondaryActionButtonPressed(course: selectedCourse)
-        }
-
         if isAdaptiveMode {
             actionButtonPressed(course: selectedCourse)
+        } else {
+            secondaryActionButtonPressed(course: selectedCourse)
         }
     }
 
     private func displayCachedAsyncIfEmpty() -> Promise<Void> {
-        return Promise<Void> {
-            [weak self]
-            fulfill, reject in
+        return Promise<Void> { [weak self] fulfill, reject in
             guard let strongSelf = self else {
                 reject(PromiseError.noSelf)
                 return
             }
             if strongSelf.courses.isEmpty {
-                Course.fetchAsync(strongSelf.listType.cachedListCourseIds).then {
-                    [weak self]
-                    courses -> Void in
+                Course.fetchAsync(strongSelf.listType.cachedListCourseIds).then { [weak self] courses -> Void in
                     guard let strongSelf = self else {
                         reject(PromiseError.noSelf)
                         return
                     }
+
                     strongSelf.courses = Sorter.sort(courses, byIds: strongSelf.listType.cachedListCourseIds)
                     strongSelf.view?.display(courses: strongSelf.getData(from: strongSelf.displayingCourses))
                     fulfill(())
-                }.catch {
-                    error in
+                }.catch { error in
                     reject(error)
                 }
             } else {
@@ -280,14 +267,8 @@ class CourseListPresenter {
         }
     }
 
-    enum PromiseError: Error {
-        case localUpdate, noSelf
-    }
-
     private func updateState() -> Promise<Void> {
-        return Promise<Void> {
-            [weak self]
-            fulfill, reject in
+        return Promise<Void> { [weak self] fulfill, reject in
             guard let strongSelf = self else {
                 reject(PromiseError.noSelf)
                 return
@@ -305,12 +286,9 @@ class CourseListPresenter {
     func refresh() {
         displayCachedAsyncIfEmpty().then {
             self.updateState()
-        }.then {
-            [weak self] in
+        }.then { [weak self] in
             self?.refreshCourses()
-        }.catch {
-            [weak self]
-            error in
+        }.catch { [weak self] error in
             guard let strongSelf = self else {
                 return
             }
@@ -329,9 +307,7 @@ class CourseListPresenter {
         }
         self.view?.setPaginationStatus(status: .loading)
         coursesAPI.cancelAllTasks()
-        listType.request(page: currentPage + 1, language: ContentLanguage.sharedContentLanguage, withAPI: coursesAPI, progressesAPI: progressesAPI, searchResultsAPI: searchResultsAPI)?.then {
-            [weak self]
-            (courses, meta) -> Void in
+        listType.request(page: currentPage + 1, language: ContentLanguage.sharedContentLanguage, withAPI: coursesAPI, progressesAPI: progressesAPI, searchResultsAPI: searchResultsAPI)?.then { [weak self] (courses, meta) -> Void in
             guard let strongSelf = self else {
                 return
             }
@@ -342,9 +318,7 @@ class CourseListPresenter {
             strongSelf.currentPage = meta.page
             strongSelf.hasNextPage = meta.hasNext
             strongSelf.view?.setPaginationStatus(status: strongSelf.shouldLoadNextPage ? .loading : .none)
-        }.catch {
-            [weak self]
-            _ in
+        }.catch { [weak self] _ in
             print("error while loading next page")
             self?.view?.setPaginationStatus(status: .error)
         }
@@ -416,24 +390,20 @@ class CourseListPresenter {
             subscriptionManager.clean()
 
             let newDisplayedCourses = getDisplaying(from: courses)
-            let deletedDisplayedCourses = oldDisplayedCourses.filter({
-                !newDisplayedCourses.contains($0)
-            })
-            let addedDisplayedCourses = newDisplayedCourses.filter({
-                !oldDisplayedCourses.contains($0)
-            })
-            oldDisplayedCourses.enumerated().forEach({
-                index, oldDisplayedCourse in
+            let deletedDisplayedCourses = oldDisplayedCourses.filter { !newDisplayedCourses.contains($0) }
+            let addedDisplayedCourses = newDisplayedCourses.filter { !oldDisplayedCourses.contains($0) }
+
+            oldDisplayedCourses.enumerated().forEach({ index, oldDisplayedCourse in
                 if deletedDisplayedCourses.contains(oldDisplayedCourse) {
                     deletedIds += [index]
                 }
             })
-            newDisplayedCourses.enumerated().forEach({
-                index, newDisplayedCourse in
+            newDisplayedCourses.enumerated().forEach({ index, newDisplayedCourse in
                 if addedDisplayedCourses.contains(newDisplayedCourse) {
                     addedIds += [index]
                 }
             })
+
             if oldDisplayedCourses.isEmpty && !newDisplayedCourses.isEmpty {
                 self.state = .displaying
             }
@@ -441,6 +411,7 @@ class CourseListPresenter {
                 self.state = .empty
                 return
             }
+
             if oldDisplayedCourses.count - deletedIds.count + addedIds.count == newDisplayedCourses.count {
                 view?.update(deletingIds: deletedIds, insertingIds: addedIds, courses: getData(from: newDisplayedCourses))
             } else {
@@ -474,9 +445,7 @@ class CourseListPresenter {
     }
 
     private func requestNonCollection(updateProgresses: Bool, completion: (() -> Void)? = nil) {
-        listType.request(page: 1, language: ContentLanguage.sharedContentLanguage, withAPI: coursesAPI, progressesAPI: progressesAPI, searchResultsAPI: searchResultsAPI)?.then {
-            [weak self]
-            (courses, meta) -> Void in
+        listType.request(page: 1, language: ContentLanguage.sharedContentLanguage, withAPI: coursesAPI, progressesAPI: progressesAPI, searchResultsAPI: searchResultsAPI)?.then { [weak self] (courses, meta) -> Void in
             guard let strongSelf = self else {
                 return
             }
@@ -492,18 +461,16 @@ class CourseListPresenter {
             strongSelf.view?.setPaginationStatus(status: strongSelf.shouldLoadNextPage ? .loading : .none)
             strongSelf.didRefreshOnce = true
             completion?()
-            }.catch {
-                [weak self]
-                _ in
-                guard let strongSelf = self else {
-                    return
-                }
-                print("Error while refreshing collection")
-                if !strongSelf.didRefreshOnce {
-                    strongSelf.setupNetworkReachabilityListener()
-                }
-                strongSelf.state = strongSelf.courses.isEmpty ? .emptyError : .displayingWithError
-                completion?()
+        }.catch { [weak self] _ in
+            guard let strongSelf = self else {
+                return
+            }
+            print("Error while refreshing collection")
+            if !strongSelf.didRefreshOnce {
+                strongSelf.setupNetworkReachabilityListener()
+            }
+            strongSelf.state = strongSelf.courses.isEmpty ? .emptyError : .displayingWithError
+            completion?()
         }
     }
 
@@ -511,9 +478,7 @@ class CourseListPresenter {
         coursesAPI.cancelAllTasks()
         switch listType {
         case let .collection(ids: ids):
-            listType.request(coursesWithIds: ids, withAPI: coursesAPI)?.then {
-                [weak self]
-                courses -> Void in
+            listType.request(coursesWithIds: ids, withAPI: coursesAPI)?.then { [weak self] courses -> Void in
                 guard let strongSelf = self else {
                     return
                 }
@@ -526,9 +491,7 @@ class CourseListPresenter {
                 strongSelf.hasNextPage = false
                 strongSelf.view?.setPaginationStatus(status: strongSelf.shouldLoadNextPage ? .loading : .none)
                 strongSelf.didRefreshOnce = true
-            }.catch {
-                [weak self]
-                _ in
+            }.catch { [weak self] _ in
                 guard let strongSelf = self else {
                     return
                 }
@@ -546,8 +509,7 @@ class CourseListPresenter {
                 self.state = .emptyAnonymous
                 return
             }
-            requestNonCollection(updateProgresses: false, completion: {
-                [weak self] in
+            requestNonCollection(updateProgresses: false, completion: { [weak self] in
                 guard let strongSelf = self else {
                     return
                 }
@@ -577,9 +539,7 @@ class CourseListPresenter {
         AnalyticsReporter.reportEvent(AnalyticsEvents.PeekNPop.Course.peeked)
         courseVC.course = course
         courseVC.didJustSubscribe = didSubscribe
-        courseVC.parentShareBlock = {
-            [weak self]
-            shareVC in
+        courseVC.parentShareBlock = { [weak self] shareVC in
             AnalyticsReporter.reportEvent(AnalyticsEvents.PeekNPop.Course.shared)
             shareVC.popoverPresentationController?.sourceView = sourceView
             self?.view?.present(controller: shareVC)
@@ -594,9 +554,7 @@ class CourseListPresenter {
         }
         AnalyticsReporter.reportEvent(AnalyticsEvents.PeekNPop.Course.peeked)
         courseVC.course = course
-        courseVC.parentShareBlock = {
-            [weak self]
-            shareVC in
+        courseVC.parentShareBlock = { [weak self] shareVC in
             AnalyticsReporter.reportEvent(AnalyticsEvents.PeekNPop.Course.shared)
             shareVC.popoverPresentationController?.sourceView = sourceView
             self?.view?.present(controller: shareVC)
@@ -610,8 +568,6 @@ class CourseListPresenter {
         return course.enrolled ? getSectionsController(for: course, sourceView: sourceView) : getCoursePreviewController(for: course, sourceView: sourceView)
     }
 
-    // Progresses
-
     @discardableResult private func updateProgresses(for courses: [Course]) -> Promise<[Course]> {
         var progressIds: [String] = []
         var progresses: [Progress] = []
@@ -624,19 +580,15 @@ class CourseListPresenter {
             }
         }
 
-        return Promise {
-            fulfill, reject in
-            progressesAPI.getObjectsByIds(ids: progressIds, updating: progresses).then {
-                [weak self]
-                newProgresses -> Void in
+        return Promise { fulfill, reject in
+            progressesAPI.getObjectsByIds(ids: progressIds, updating: progresses).then { [weak self] newProgresses -> Void in
                 guard let strongSelf = self else {
                     return
                 }
                 strongSelf.matchProgresses(newProgresses: newProgresses, ids: progressIds, courses: courses)
                 strongSelf.view?.update(updatedCourses: strongSelf.getData(from: strongSelf.getDisplaying(from: courses)), courses: strongSelf.getData(from: strongSelf.displayingCourses))
                 fulfill(strongSelf.courses)
-            }.catch {
-                error in
+            }.catch { error in
                 print("Error while loading progresses")
                 reject(error)
             }
@@ -678,16 +630,13 @@ class CourseListPresenter {
             }
         }
 
-        reviewSummariesAPI.getObjectsByIds(ids: reviewIds, updating: reviews).then {
-            [weak self]
-            newReviews -> Void in
+        reviewSummariesAPI.getObjectsByIds(ids: reviewIds, updating: reviews).then { [weak self] newReviews -> Void in
             guard let strongSelf = self else {
                 return
             }
             strongSelf.matchReviewSummaries(newReviewSummaries: newReviews, ids: reviewIds, courses: courses)
             strongSelf.view?.update(updatedCourses: strongSelf.getData(from: strongSelf.getDisplaying(from: courses)), courses: strongSelf.getData(from: strongSelf.courses) )
-        }.catch {
-            _ in
+        }.catch { _ in
             print("error while loading review summaries")
         }
     }
@@ -711,28 +660,9 @@ class CourseListPresenter {
         }
         CoreDataHelper.instance.save()
     }
-}
 
-struct CourseViewData {
-    var id: Int
-    var title: String
-    var isEnrolled: Bool
-    var coverURLString: String
-    var rating: Float?
-    var learners: Int?
-    var progress: Float?
-    var action: (() -> Void)?
-    var secondaryAction: (() -> Void)?
-    init(course: Course, action: @escaping () -> Void, secondaryAction: @escaping () -> Void) {
-        self.id = course.id
-        self.title = course.title
-        self.isEnrolled = course.enrolled
-        self.coverURLString = course.coverURLString
-        self.rating = course.reviewSummary?.average
-        self.learners = course.learnersCount
-        self.progress = course.enrolled ? course.progress?.percentPassed : nil
-        self.action = action
-        self.secondaryAction = secondaryAction
+    enum PromiseError: Error {
+        case localUpdate, noSelf
     }
 }
 

--- a/Stepic/CourseListViewData.swift
+++ b/Stepic/CourseListViewData.swift
@@ -1,0 +1,33 @@
+//
+//  CourseViewData.swift
+//  Stepic
+//
+//  Created by Ostrenkiy on 11.10.2017.
+//  Copyright © 2017 Alex Karpov. All rights reserved.
+//
+
+import Foundation
+
+struct CourseViewData {
+    var id: Int
+    var title: String
+    var isEnrolled: Bool
+    var coverURLString: String
+    var rating: Float?
+    var learners: Int?
+    var progress: Float?
+    var action: (() -> Void)?
+    var secondaryAction: (() -> Void)?
+
+    init(course: Course, action: @escaping () -> Void, secondaryAction: @escaping () -> Void) {
+        self.id = course.id
+        self.title = course.title
+        self.isEnrolled = course.enrolled
+        self.coverURLString = course.coverURLString
+        self.rating = course.reviewSummary?.average
+        self.learners = course.learnersCount
+        self.progress = course.enrolled ? course.progress?.percentPassed : nil
+        self.action = action
+        self.secondaryAction = secondaryAction
+    }
+}

--- a/Stepic/ExplorePresenter.swift
+++ b/Stepic/ExplorePresenter.swift
@@ -67,12 +67,12 @@ class ExplorePresenter: CourseListCountDelegate {
             [weak self]
             tag in
             if let controller = ControllerHelper.instantiateViewController(identifier: "CourseListVerticalViewController", storyboardName: "CourseLists") as? CourseListVerticalViewController {
+                controller.colorMode = .light
                 controller.presenter = CourseListPresenter(
                     view: controller,
-                    ID: "Tag_\(tag.ID)",
+                    id: "Tag_\(tag.ID)",
                     limit: nil,
                     listType:  CourseListType.tag(id: tag.ID) ,
-                    colorMode: .light,
                     onlyLocal: false,
                     subscriptionManager: CourseSubscriptionManager(), coursesAPI: CoursesAPI(), progressesAPI: ProgressesAPI(), reviewSummariesAPI: CourseReviewSummariesAPI(), searchResultsAPI: SearchResultsAPI(), subscriber: CourseSubscriber(), adaptiveStorageManager: AdaptiveStorageManager()
                 )

--- a/Stepic/HomeScreenPresenter.swift
+++ b/Stepic/HomeScreenPresenter.swift
@@ -153,9 +153,10 @@ class CourseListBlock {
         self.onlyLocal = onlyLocal
         self.listType = listType
         self.horizontalController = ControllerHelper.instantiateViewController(identifier: "CourseListHorizontalViewController", storyboardName: "CourseLists") as! CourseListHorizontalViewController
-        self.horizontalController.presenter = CourseListPresenter(view: horizontalController, ID: ID, limit: horizontalLimit, listType: listType, colorMode: colorMode, onlyLocal: onlyLocal, subscriptionManager: CourseSubscriptionManager(), coursesAPI: CoursesAPI(), progressesAPI: ProgressesAPI(), reviewSummariesAPI: CourseReviewSummariesAPI(), searchResultsAPI: SearchResultsAPI(), subscriber: CourseSubscriber(), adaptiveStorageManager: AdaptiveStorageManager())
+        self.horizontalController.presenter = CourseListPresenter(view: horizontalController, id: ID, limit: horizontalLimit, listType: listType, onlyLocal: onlyLocal, subscriptionManager: CourseSubscriptionManager(), coursesAPI: CoursesAPI(), progressesAPI: ProgressesAPI(), reviewSummariesAPI: CourseReviewSummariesAPI(), searchResultsAPI: SearchResultsAPI(), subscriber: CourseSubscriber(), adaptiveStorageManager: AdaptiveStorageManager())
         self.horizontalController.presenter?.lastStepDataSource = lastStepWidgetDataSource
         self.horizontalController.presenter?.couseListCountDelegate = courseListCountDelegate
+        self.horizontalController.colorMode = colorMode
         self.showVerticalBlock = {
             [weak self]
             count in
@@ -167,8 +168,9 @@ class CourseListBlock {
             verticalController.descriptionView.colorStyle = strongSelf.colorStyle
             verticalController.courseCount = count
             verticalController.listDescription = strongSelf.description
-            verticalController.presenter = CourseListPresenter(view: verticalController, ID: ID, limit: nil, listType: strongSelf.listType, colorMode: strongSelf.colorMode, onlyLocal: strongSelf.onlyLocal, subscriptionManager: CourseSubscriptionManager(), coursesAPI: CoursesAPI(), progressesAPI: ProgressesAPI(), reviewSummariesAPI: CourseReviewSummariesAPI(), searchResultsAPI: SearchResultsAPI(), subscriber: CourseSubscriber(), adaptiveStorageManager: AdaptiveStorageManager())
+            verticalController.presenter = CourseListPresenter(view: verticalController, id: ID, limit: nil, listType: strongSelf.listType, onlyLocal: strongSelf.onlyLocal, subscriptionManager: CourseSubscriptionManager(), coursesAPI: CoursesAPI(), progressesAPI: ProgressesAPI(), reviewSummariesAPI: CourseReviewSummariesAPI(), searchResultsAPI: SearchResultsAPI(), subscriber: CourseSubscriber(), adaptiveStorageManager: AdaptiveStorageManager())
             verticalController.presenter?.couseListCountDelegate = verticalController
+            verticalController.colorMode = strongSelf.colorMode
             showControllerBlock(verticalController)
         }
     }

--- a/Stepic/SearchResultsPresenter.swift
+++ b/Stepic/SearchResultsPresenter.swift
@@ -53,7 +53,8 @@ class SearchResultsPresenter {
         if resultsVC == nil {
             resultsVC = ControllerHelper.instantiateViewController(identifier: "CourseListVerticalViewController", storyboardName: "CourseLists") as? CourseListVerticalViewController
             if let resultsVC = resultsVC {
-                resultsVC.presenter = CourseListPresenter(view: resultsVC, ID: "SearchCourses", limit: nil, listType: .search(query: query), colorMode: .light, onlyLocal: false, subscriptionManager: CourseSubscriptionManager(), coursesAPI: CoursesAPI(), progressesAPI: ProgressesAPI(), reviewSummariesAPI: CourseReviewSummariesAPI(), searchResultsAPI: SearchResultsAPI(), subscriber: CourseSubscriber(), adaptiveStorageManager: AdaptiveStorageManager())
+                resultsVC.colorMode = .light
+                resultsVC.presenter = CourseListPresenter(view: resultsVC, id: "SearchCourses", limit: nil, listType: .search(query: query), onlyLocal: false, subscriptionManager: CourseSubscriptionManager(), coursesAPI: CoursesAPI(), progressesAPI: ProgressesAPI(), reviewSummariesAPI: CourseReviewSummariesAPI(), searchResultsAPI: SearchResultsAPI(), subscriber: CourseSubscriber(), adaptiveStorageManager: AdaptiveStorageManager())
                 self.view?.set(controller: resultsVC, forState: .courses)
             }
         } else {

--- a/Stepic/StepikTableView.swift
+++ b/Stepic/StepikTableView.swift
@@ -48,7 +48,7 @@ extension StepikTableView {
         // Remove cell separators
         savedFooterView = self.tableFooterView
         hasSavedFooter = true
-        
+
         tableFooterView = UIView()
         placeholderView.isHidden = false
     }


### PR DESCRIPTION
**Задача**: [#APPS-1835](https://vyahhi.myjetbrains.com/youtrack/issue/APPS-1835)

**Коротко для Release Notes, в формате «Сделали/Добавили/Исправили N»**:
Исправили отображение курсов в кешированных списках

**Описание**:
Из-за того, что в `CourseListPresenter` обновляем кеш в блоке `didSet`, кеш перезатирался на пустой. Теперь обновляем его вручную и только тогда, когда данные в памяти актуальнее, чем кешированные.