### PR TITLE
Fixed bug with empty single-choice quiz solution

### DIFF
--- a/Stepic/ChoiceQuizViewController.swift
+++ b/Stepic/ChoiceQuizViewController.swift
@@ -110,8 +110,12 @@ class ChoiceQuizViewController: QuizViewController {
         self.view.layoutIfNeeded()
     }
 
-    override func getReply() -> Reply {
-        return ChoiceReply(choices: self.choices)
+    override func getReply() -> Reply? {
+        if self.choices.contains(true) || dataset?.isMultipleChoice == true {
+            return ChoiceReply(choices: self.choices)
+        } else {
+            return nil
+        }
     }
 
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {


### PR DESCRIPTION
**Задача**: [#APPS-1865](https://vyahhi.myjetbrains.com/youtrack/issue/APPS-1865)

**Коротко для Release Notes, в формате «Сделали/Добавили/Исправили N»**: 
Исправили ошибку с пустым ответом в чойс квизах

**Описание**:
Теперь `getReply() `возвращает `nil` для single-choice квизов, в которых нет ни одного `true` в чойсах.