### PR TITLE
Fixed crash in AppDelegate & updated fastlane to 2.93.1

### DIFF
--- a/Stepic.xcodeproj/project.pbxproj
+++ b/Stepic.xcodeproj/project.pbxproj
@@ -15881,7 +15881,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 87;
+				CURRENT_PROJECT_VERSION = 88;
 				DEVELOPMENT_TEAM = E9KER42773;
 				ENABLE_BITCODE = YES;
 				INFOPLIST_FILE = Stepic/Info.plist;
@@ -15912,7 +15912,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 87;
+				CURRENT_PROJECT_VERSION = 88;
 				DEVELOPMENT_TEAM = E9KER42773;
 				ENABLE_BITCODE = YES;
 				INFOPLIST_FILE = Stepic/Info.plist;

--- a/Stepic/AppDelegate.swift
+++ b/Stepic/AppDelegate.swift
@@ -280,7 +280,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         return false
     }
 
-    func application(_ application: UIApplication, open url: URL, sourceApplication: String?, annotation: Any) -> Bool {
+    func application(_ application: UIApplication, open url: URL, sourceApplication: String?, annotation: Any?) -> Bool {
         print("opened app via url \(url.absoluteString)")
         if VKSdk.processOpen(url, fromApplication: sourceApplication) {
             return true

--- a/Stepic/Info.plist
+++ b/Stepic/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.57</string>
+	<string>1.57.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>
@@ -52,7 +52,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>87</string>
+	<string>88</string>
 	<key>Fabric</key>
 	<dict>
 		<key>APIKey</key>

--- a/StepicAdaptiveCourse/Content/1838/AdaptiveInfo.plist
+++ b/StepicAdaptiveCourse/Content/1838/AdaptiveInfo.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.57</string>
+	<string>1.57.1</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -44,7 +44,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>87</string>
+	<string>88</string>
 	<key>Fabric</key>
 	<dict>
 		<key>APIKey</key>

--- a/StepicAdaptiveCourse/Content/3124/AdaptiveInfo.plist
+++ b/StepicAdaptiveCourse/Content/3124/AdaptiveInfo.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.57</string>
+	<string>1.57.1</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -44,7 +44,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>87</string>
+	<string>88</string>
 	<key>Fabric</key>
 	<dict>
 		<key>APIKey</key>

--- a/StepicAdaptiveCourse/Content/3149/AdaptiveInfo.plist
+++ b/StepicAdaptiveCourse/Content/3149/AdaptiveInfo.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.57</string>
+	<string>1.57.1</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -44,7 +44,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>87</string>
+	<string>88</string>
 	<key>Fabric</key>
 	<dict>
 		<key>APIKey</key>

--- a/StepicAdaptiveCourse/Content/3150/AdaptiveInfo.plist
+++ b/StepicAdaptiveCourse/Content/3150/AdaptiveInfo.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.57</string>
+	<string>1.57.1</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -44,7 +44,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>87</string>
+	<string>88</string>
 	<key>Fabric</key>
 	<dict>
 		<key>APIKey</key>

--- a/StepicTests/Info.plist
+++ b/StepicTests/Info.plist
@@ -15,10 +15,10 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.57</string>
+	<string>1.57.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>87</string>
+	<string>88</string>
 </dict>
 </plist>

--- a/StepicWatch Extension/Info.plist
+++ b/StepicWatch Extension/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.57</string>
+	<string>1.57.1</string>
 	<key>CFBundleVersion</key>
-	<string>87</string>
+	<string>88</string>
 	<key>CLKComplicationPrincipalClass</key>
 	<string>$(PRODUCT_MODULE_NAME).ComplicationController</string>
 	<key>CLKComplicationSupportedFamilies</key>

--- a/StepicWatch/Info.plist
+++ b/StepicWatch/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.57</string>
+	<string>1.57.1</string>
 	<key>CFBundleVersion</key>
-	<string>87</string>
+	<string>88</string>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>

--- a/StepikTV/Info.plist
+++ b/StepikTV/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.57</string>
+	<string>1.57.1</string>
 	<key>CFBundleVersion</key>
-	<string>87</string>
+	<string>88</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSAppTransportSecurity</key>

--- a/StepikTVTests/Info.plist
+++ b/StepikTVTests/Info.plist
@@ -15,8 +15,8 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.57</string>
+	<string>1.57.1</string>
 	<key>CFBundleVersion</key>
-	<string>87</string>
+	<string>88</string>
 </dict>
 </plist>

--- a/StickerPackExtension/Info.plist
+++ b/StickerPackExtension/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.57</string>
+	<string>1.57.1</string>
 	<key>CFBundleVersion</key>
-	<string>87</string>
+	<string>88</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionPointIdentifier</key>

--- a/UITests/Screenshots/Info.plist
+++ b/UITests/Screenshots/Info.plist
@@ -15,8 +15,8 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.57</string>
+	<string>1.57.1</string>
 	<key>CFBundleVersion</key>
-	<string>87</string>
+	<string>88</string>
 </dict>
 </plist>

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -11,7 +11,7 @@
 
 # This is the minimum version number required.
 # Update this, if you use features of a newer version
-fastlane_version "2.61.0"
+fastlane_version "2.93.1"
 
 default_platform :ios
 


### PR DESCRIPTION
- Фикс краша при логине через соцсети

- Апдейт fastlane до 2.93.1