### PR TITLE
Fix Date to timeString conversion 

### DIFF
--- a/Stepic/NSDateExtensions.swift
+++ b/Stepic/NSDateExtensions.swift
@@ -25,12 +25,21 @@ extension Date {
 extension TimeInterval {
     init(timeString: String) {
         let formatter = DateFormatter()
-        formatter.timeZone = TimeZone(secondsFromGMT: 0)
-        formatter.locale = Locale(identifier: "en_US")
-        formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss'Z'"
-        if (formatter.date(from: timeString)?.timeIntervalSince1970) == nil {
-            formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"
+        formatter.timeZone = TimeZone(abbreviation: "UTC")!
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+
+        let dateFormats = ["yyyy-MM-dd'T'HH:mm:ss'Z'",
+                           "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'",
+                           "yyyy-MM-dd'T'hh:mm:ss.SSS a'Z'"]
+
+        for dateFormat in dateFormats {
+            formatter.dateFormat = dateFormat
+            if let timeInterval = formatter.date(from: timeString)?.timeIntervalSince1970 {
+                self = timeInterval
+                return
+            }
         }
+
         self = formatter.date(from: timeString)!.timeIntervalSince1970
     }
 }

--- a/Stepic/Parser.swift
+++ b/Stepic/Parser.swift
@@ -44,6 +44,7 @@ class Parser: NSObject {
     func timedateStringFromDate(date: Date) -> String {
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"
+        dateFormatter.locale = Locale(identifier: "en_US_POSIX")
         dateFormatter.timeZone = TimeZone(abbreviation: "UTC")
         return dateFormatter.string(from: date)
     }


### PR DESCRIPTION
**Задача**: [#APPS-1927](https://vyahhi.myjetbrains.com/youtrack/issue/APPS-1927)

**Коротко для Release Notes, в формате «Сделали/Добавили/Исправили N»**: 
Исправили конвертацию в time string и обратно

**Описание**:
Теперь не учитывается пользовательская локаль, в конструктор TimeInterval добавлен формат с AM/PM для обработки неверных существующих дат.
