### PR TITLE
Amplitude fixes

### DIFF
--- a/Stepic/AppDelegate.swift
+++ b/Stepic/AppDelegate.swift
@@ -64,9 +64,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         if !DefaultsContainer.launch.didLaunch {
             AnalyticsReporter.reportEvent(AnalyticsEvents.App.firstLaunch, parameters: nil)
             AnalyticsReporter.reportAmplitudeEvent(AmplitudeAnalyticsEvents.Launch.firstTime)
-        } else {
-            AnalyticsReporter.reportAmplitudeEvent(AmplitudeAnalyticsEvents.Launch.sessionStart)
         }
+        AnalyticsReporter.reportAmplitudeEvent(AmplitudeAnalyticsEvents.Launch.sessionStart)
 
         if StepicApplicationsInfo.inAppUpdatesAvailable {
             checkForUpdates()

--- a/Stepic/CardStepPresenter.swift
+++ b/Stepic/CardStepPresenter.swift
@@ -77,6 +77,7 @@ class CardStepPresenter {
         view?.updateQuiz(with: quizViewController)
 
         quizViewController.isSubmitButtonHidden = true
+        AnalyticsReporter.reportAmplitudeEvent(AmplitudeAnalyticsEvents.Steps.stepOpened, parameters: ["step": step.id, "type": step.block.name])
     }
 
     func problemDidLoad() {


### PR DESCRIPTION
**Задача**: [#APPS-1947](https://vyahhi.myjetbrains.com/youtrack/issue/APPS-1947)

**Коротко для Release Notes, в формате «Сделали/Добавили/Исправили N»**: 
Исправили неправильные события в amplitude

**Описание**:
- Теперь отсылается событие `Step opened` для адаптивных шагов
- Также отправляется `Session start` во время первого запуска
