### PR TITLE
Fill blanks bug

### DIFF
--- a/Stepic/FillBlanksQuizViewController.swift
+++ b/Stepic/FillBlanksQuizViewController.swift
@@ -141,6 +141,10 @@ class FillBlanksQuizViewController: QuizViewController {
         self.tableView.isUserInteractionEnabled = true
         answerForComponent = [:]
         self.tableView.reloadData()
+        DispatchQueue.main.async {
+            self.tableView.invalidateIntrinsicContentSize()
+            self.view.layoutSubviews()
+        }
     }
 
     override func display(reply: Reply, withStatus status: SubmissionStatus) {
@@ -171,6 +175,10 @@ class FillBlanksQuizViewController: QuizViewController {
         }
 
         self.tableView.reloadData()
+        DispatchQueue.main.async {
+            self.tableView.invalidateIntrinsicContentSize()
+            self.view.layoutSubviews()
+        }
     }
 }
 

--- a/Stepic/FillBlanksQuizViewController.swift
+++ b/Stepic/FillBlanksQuizViewController.swift
@@ -143,7 +143,8 @@ class FillBlanksQuizViewController: QuizViewController {
         self.tableView.reloadData()
         DispatchQueue.main.async {
             self.tableView.invalidateIntrinsicContentSize()
-            self.view.layoutSubviews()
+            self.view.setNeedsLayout()
+            self.view.layoutIfNeeded()
         }
     }
 
@@ -177,7 +178,8 @@ class FillBlanksQuizViewController: QuizViewController {
         self.tableView.reloadData()
         DispatchQueue.main.async {
             self.tableView.invalidateIntrinsicContentSize()
-            self.view.layoutSubviews()
+            self.view.setNeedsLayout()
+            self.view.layoutIfNeeded()
         }
     }
 }


### PR DESCRIPTION
**Задача**: [#APPS-1924](https://vyahhi.myjetbrains.com/youtrack/issue/APPS-1924)

**Описание**:
Делаем `tableView.invalidateIntrinsicContentSize()` после `tableView.reloadData()`, чтобы лишний раз пересчиталась высота таблицы. Теперь все работает хорошо.