### PR TITLE
New file downloader

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -67,7 +67,6 @@ end
 def testing_pods
     pod 'Quick'
     pod 'Nimble'
-    pod 'Mockingjay'
 end
 
 def adaptive_pods
@@ -81,6 +80,7 @@ target 'Stepic' do
         inherit! :search_paths
         all_pods
         testing_pods
+	pod 'Mockingjay'
     end
 end
 

--- a/Podfile
+++ b/Podfile
@@ -67,6 +67,7 @@ end
 def testing_pods
     pod 'Quick'
     pod 'Nimble'
+    pod 'Mockingjay'
 end
 
 def adaptive_pods

--- a/Stepic.xcodeproj/project.pbxproj
+++ b/Stepic.xcodeproj/project.pbxproj
@@ -1908,6 +1908,7 @@
 		2C23C5E41F6BF52700FC2B7C /* AuthButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C23C5E31F6BF52700FC2B7C /* AuthButton.swift */; };
 		2C23C5E61F6BFA8800FC2B7C /* RegistrationPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C23C5E51F6BFA8800FC2B7C /* RegistrationPresenter.swift */; };
 		2C2485472101D91F006F8858 /* RestorableBackgroundDownloaderProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C2485462101D91F006F8858 /* RestorableBackgroundDownloaderProtocol.swift */; };
+		2C2485492101EE3E006F8858 /* DownloaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C2485482101EE3E006F8858 /* DownloaderTests.swift */; };
 		2C315E6D1F0A947D0039E4F0 /* CodeLanguagePickerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 081BF3461EFEF630002F84AA /* CodeLanguagePickerViewController.swift */; };
 		2C315E6E1F0A947D0039E4F0 /* LessonViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 089984281ECDE188005C0B27 /* LessonViewController.swift */; };
 		2C315E6F1F0A947D0039E4F0 /* LessonPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0899842B1ECDE194005C0B27 /* LessonPresenter.swift */; };
@@ -5579,6 +5580,7 @@
 		2C23C5E31F6BF52700FC2B7C /* AuthButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AuthButton.swift; sourceTree = "<group>"; };
 		2C23C5E51F6BFA8800FC2B7C /* RegistrationPresenter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RegistrationPresenter.swift; sourceTree = "<group>"; };
 		2C2485462101D91F006F8858 /* RestorableBackgroundDownloaderProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RestorableBackgroundDownloaderProtocol.swift; sourceTree = "<group>"; };
+		2C2485482101EE3E006F8858 /* DownloaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloaderTests.swift; sourceTree = "<group>"; };
 		2C2544081F3480BE004DB3D9 /* AchievementNotificationView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AchievementNotificationView.swift; sourceTree = "<group>"; };
 		2C33CBDA20EC2C2E009956B0 /* UserRegistrationServiceImplementation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserRegistrationServiceImplementation.swift; sourceTree = "<group>"; };
 		2C35C4981F4DA3B6002F3BF4 /* AdaptiveAchievementsPresenter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AdaptiveAchievementsPresenter.swift; sourceTree = "<group>"; };
@@ -6915,6 +6917,7 @@
 				080AA2361EA05CD20079272F /* TestConfig.swift */,
 				2CB51F6A204FC6220008431C /* UserActivitySpec.swift */,
 				62E987B9D418CC2175A64EC2 /* UserAgentTests.swift */,
+				2C2485482101EE3E006F8858 /* DownloaderTests.swift */,
 			);
 			path = StepicTests;
 			sourceTree = "<group>";
@@ -12686,6 +12689,7 @@
 				085D5CE41D007F6500092060 /* HTMLParsingTests.swift in Sources */,
 				0805FE481F0E584B001226B4 /* CodePlaygroundTest.swift in Sources */,
 				2C45339A204D5DEE0061342A /* PinsMapSpec.swift in Sources */,
+				2C2485492101EE3E006F8858 /* DownloaderTests.swift in Sources */,
 				080AA2371EA05CD20079272F /* TestConfig.swift in Sources */,
 				62E98ABEDEB0D955D6F3A951 /* UserAgentTests.swift in Sources */,
 			);

--- a/Stepic.xcodeproj/project.pbxproj
+++ b/Stepic.xcodeproj/project.pbxproj
@@ -4037,6 +4037,10 @@
 		2CE527C22029D9030047EC5F /* AdaptiveStatsSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CE527C02029D8EE0047EC5F /* AdaptiveStatsSection.swift */; };
 		2CE527C72029DFE70047EC5F /* AdaptiveAdaptiveStatsPagerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CE527C42029D9780047EC5F /* AdaptiveAdaptiveStatsPagerViewController.swift */; };
 		2CE527C82029E1600047EC5F /* AdaptiveAchievementsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C1649661F2A0842002C9F99 /* AdaptiveAchievementsViewController.swift */; };
+		2CE664E320F5207A0082F3FE /* Downloader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CE664DF20F520790082F3FE /* Downloader.swift */; };
+		2CE664E420F5207A0082F3FE /* DownloaderTaskProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CE664E020F520790082F3FE /* DownloaderTaskProtocol.swift */; };
+		2CE664E520F5207A0082F3FE /* DownloaderTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CE664E120F520790082F3FE /* DownloaderTask.swift */; };
+		2CE664E620F5207A0082F3FE /* DownloaderProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CE664E220F5207A0082F3FE /* DownloaderProtocol.swift */; };
 		2CE8390820C7F16700FE3672 /* ContentMenuBlockTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CE8390620C7F16700FE3672 /* ContentMenuBlockTableViewCell.swift */; };
 		2CE8390920C7F16700FE3672 /* ContentMenuBlockTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 2CE8390720C7F16700FE3672 /* ContentMenuBlockTableViewCell.xib */; };
 		2CE8390C20C8094000FE3672 /* ProfileAchievementsContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CE8390B20C8094000FE3672 /* ProfileAchievementsContentView.swift */; };
@@ -5771,6 +5775,10 @@
 		2CE3BCA61FBF13CE000AD405 /* SQLReply.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SQLReply.swift; sourceTree = "<group>"; };
 		2CE527C02029D8EE0047EC5F /* AdaptiveStatsSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdaptiveStatsSection.swift; sourceTree = "<group>"; };
 		2CE527C42029D9780047EC5F /* AdaptiveAdaptiveStatsPagerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdaptiveAdaptiveStatsPagerViewController.swift; sourceTree = "<group>"; };
+		2CE664DF20F520790082F3FE /* Downloader.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Downloader.swift; sourceTree = "<group>"; };
+		2CE664E020F520790082F3FE /* DownloaderTaskProtocol.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DownloaderTaskProtocol.swift; sourceTree = "<group>"; };
+		2CE664E120F520790082F3FE /* DownloaderTask.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DownloaderTask.swift; sourceTree = "<group>"; };
+		2CE664E220F5207A0082F3FE /* DownloaderProtocol.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DownloaderProtocol.swift; sourceTree = "<group>"; };
 		2CE8390620C7F16700FE3672 /* ContentMenuBlockTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentMenuBlockTableViewCell.swift; sourceTree = "<group>"; };
 		2CE8390720C7F16700FE3672 /* ContentMenuBlockTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ContentMenuBlockTableViewCell.xib; sourceTree = "<group>"; };
 		2CE8390B20C8094000FE3672 /* ProfileAchievementsContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileAchievementsContentView.swift; sourceTree = "<group>"; };
@@ -7591,6 +7599,7 @@
 		08DE94131B8C58AC00D278AB /* Stepic */ = {
 			isa = PBXGroup;
 			children = (
+				2CE664DE20F5204D0082F3FE /* Downloader */,
 				088E73E92060124B00D458E3 /* ApiRequestRetrier.swift */,
 				084C658B1FDAAD35006A3E17 /* Remote Config */,
 				08DF78D01F64056B00AEEA85 /* UI Elements */,
@@ -9081,6 +9090,17 @@
 				2C1649661F2A0842002C9F99 /* AdaptiveAchievementsViewController.swift */,
 			);
 			name = Achievements;
+			sourceTree = "<group>";
+		};
+		2CE664DE20F5204D0082F3FE /* Downloader */ = {
+			isa = PBXGroup;
+			children = (
+				2CE664DF20F520790082F3FE /* Downloader.swift */,
+				2CE664E220F5207A0082F3FE /* DownloaderProtocol.swift */,
+				2CE664E120F520790082F3FE /* DownloaderTask.swift */,
+				2CE664E020F520790082F3FE /* DownloaderTaskProtocol.swift */,
+			);
+			name = Downloader;
 			sourceTree = "<group>";
 		};
 		2CE8390320C7EF5A00FE3672 /* GenericContent */ = {
@@ -12680,6 +12700,7 @@
 				088CB1EC1D4BD5ED00C6ED1B /* FreeAnswerDataset.swift in Sources */,
 				08CB0D4D1FB63F83001A1E02 /* ContentLanguagesView.swift in Sources */,
 				08AF59FC1E6D9BE800423EFF /* RGPageViewControllerDelegate.swift in Sources */,
+				2CE664E520F5207A0082F3FE /* DownloaderTask.swift in Sources */,
 				086A9D621C74AF90003611DC /* GlobalFunctions.swift in Sources */,
 				08EB85E91D0F649700E4F345 /* CellOperationsUtil.swift in Sources */,
 				866AD0D62061A7D70004C2B2 /* ControllerWithStepikPlaceholder.swift in Sources */,
@@ -12809,6 +12830,7 @@
 				085C4FF31D89C86F00B27C95 /* UnitsAPI.swift in Sources */,
 				2CE3BCA51FBF0121000AD405 /* SQLQuizViewController.swift in Sources */,
 				0800B8181D06D961006C987E /* DiscussionProxy.swift in Sources */,
+				2CE664E620F5207A0082F3FE /* DownloaderProtocol.swift in Sources */,
 				0813EEA71BFE5A5400DB4B83 /* Assignment.swift in Sources */,
 				08DF1D8C1BDA77A200BA35EA /* PathManager.swift in Sources */,
 				080C5E671EFC07C10036EB3D /* CodeQuizViewController.swift in Sources */,
@@ -12859,6 +12881,7 @@
 				0891424E1BCEED8E0000BCB0 /* VideoStepViewController.swift in Sources */,
 				088AADA91D175DA00034D86D /* HTMLContentView.swift in Sources */,
 				083749261DE5AE0400144C14 /* Alerts.swift in Sources */,
+				2CE664E420F5207A0082F3FE /* DownloaderTaskProtocol.swift in Sources */,
 				08A3A9CE1BD5A14D0032C36E /* NSDateExtensions.swift in Sources */,
 				08C9F7D01C29AE8B00E544D0 /* WebControllerManager.swift in Sources */,
 				080CE15B1E95804C0089A27F /* SearchResultsAPI.swift in Sources */,
@@ -12929,6 +12952,7 @@
 				08E6BB681DC8DF59006622EC /* UserActivitiesAPI.swift in Sources */,
 				08F485931C574D79000165AA /* WarningView.swift in Sources */,
 				080C5E801EFC28CF0036EB3D /* CodeSample+CoreDataProperties.swift in Sources */,
+				2CE664E320F5207A0082F3FE /* Downloader.swift in Sources */,
 				0829B8351E9D025C009B4A84 /* CertificatesAPI.swift in Sources */,
 				087387D81BB9A4BD003CFAD1 /* CoreDataHelper.swift in Sources */,
 				08E8F97A1F34E64E008CF4A1 /* SearchSuggestionTableViewCell.swift in Sources */,

--- a/Stepic.xcodeproj/project.pbxproj
+++ b/Stepic.xcodeproj/project.pbxproj
@@ -1907,6 +1907,7 @@
 		2C23C5E21F6BD43300FC2B7C /* EmailAuthPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C23C5E11F6BD43300FC2B7C /* EmailAuthPresenter.swift */; };
 		2C23C5E41F6BF52700FC2B7C /* AuthButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C23C5E31F6BF52700FC2B7C /* AuthButton.swift */; };
 		2C23C5E61F6BFA8800FC2B7C /* RegistrationPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C23C5E51F6BFA8800FC2B7C /* RegistrationPresenter.swift */; };
+		2C2485472101D91F006F8858 /* RestorableBackgroundDownloaderProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C2485462101D91F006F8858 /* RestorableBackgroundDownloaderProtocol.swift */; };
 		2C315E6D1F0A947D0039E4F0 /* CodeLanguagePickerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 081BF3461EFEF630002F84AA /* CodeLanguagePickerViewController.swift */; };
 		2C315E6E1F0A947D0039E4F0 /* LessonViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 089984281ECDE188005C0B27 /* LessonViewController.swift */; };
 		2C315E6F1F0A947D0039E4F0 /* LessonPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0899842B1ECDE194005C0B27 /* LessonPresenter.swift */; };
@@ -5577,6 +5578,7 @@
 		2C23C5E11F6BD43300FC2B7C /* EmailAuthPresenter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EmailAuthPresenter.swift; sourceTree = "<group>"; };
 		2C23C5E31F6BF52700FC2B7C /* AuthButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AuthButton.swift; sourceTree = "<group>"; };
 		2C23C5E51F6BFA8800FC2B7C /* RegistrationPresenter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RegistrationPresenter.swift; sourceTree = "<group>"; };
+		2C2485462101D91F006F8858 /* RestorableBackgroundDownloaderProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RestorableBackgroundDownloaderProtocol.swift; sourceTree = "<group>"; };
 		2C2544081F3480BE004DB3D9 /* AchievementNotificationView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AchievementNotificationView.swift; sourceTree = "<group>"; };
 		2C33CBDA20EC2C2E009956B0 /* UserRegistrationServiceImplementation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserRegistrationServiceImplementation.swift; sourceTree = "<group>"; };
 		2C35C4981F4DA3B6002F3BF4 /* AdaptiveAchievementsPresenter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AdaptiveAchievementsPresenter.swift; sourceTree = "<group>"; };
@@ -9099,6 +9101,7 @@
 				2CE664E220F5207A0082F3FE /* DownloaderProtocol.swift */,
 				2CE664E120F520790082F3FE /* DownloaderTask.swift */,
 				2CE664E020F520790082F3FE /* DownloaderTaskProtocol.swift */,
+				2C2485462101D91F006F8858 /* RestorableBackgroundDownloaderProtocol.swift */,
 			);
 			name = Downloader;
 			sourceTree = "<group>";
@@ -13075,6 +13078,7 @@
 				0889FEAF1BFB771200C6417E /* DownloadsViewController.swift in Sources */,
 				084DDDE1204EDF7600913503 /* NotificationRequestAlertViewController.swift in Sources */,
 				083749371DE5C7DC00144C14 /* LocalNotificationManager.swift in Sources */,
+				2C2485472101D91F006F8858 /* RestorableBackgroundDownloaderProtocol.swift in Sources */,
 				2C92669720B5C7CF00525AFC /* PlaceholderTableViewCell.swift in Sources */,
 				2CC0754720177A2E004A6005 /* AdaptiveStatsViewController.swift in Sources */,
 				088EDB501F8E8A5D009B736E /* CourseListVerticalViewController.swift in Sources */,

--- a/Stepic/Downloader.swift
+++ b/Stepic/Downloader.swift
@@ -14,7 +14,6 @@ fileprivate extension DownloaderSessionType {
         case .background(let id):
             let identifier = "downloader.\(id)"
             let config = URLSessionConfiguration.background(withIdentifier: identifier)
-            config.waitsForConnectivity = true
             config.isDiscretionary = true
             config.sessionSendsLaunchEvents = true
             return config
@@ -33,7 +32,7 @@ fileprivate extension DownloaderSessionType {
     }
 }
 
-final class Downloader: DownloaderProtocol {
+final class Downloader: RestorableBackgroundDownloaderProtocol {
     // Downloader class can't implement delegate protocols
     // cause it doesn't extend NSObject
     fileprivate final class Delegate: NSObject {
@@ -491,7 +490,7 @@ extension Downloader.Cache {
     }
 }
 
-extension Downloader: RestorableBackgroundDownloaderProtocol {
+extension Downloader {
     var id: String? {
         return session.configuration.identifier
     }

--- a/Stepic/Downloader.swift
+++ b/Stepic/Downloader.swift
@@ -1,0 +1,222 @@
+//
+//  Downloader.swift
+//  Stepic
+//
+//  Created by Vladislav Kiryukhin on 06.07.2018.
+//  Copyright © 2018 Alex Karpov. All rights reserved.
+//
+
+import Foundation
+
+final class Downloader: DownloaderProtocol {
+    // DownloaderImplementation can't implement delegate protocols
+    // cause it doesn't extend NSObject
+    fileprivate class Delegate: NSObject {
+        var downloader: Downloader!
+
+        init(downloader: Downloader) {
+            self.downloader = downloader
+        }
+    }
+
+    // Store additional information for each download task
+    fileprivate class TaskInfo {
+        let task: DownloaderTaskProtocol
+        var urlSessionTask: URLSessionDownloadTask
+
+        var expectedContentLength: Int64 = 0
+        var downloadedContentLength: Int64 = 0
+
+        var canBeRestarted = false
+        var resumeDataAfterError: Data = Data(count: 0)
+
+        init(task: DownloaderTaskProtocol, urlSessionTask: URLSessionDownloadTask) {
+            self.task = task
+            self.urlSessionTask = urlSessionTask
+        }
+    }
+
+    /// Mapping URLSession id -> TaskInfo
+    private var tasks: [Int: TaskInfo] = [:]
+    /// Mapping DownloaderTask id -> URLSession id
+    private var tasksMapping: [Int: Int] = [:]
+
+    private func resume(urlSessionTaskId: Int) {
+        let taskInfo = getTaskInfo(urlSessionTaskId: urlSessionTaskId)
+
+        // Re-init task with saved data
+        // Or just resume current download
+        if taskInfo.canBeRestarted {
+            let resumeData = taskInfo.resumeDataAfterError
+            let task = taskInfo.task
+
+            removeTask(urlSessionTaskId: urlSessionTaskId)
+            add(task: task, resumeData: resumeData)
+            // canBeRestarted == false now
+            resume(task: task)
+        } else {
+            taskInfo.task.set(state: .active)
+            taskInfo.urlSessionTask.resume()
+        }
+    }
+
+    private func pause(urlSessionTaskId: Int) {
+        let taskInfo = getTaskInfo(urlSessionTaskId: urlSessionTaskId)
+        taskInfo.task.set(state: .paused)
+        taskInfo.urlSessionTask.suspend()
+    }
+
+    private func cancel(urlSessionTaskId: Int) {
+        let taskInfo = getTaskInfo(urlSessionTaskId: urlSessionTaskId)
+        taskInfo.task.set(state: .canceled)
+        taskInfo.urlSessionTask.cancel()
+    }
+
+    private func reportOnCompletion(urlSessionTaskId: Int, location: URL) {
+        let taskInfo = getTaskInfo(urlSessionTaskId: urlSessionTaskId)
+        taskInfo.task.set(state: .completed)
+        taskInfo.task.completionReporter?(location)
+
+        removeTask(urlSessionTaskId: urlSessionTaskId)
+    }
+
+    private func reportOnFailure(urlSessionTaskId: Int, error: Error) {
+        getTaskInfo(urlSessionTaskId: urlSessionTaskId).task.failureReporter?(error)
+    }
+
+    private func reportProgress(urlSessionTaskId: Int) {
+        let taskInfo = getTaskInfo(urlSessionTaskId: urlSessionTaskId)
+        let progress = Double(taskInfo.downloadedContentLength) / Double(taskInfo.expectedContentLength)
+
+        taskInfo.task.set(state: .active)
+        taskInfo.task.progressReporter?(Float(progress))
+    }
+
+    private func canStart(urlSessionTaskId: Int) -> Bool {
+        if let taskInfo = tasks[urlSessionTaskId] {
+            return tasksMapping[taskInfo.task.id] != nil
+        }
+        return false
+    }
+
+    private func updateExpectedContentLength(urlSessionTaskId: Int, length: Int64) {
+        getTaskInfo(urlSessionTaskId: urlSessionTaskId).expectedContentLength = length
+    }
+
+    private func updateDownloadedContentLength(urlSessionTaskId: Int, length: Int64) {
+        getTaskInfo(urlSessionTaskId: urlSessionTaskId).downloadedContentLength = length
+    }
+
+    private func invalidateTask(urlSessionTaskId: Int) {
+        getTaskInfo(urlSessionTaskId: urlSessionTaskId).task.set(state: .canceled)
+    }
+
+    private func markAsCanBeRestarted(urlSessionTaskId: Int, buffer: Data?) {
+        let taskInfo = getTaskInfo(urlSessionTaskId: urlSessionTaskId)
+
+        taskInfo.canBeRestarted = true
+        taskInfo.resumeDataAfterError = buffer ?? Data(count: 0)
+    }
+
+    private func removeTask(urlSessionTaskId: Int) {
+        let taskInfo = getTaskInfo(urlSessionTaskId: urlSessionTaskId)
+
+        tasksMapping.removeValue(forKey: taskInfo.task.id)
+        tasks.removeValue(forKey: urlSessionTaskId)
+    }
+
+    private func getTaskInfo(urlSessionTaskId: Int) -> TaskInfo {
+        guard let taskInfo = tasks[urlSessionTaskId] else {
+            fatalError("Downloader has no tasks with given ID!")
+        }
+
+        return taskInfo
+    }
+
+    private func add(task: DownloaderTaskProtocol, resumeData: Data?) {
+        let delegate = Delegate(downloader: self)
+
+        let configuration = URLSessionConfiguration.background(withIdentifier: "downloader_urlsession_\(Date().timeIntervalSince1970)")
+        configuration.isDiscretionary = true
+
+        let session = URLSession(configuration: configuration,
+                                 delegate: delegate,
+                                 delegateQueue: nil)
+
+        var urlSessionDownloadTask: URLSessionDownloadTask
+        if let resumeData = resumeData {
+            urlSessionDownloadTask = session.downloadTask(withResumeData: resumeData)
+        } else {
+            urlSessionDownloadTask = session.downloadTask(with: task.url)
+        }
+        urlSessionDownloadTask.priority = task.priority.rawValue
+
+        let taskInfo = TaskInfo(task: task, urlSessionTask: urlSessionDownloadTask)
+        assert(taskInfo.canBeRestarted == false)
+
+        tasksMapping[task.id] = urlSessionDownloadTask.taskIdentifier
+        tasks[urlSessionDownloadTask.taskIdentifier] = taskInfo
+    }
+}
+
+extension Downloader {
+    func add(task: DownloaderTaskProtocol) {
+        add(task: task, resumeData: nil)
+    }
+
+    func resume(task: DownloaderTaskProtocol) {
+        guard let taskId = tasksMapping[task.id] else {
+            return
+        }
+
+        resume(urlSessionTaskId: taskId)
+    }
+
+    func pause(task: DownloaderTaskProtocol) {
+        guard let taskId = tasksMapping[task.id] else {
+            return
+        }
+
+        pause(urlSessionTaskId: taskId)
+    }
+
+    func cancel(task: DownloaderTaskProtocol) {
+        guard let taskId = tasksMapping[task.id] else {
+            return
+        }
+
+        cancel(urlSessionTaskId: taskId)
+    }
+}
+
+extension Downloader.Delegate: URLSessionDownloadDelegate {
+    func urlSession(_ session: URLSession, downloadTask: URLSessionDownloadTask, didFinishDownloadingTo location: URL) {
+        downloader.reportOnCompletion(urlSessionTaskId: downloadTask.taskIdentifier, location: location)
+    }
+
+    func urlSession(_ session: URLSession, downloadTask: URLSessionDownloadTask, didResumeAtOffset fileOffset: Int64, expectedTotalBytes: Int64) {
+        downloader.updateDownloadedContentLength(urlSessionTaskId: downloadTask.taskIdentifier, length: fileOffset)
+        downloader.updateExpectedContentLength(urlSessionTaskId: downloadTask.taskIdentifier, length: expectedTotalBytes)
+    }
+
+    func urlSession(_ session: URLSession, downloadTask: URLSessionDownloadTask, didWriteData bytesWritten: Int64, totalBytesWritten: Int64, totalBytesExpectedToWrite: Int64) {
+        downloader.updateDownloadedContentLength(urlSessionTaskId: downloadTask.taskIdentifier, length: totalBytesWritten)
+        downloader.updateExpectedContentLength(urlSessionTaskId: downloadTask.taskIdentifier, length: totalBytesExpectedToWrite)
+        downloader.reportProgress(urlSessionTaskId: downloadTask.taskIdentifier)
+    }
+
+    func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
+        guard let err = error as NSError? else {
+            return
+        }
+
+        downloader.invalidateTask(urlSessionTaskId: task.taskIdentifier)
+        if err.code == NSURLErrorCancelled {
+            downloader.removeTask(urlSessionTaskId: task.taskIdentifier)
+        } else {
+            let resumeData = err.userInfo[NSURLSessionDownloadTaskResumeData] as? Data
+            downloader.reportOnFailure(urlSessionTaskId: task.taskIdentifier, error: error!)
+            downloader.markAsCanBeRestarted(urlSessionTaskId: task.taskIdentifier, buffer: resumeData)
+        }
+    }
+}

--- a/Stepic/Downloader.swift
+++ b/Stepic/Downloader.swift
@@ -8,11 +8,36 @@
 
 import Foundation
 
+fileprivate extension DownloaderSessionType {
+    var configuration: URLSessionConfiguration {
+        switch self {
+        case .background(let id):
+            let identifier = "downloader.\(id)"
+            let config = URLSessionConfiguration.background(withIdentifier: identifier)
+            config.waitsForConnectivity = true
+            config.isDiscretionary = true
+            config.sessionSendsLaunchEvents = true
+            return config
+        case .foreground:
+            return URLSessionConfiguration.default
+        }
+    }
+
+    var description: String {
+        switch self {
+        case .background(let id):
+            return "background(\(id))"
+        case .foreground:
+            return "foreground"
+        }
+    }
+}
+
 final class Downloader: DownloaderProtocol {
-    // DownloaderImplementation can't implement delegate protocols
+    // Downloader class can't implement delegate protocols
     // cause it doesn't extend NSObject
-    fileprivate class Delegate: NSObject {
-        var downloader: Downloader!
+    fileprivate final class Delegate: NSObject {
+        var downloader: Downloader
 
         init(downloader: Downloader) {
             self.downloader = downloader
@@ -20,9 +45,10 @@ final class Downloader: DownloaderProtocol {
     }
 
     // Store additional information for each download task
-    fileprivate class TaskInfo {
+    fileprivate final class TaskInfo {
         let task: DownloaderTaskProtocol
         var urlSessionTask: URLSessionDownloadTask
+        var state: DownloaderTaskState = .attached
 
         var expectedContentLength: Int64 = 0
         var downloadedContentLength: Int64 = 0
@@ -36,13 +62,91 @@ final class Downloader: DownloaderProtocol {
         }
     }
 
+    // Cache sessions
+    fileprivate final class Cache {
+        private static let taskIDKey = "taskId"
+        private static let urlTaskIDKey = "urlTaskId"
+        private static let urlKey = "url"
+
+        var downloader: Downloader
+
+        init(downloader: Downloader) {
+            self.downloader = downloader
+        }
+    }
+
+    /// Semaphore wait delay
+    private static let waitDelay = 20.0
     /// Mapping URLSession id -> TaskInfo
     private var tasks: [Int: TaskInfo] = [:]
-    /// Mapping DownloaderTask id -> URLSession id
+    /// Mapping DownloaderTask id -> URLSession task id
     private var tasksMapping: [Int: Int] = [:]
+    private var session: URLSession!
 
-    private func resume(urlSessionTaskId: Int) {
+    /// Caches (nil when session is .foreground)
+    private var cache: Cache?
+    /// Mapping URLSession task id -> DownloaderTask
+    private var restoredTasksMapping: [Int: DownloaderTaskProtocol] = [:]
+    private var sessionInitSemaphore = DispatchSemaphore(value: 1)
+    private var restoreTasksSemaphore = DispatchSemaphore(value: 1)
+    /// URLSession tasks ids restored from previous background URLSession
+    private var validRestoredTasksIDs: [Int] = []
+
+    var restoredTasks: [DownloaderTaskProtocol] {
+        return Array(self.restoredTasksMapping.values)
+    }
+
+    init(session: DownloaderSessionType) {
+        NSLog("Downloader: created, session type = \(session.description)")
+        // Acquire semaphore to synchronize with delegate methods
+        self.sessionInitSemaphore.wait()
+
+        let delegate = Delegate(downloader: self)
+
+        self.session = URLSession(configuration: session.configuration,
+                                  delegate: delegate,
+                                  delegateQueue: nil)
+
+        if case DownloaderSessionType.background(_) = session {
+            cache = Cache(downloader: self)
+
+            // Decrement here, increment in resumeRestoredTasks
+            NSLog("Downloader: trying to restore tasks from previous background session with same ID...")
+            restoreTasksSemaphore.wait()
+
+            // Restore DownloaderTasks from cache
+            restoreTasksFromCache()
+
+            // Link DownloaderTasks with URLSessionTasks
+            self.session.getAllTasks { tasks in
+                defer {
+                    self.sessionInitSemaphore.signal()
+                    NSLog("Downloader: restored \(self.validRestoredTasksIDs.count) tasks from previous background session with same ID")
+                }
+
+                for task in tasks {
+                    if let task = task as? URLSessionDownloadTask {
+                        self.attachTaskAfterRestore(downloadTask: task)
+                        self.validRestoredTasksIDs.append(task.taskIdentifier)
+                    }
+                }
+
+                self.cache?.flush()
+            }
+        } else {
+            // sessionInitSemaphore should be used only for background sessions
+            sessionInitSemaphore.signal()
+        }
+    }
+
+    private func resume(urlSessionTaskId: Int) throws {
         let taskInfo = getTaskInfo(urlSessionTaskId: urlSessionTaskId)
+
+        guard taskInfo.state == .attached ||
+            taskInfo.state == .paused ||
+            taskInfo.state == .stopped else {
+                throw DownloaderError.incorrectState
+        }
 
         // Re-init task with saved data
         // Or just resume current download
@@ -51,32 +155,45 @@ final class Downloader: DownloaderProtocol {
             let task = taskInfo.task
 
             removeTask(urlSessionTaskId: urlSessionTaskId)
-            add(task: task, resumeData: resumeData)
+            try add(task: task, resumeData: resumeData)
             // canBeRestarted == false now
-            resume(task: task)
+            try resume(task: task)
         } else {
-            taskInfo.task.set(state: .active)
+            taskInfo.state = .active
+            taskInfo.task.stateReporter?(.active)
             taskInfo.urlSessionTask.resume()
         }
     }
 
-    private func pause(urlSessionTaskId: Int) {
+    private func pause(urlSessionTaskId: Int) throws {
         let taskInfo = getTaskInfo(urlSessionTaskId: urlSessionTaskId)
-        taskInfo.task.set(state: .paused)
+
+        guard taskInfo.state == .active else {
+            throw DownloaderError.incorrectState
+        }
+
+        taskInfo.state = .paused
+        taskInfo.task.stateReporter?(.paused)
+
         taskInfo.urlSessionTask.suspend()
     }
 
-    private func cancel(urlSessionTaskId: Int) {
+    private func cancel(urlSessionTaskId: Int) throws {
         let taskInfo = getTaskInfo(urlSessionTaskId: urlSessionTaskId)
-        taskInfo.task.set(state: .canceled)
+
+        guard taskInfo.state == .active ||
+            taskInfo.state == .paused ||
+            taskInfo.state == .attached else {
+                throw DownloaderError.incorrectState
+        }
+
         taskInfo.urlSessionTask.cancel()
     }
 
     private func reportOnCompletion(urlSessionTaskId: Int, location: URL) {
         let taskInfo = getTaskInfo(urlSessionTaskId: urlSessionTaskId)
-        taskInfo.task.set(state: .completed)
-        taskInfo.task.completionReporter?(location)
 
+        taskInfo.task.completionReporter?(location)
         removeTask(urlSessionTaskId: urlSessionTaskId)
     }
 
@@ -88,15 +205,17 @@ final class Downloader: DownloaderProtocol {
         let taskInfo = getTaskInfo(urlSessionTaskId: urlSessionTaskId)
         let progress = Double(taskInfo.downloadedContentLength) / Double(taskInfo.expectedContentLength)
 
-        taskInfo.task.set(state: .active)
-        taskInfo.task.progressReporter?(Float(progress))
-    }
-
-    private func canStart(urlSessionTaskId: Int) -> Bool {
-        if let taskInfo = tasks[urlSessionTaskId] {
-            return tasksMapping[taskInfo.task.id] != nil
+        if taskInfo.state != .active {
+            // Report about .active only if state is changed (is it possible?)
+            taskInfo.task.stateReporter?(.active)
         }
-        return false
+        taskInfo.state = .active
+
+        if taskInfo.expectedContentLength == NSURLSessionTransferSizeUnknown {
+            taskInfo.task.progressReporter?(nil)
+        } else {
+            taskInfo.task.progressReporter?(Float(progress))
+        }
     }
 
     private func updateExpectedContentLength(urlSessionTaskId: Int, length: Int64) {
@@ -108,7 +227,10 @@ final class Downloader: DownloaderProtocol {
     }
 
     private func invalidateTask(urlSessionTaskId: Int) {
-        getTaskInfo(urlSessionTaskId: urlSessionTaskId).task.set(state: .canceled)
+        let taskInfo = getTaskInfo(urlSessionTaskId: urlSessionTaskId)
+
+        taskInfo.state = .stopped
+        taskInfo.task.stateReporter?(.stopped)
     }
 
     private func markAsCanBeRestarted(urlSessionTaskId: Int, buffer: Data?) {
@@ -121,8 +243,14 @@ final class Downloader: DownloaderProtocol {
     private func removeTask(urlSessionTaskId: Int) {
         let taskInfo = getTaskInfo(urlSessionTaskId: urlSessionTaskId)
 
+        taskInfo.state = .detached
+        taskInfo.task.stateReporter?(.detached)
+
         tasksMapping.removeValue(forKey: taskInfo.task.id)
         tasks.removeValue(forKey: urlSessionTaskId)
+        restoredTasksMapping.removeValue(forKey: urlSessionTaskId)
+
+        cache?.flush()
     }
 
     private func getTaskInfo(urlSessionTaskId: Int) -> TaskInfo {
@@ -133,15 +261,10 @@ final class Downloader: DownloaderProtocol {
         return taskInfo
     }
 
-    private func add(task: DownloaderTaskProtocol, resumeData: Data?) {
-        let delegate = Delegate(downloader: self)
-
-        let configuration = URLSessionConfiguration.background(withIdentifier: "downloader_urlsession_\(Date().timeIntervalSince1970)")
-        configuration.isDiscretionary = true
-
-        let session = URLSession(configuration: configuration,
-                                 delegate: delegate,
-                                 delegateQueue: nil)
+    private func add(task: DownloaderTaskProtocol, resumeData: Data?) throws {
+        if tasksMapping[task.id] != nil {
+            throw DownloaderError.incorrectState
+        }
 
         var urlSessionDownloadTask: URLSessionDownloadTask
         if let resumeData = resumeData {
@@ -154,69 +277,236 @@ final class Downloader: DownloaderProtocol {
         let taskInfo = TaskInfo(task: task, urlSessionTask: urlSessionDownloadTask)
         assert(taskInfo.canBeRestarted == false)
 
+        // If we have restored task with same id then task from
+        // background attached session is invalid, so just remove it
+        if restoredTasksMapping[urlSessionDownloadTask.taskIdentifier] != nil {
+            invalidateRestoredTask(urlSessionTaskId: urlSessionDownloadTask.taskIdentifier)
+        }
+
         tasksMapping[task.id] = urlSessionDownloadTask.taskIdentifier
         tasks[urlSessionDownloadTask.taskIdentifier] = taskInfo
+
+        taskInfo.task.stateReporter?(.attached)
+        cache?.flush()
+    }
+
+    private func getTaskState(urlSessionTaskId: Int) -> DownloaderTaskState? {
+        return tasks[urlSessionTaskId]?.state
+    }
+
+    private func attachTaskAfterRestore(downloadTask: URLSessionDownloadTask) {
+        NSLog("Downloader: restored url session tasks with id = \(downloadTask.taskIdentifier) from previous background session")
+        guard let task = restoredTasksMapping[downloadTask.taskIdentifier] else {
+            return
+        }
+
+        let taskInfo = TaskInfo(task: task, urlSessionTask: downloadTask)
+
+        tasksMapping[task.id] = downloadTask.taskIdentifier
+        tasks[downloadTask.taskIdentifier] = taskInfo
+
+        taskInfo.state = .active
+        taskInfo.task.stateReporter?(.active)
+    }
+
+    private func restoreTasksFromCache() {
+        cache?.load().forEach { value in
+            restoredTasksMapping[value.1] = value.0
+        }
+    }
+
+    private func isRestoredTask(urlSessionTaskId: Int) -> Bool {
+        return restoredTasksMapping[urlSessionTaskId] != nil
+    }
+
+    private func invalidateRestoredTask(urlSessionTaskId: Int) {
+        guard let task = restoredTasksMapping[urlSessionTaskId] else {
+            return
+        }
+
+        task.failureReporter?(RestorableBackgroundDownloaderError.invalidTask)
+        task.stateReporter?(.detached)
+
+        restoredTasksMapping.removeValue(forKey: urlSessionTaskId)
     }
 }
 
 extension Downloader {
-    func add(task: DownloaderTaskProtocol) {
-        add(task: task, resumeData: nil)
+    func add(task: DownloaderTaskProtocol) throws {
+        try add(task: task, resumeData: nil)
     }
 
-    func resume(task: DownloaderTaskProtocol) {
+    func resume(task: DownloaderTaskProtocol) throws {
         guard let taskId = tasksMapping[task.id] else {
-            return
+            throw DownloaderError.detachedState
         }
 
-        resume(urlSessionTaskId: taskId)
+        try resume(urlSessionTaskId: taskId)
     }
 
-    func pause(task: DownloaderTaskProtocol) {
+    func pause(task: DownloaderTaskProtocol) throws {
         guard let taskId = tasksMapping[task.id] else {
-            return
+            throw DownloaderError.detachedState
         }
 
-        pause(urlSessionTaskId: taskId)
+        try pause(urlSessionTaskId: taskId)
     }
 
-    func cancel(task: DownloaderTaskProtocol) {
+    func cancel(task: DownloaderTaskProtocol) throws {
         guard let taskId = tasksMapping[task.id] else {
-            return
+            throw DownloaderError.detachedState
         }
 
-        cancel(urlSessionTaskId: taskId)
+        try cancel(urlSessionTaskId: taskId)
+    }
+
+    func getTaskState(for task: DownloaderTaskProtocol) -> DownloaderTaskState? {
+        guard let taskId = tasksMapping[task.id] else {
+            return nil
+        }
+
+        return getTaskState(urlSessionTaskId: taskId)
     }
 }
 
 extension Downloader.Delegate: URLSessionDownloadDelegate {
     func urlSession(_ session: URLSession, downloadTask: URLSessionDownloadTask, didFinishDownloadingTo location: URL) {
-        downloader.reportOnCompletion(urlSessionTaskId: downloadTask.taskIdentifier, location: location)
+        NSLog("Downloader: received downloader delegate completion method for downloadTask = \(downloadTask.taskIdentifier), location = \(location)")
+        let urlSessionTaskId = downloadTask.taskIdentifier
+
+        _ = downloader.sessionInitSemaphore.wait(timeout: .now() + Downloader.waitDelay)
+        downloader.sessionInitSemaphore.signal()
+
+        if downloader.isRestoredTask(urlSessionTaskId: urlSessionTaskId) {
+            downloader.restoreTasksSemaphore.wait()
+            downloader.restoreTasksSemaphore.signal()
+        }
+
+        // Check for server-side errors
+        if let response = downloadTask.response as? HTTPURLResponse {
+            let statusCode = response.statusCode
+            if !(200...299).contains(statusCode) {
+                downloader.invalidateTask(urlSessionTaskId: urlSessionTaskId)
+                downloader.reportOnFailure(urlSessionTaskId: urlSessionTaskId, error: DownloaderError.serverSide(statusCode: statusCode))
+                return
+            }
+        }
+
+        downloader.reportOnCompletion(urlSessionTaskId: urlSessionTaskId, location: location)
     }
 
     func urlSession(_ session: URLSession, downloadTask: URLSessionDownloadTask, didResumeAtOffset fileOffset: Int64, expectedTotalBytes: Int64) {
-        downloader.updateDownloadedContentLength(urlSessionTaskId: downloadTask.taskIdentifier, length: fileOffset)
-        downloader.updateExpectedContentLength(urlSessionTaskId: downloadTask.taskIdentifier, length: expectedTotalBytes)
+        NSLog("Downloader: received downloader delegate resume method for downloadTask = \(downloadTask.taskIdentifier)")
+        _ = downloader.sessionInitSemaphore.wait(timeout: .now() + Downloader.waitDelay)
+        downloader.sessionInitSemaphore.signal()
+
+        let urlSessionTaskId = downloadTask.taskIdentifier
+
+        if downloader.isRestoredTask(urlSessionTaskId: urlSessionTaskId) {
+            downloader.restoreTasksSemaphore.wait()
+            downloader.restoreTasksSemaphore.signal()
+        }
+
+        downloader.updateDownloadedContentLength(urlSessionTaskId: urlSessionTaskId, length: fileOffset)
+        downloader.updateExpectedContentLength(urlSessionTaskId: urlSessionTaskId, length: expectedTotalBytes)
     }
 
     func urlSession(_ session: URLSession, downloadTask: URLSessionDownloadTask, didWriteData bytesWritten: Int64, totalBytesWritten: Int64, totalBytesExpectedToWrite: Int64) {
-        downloader.updateDownloadedContentLength(urlSessionTaskId: downloadTask.taskIdentifier, length: totalBytesWritten)
-        downloader.updateExpectedContentLength(urlSessionTaskId: downloadTask.taskIdentifier, length: totalBytesExpectedToWrite)
-        downloader.reportProgress(urlSessionTaskId: downloadTask.taskIdentifier)
+        _ = downloader.sessionInitSemaphore.wait(timeout: .now() + Downloader.waitDelay)
+        downloader.sessionInitSemaphore.signal()
+
+        let urlSessionTaskId = downloadTask.taskIdentifier
+
+        if downloader.isRestoredTask(urlSessionTaskId: urlSessionTaskId) {
+            downloader.restoreTasksSemaphore.wait()
+            downloader.restoreTasksSemaphore.signal()
+        }
+
+        downloader.updateDownloadedContentLength(urlSessionTaskId: urlSessionTaskId, length: totalBytesWritten)
+        downloader.updateExpectedContentLength(urlSessionTaskId: urlSessionTaskId, length: totalBytesExpectedToWrite)
+        downloader.reportProgress(urlSessionTaskId: urlSessionTaskId)
     }
 
     func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
+        _ = downloader.sessionInitSemaphore.wait(timeout: .now() + Downloader.waitDelay)
+        downloader.sessionInitSemaphore.signal()
+
+        let urlSessionTaskId = task.taskIdentifier
+
+        if downloader.isRestoredTask(urlSessionTaskId: urlSessionTaskId) {
+            downloader.restoreTasksSemaphore.wait()
+            downloader.restoreTasksSemaphore.signal()
+        }
+
         guard let err = error as NSError? else {
             return
         }
 
+        NSLog("Downloader: received downloader delegate error method for downloadTask = \(task.taskIdentifier)")
         downloader.invalidateTask(urlSessionTaskId: task.taskIdentifier)
         if err.code == NSURLErrorCancelled {
             downloader.removeTask(urlSessionTaskId: task.taskIdentifier)
         } else {
             let resumeData = err.userInfo[NSURLSessionDownloadTaskResumeData] as? Data
-            downloader.reportOnFailure(urlSessionTaskId: task.taskIdentifier, error: error!)
+            downloader.reportOnFailure(urlSessionTaskId: task.taskIdentifier, error: DownloaderError.clientSide(error: err))
             downloader.markAsCanBeRestarted(urlSessionTaskId: task.taskIdentifier, buffer: resumeData)
+        }
+    }
+}
+
+extension Downloader.Cache {
+    var key: String {
+        return "downloaderCacheFor\(downloader.session.configuration.identifier ?? "")"
+    }
+
+    var defaults: UserDefaults {
+        return UserDefaults.standard
+    }
+
+    func flush() {
+        var data = [[String: Any]]()
+        for (urlTaskID, taskInfo) in downloader.tasks {
+            data.append([
+                Downloader.Cache.taskIDKey: taskInfo.task.id,
+                Downloader.Cache.urlTaskIDKey: urlTaskID,
+                Downloader.Cache.urlKey: taskInfo.task.url.absoluteString
+                ])
+        }
+        defaults.set(data, forKey: key)
+        // Write on disk immediately to prevent cache losing
+        defaults.synchronize()
+    }
+
+    func load() -> [(DownloaderTask, Int)] {
+        var result = [(DownloaderTask, Int)]()
+        for value in defaults.object(forKey: key) as? [[String: Any]] ?? [] {
+            if let taskId = value[Downloader.Cache.taskIDKey] as? Int,
+                let urlTaskId = value[Downloader.Cache.urlTaskIDKey] as? Int,
+                let urlString = value[Downloader.Cache.urlKey] as? String,
+                let url = URL(string: urlString) {
+                result.append((DownloaderTask(id: taskId, url: url, executor: downloader, priority: .default), urlTaskId))
+            }
+        }
+        return result
+    }
+}
+
+extension Downloader: RestorableBackgroundDownloaderProtocol {
+    var id: String? {
+        return session.configuration.identifier
+    }
+
+    func resumeRestoredTasks() {
+        defer {
+            restoreTasksSemaphore.signal()
+            NSLog("Downloader: resumed restored downloaders tasks")
+        }
+
+        // Send cancel for all invalid tasks
+        for (key, _) in restoredTasksMapping {
+            if !validRestoredTasksIDs.contains(where: { $0 == key }) {
+                invalidateRestoredTask(urlSessionTaskId: key)
+            }
         }
     }
 }

--- a/Stepic/DownloaderProtocol.swift
+++ b/Stepic/DownloaderProtocol.swift
@@ -8,13 +8,30 @@
 
 import Foundation
 
+enum DownloaderSessionType {
+    case background(id: String)
+    case foreground
+}
+
+enum DownloaderError: Error {
+    case serverSide(statusCode: Int?)
+    case incorrectState
+    case detachedState
+    case clientSide(error: NSError)
+}
+
 protocol DownloaderProtocol: class {
     /// Add task to downloader (w/o execution)
-    func add(task: DownloaderTaskProtocol)
+    func add(task: DownloaderTaskProtocol) throws
     /// Start or resume task (task should be added before)
-    func resume(task: DownloaderTaskProtocol)
+    func resume(task: DownloaderTaskProtocol) throws
     /// Pause task (task should be added before)
-    func pause(task: DownloaderTaskProtocol)
+    func pause(task: DownloaderTaskProtocol) throws
     /// Cancel task (task should be added before)
-    func cancel(task: DownloaderTaskProtocol)
+    func cancel(task: DownloaderTaskProtocol) throws
+    /// Get state for task
+    func getTaskState(for task: DownloaderTaskProtocol) -> DownloaderTaskState?
+
+    /// Init downloader with given session type
+    init(session: DownloaderSessionType)
 }

--- a/Stepic/DownloaderProtocol.swift
+++ b/Stepic/DownloaderProtocol.swift
@@ -1,0 +1,20 @@
+//
+//  DownloaderProtocol.swift
+//  Stepic
+//
+//  Created by Vladislav Kiryukhin on 10.07.2018.
+//  Copyright © 2018 Alex Karpov. All rights reserved.
+//
+
+import Foundation
+
+protocol DownloaderProtocol: class {
+    /// Add task to downloader (w/o execution)
+    func add(task: DownloaderTaskProtocol)
+    /// Start or resume task (task should be added before)
+    func resume(task: DownloaderTaskProtocol)
+    /// Pause task (task should be added before)
+    func pause(task: DownloaderTaskProtocol)
+    /// Cancel task (task should be added before)
+    func cancel(task: DownloaderTaskProtocol)
+}

--- a/Stepic/DownloaderTask.swift
+++ b/Stepic/DownloaderTask.swift
@@ -1,0 +1,69 @@
+//
+//  DownloaderTask.swift
+//  Stepic
+//
+//  Created by Vladislav Kiryukhin on 06.07.2018.
+//  Copyright © 2018 Alex Karpov. All rights reserved.
+//
+
+import Foundation
+
+class DownloaderTask: DownloaderTaskProtocol {
+    private(set) var url: URL
+    private(set) var priority: DownloaderTaskPriority
+    private(set) var id: Int
+
+    /// Task state
+    private var state: DownloaderTaskState
+    /// Current executor
+    private(set) weak var executor: DownloaderProtocol?
+
+    var progressReporter: ((_ progress: Float) -> Void)?
+    var completionReporter: ((_ location: URL) -> Void)?
+    var failureReporter: ((_ error: Error) -> Void)?
+
+    required init(url: URL, priority: DownloaderTaskPriority = .default) {
+        self.url = url
+        self.priority = priority
+        self.state = .inited
+
+        self.id = url.hashValue &* Date().hashValue
+    }
+
+    func add(to executor: DownloaderProtocol) {
+        guard state == .inited else {
+            return
+        }
+
+        self.executor = executor
+        executor.add(task: self)
+    }
+
+    func resume() {
+        guard state == .inited || state == .paused || state == .canceled else {
+            return
+        }
+
+        executor?.resume(task: self)
+    }
+
+    func pause() {
+        guard state == .active else {
+            return
+        }
+
+        executor?.pause(task: self)
+    }
+
+    func cancel() {
+        guard state == .active else {
+            return
+        }
+
+        executor?.cancel(task: self)
+    }
+
+    func set(state: DownloaderTaskState) {
+        self.state = state
+    }
+}

--- a/Stepic/DownloaderTask.swift
+++ b/Stepic/DownloaderTask.swift
@@ -31,7 +31,8 @@ class DownloaderTask: DownloaderTaskProtocol {
     }
 
     convenience init(url: URL, priority: DownloaderTaskPriority = .default) {
-        self.init(id: Int(arc4random()), url: url, executor: nil, priority: priority)
+        let id = Int(arc4random()) &* url.hashValue
+        self.init(id: id, url: url, executor: nil, priority: priority)
     }
 
     init(id: Int, url: URL, executor: DownloaderProtocol? = nil, priority: DownloaderTaskPriority) {

--- a/Stepic/DownloaderTaskProtocol.swift
+++ b/Stepic/DownloaderTaskProtocol.swift
@@ -15,11 +15,11 @@ enum DownloaderTaskPriority: Float {
 }
 
 enum DownloaderTaskState {
-    case inited
+    case attached
+    case detached
     case paused
     case active
-    case completed
-    case canceled
+    case stopped
 }
 
 protocol DownloaderTaskProtocol: class {
@@ -29,18 +29,17 @@ protocol DownloaderTaskProtocol: class {
     var url: URL { get }
     /// Download priority
     var priority: DownloaderTaskPriority { get }
+    /// Download state
+    var state: DownloaderTaskState { get }
 
     /// Reporter block with progress 0.0 - 1.0
-    var progressReporter: ((Float) -> Void)? { get set }
+    var progressReporter: ((Float?) -> Void)? { get set }
     /// Reporter block on completion
     var completionReporter: ((URL) -> Void)? { get set }
     /// Reporter block on failure
     var failureReporter: ((Error) -> Void)? { get set }
-
-    init(url: URL, priority: DownloaderTaskPriority)
-
-    /// Update task state
-    func set(state: DownloaderTaskState)
+    /// Reporter on state changed
+    var stateReporter: ((DownloaderTaskState) -> Void)? { get set }
 
     /// Add & run task with given executor
     func start(with executor: DownloaderProtocol)

--- a/Stepic/DownloaderTaskProtocol.swift
+++ b/Stepic/DownloaderTaskProtocol.swift
@@ -1,0 +1,62 @@
+//
+//  DownloaderTaskProtocol.swift
+//  Stepic
+//
+//  Created by Vladislav Kiryukhin on 10.07.2018.
+//  Copyright © 2018 Alex Karpov. All rights reserved.
+//
+
+import Foundation
+
+enum DownloaderTaskPriority: Float {
+    case low = 0.0
+    case `default` = 0.5
+    case high = 1.0
+}
+
+enum DownloaderTaskState {
+    case inited
+    case paused
+    case active
+    case completed
+    case canceled
+}
+
+protocol DownloaderTaskProtocol: class {
+    /// Task unique id
+    var id: Int { get }
+    /// Download URL
+    var url: URL { get }
+    /// Download priority
+    var priority: DownloaderTaskPriority { get }
+
+    /// Reporter block with progress 0.0 - 1.0
+    var progressReporter: ((Float) -> Void)? { get set }
+    /// Reporter block on completion
+    var completionReporter: ((URL) -> Void)? { get set }
+    /// Reporter block on failure
+    var failureReporter: ((Error) -> Void)? { get set }
+
+    init(url: URL, priority: DownloaderTaskPriority)
+
+    /// Update task state
+    func set(state: DownloaderTaskState)
+
+    /// Add & run task with given executor
+    func start(with executor: DownloaderProtocol)
+    /// Add task to executor
+    func add(to executor: DownloaderProtocol)
+    /// Run task on selected executor
+    func resume()
+    /// Suspend task
+    func pause()
+    /// Cancel task (after this action task can't be resumed)
+    func cancel()
+}
+
+extension DownloaderTaskProtocol {
+    func start(with executor: DownloaderProtocol) {
+        add(to: executor)
+        resume()
+    }
+}

--- a/Stepic/RestorableBackgroundDownloaderProtocol.swift
+++ b/Stepic/RestorableBackgroundDownloaderProtocol.swift
@@ -1,0 +1,20 @@
+//
+//  RestorableBackgroundDownloaderProtocol.swift
+//  Stepic
+//
+//  Created by Vladislav Kiryukhin on 16.07.2018.
+//  Copyright © 2018 Alex Karpov. All rights reserved.
+//
+
+import Foundation
+
+enum RestorableBackgroundDownloaderError: Error {
+    case invalidTask
+}
+
+protocol RestorableBackgroundDownloaderProtocol: DownloaderProtocol {
+    var id: String? { get }
+    var restoredTasks: [DownloaderTaskProtocol] { get }
+
+    func resumeRestoredTasks()
+}

--- a/StepicTests/DownloaderTests.swift
+++ b/StepicTests/DownloaderTests.swift
@@ -1,0 +1,350 @@
+//
+//  DownloaderTests.swift
+//  StepicTests
+//
+//  Created by Vladislav Kiryukhin on 11.07.2018.
+//  Copyright © 2018 Alex Karpov. All rights reserved.
+//
+
+import Foundation
+import Nimble
+import Quick
+import XCTest
+import Mockingjay
+
+class DownloaderTaskMock: DownloaderTask {
+    var isCompleted = false
+
+    // In this tests we run Downloader's methods directly
+    // So task is detached and we should manually update its state
+    var _state: DownloaderTaskState = .detached
+    var customStateReporter: ((DownloaderTaskState) -> Void)?
+
+    override var stateReporter: ((DownloaderTaskState) -> Void)? {
+        get {
+            return { newState in
+                self._state = newState
+                self.customStateReporter?(newState)
+            }
+        }
+        set {
+            self.customStateReporter = newValue
+        }
+    }
+
+    override var state: DownloaderTaskState {
+        return _state
+    }
+}
+
+class DownloaderSpec: QuickSpec {
+    private static let okFileLink = "https://fake.fake/ok.json"
+    private static let fileWithExpectedSizeLink = "https://fake.fake/size.json"
+    private static let notFoundLink = "https://fake.fake/notfound.json"
+
+    private static let fileSizeInBytes: UInt64 = 1024
+    private static let fileChunksCount = 5
+
+    var downloader: Downloader!
+
+    private func isFileExists(url: URL) -> Bool {
+        return FileManager.default.fileExists(atPath: url.path)
+    }
+
+    private func getFileSize(url: URL) -> UInt64? {
+        return (try? FileManager.default.attributesOfItem(atPath: url.path))?[FileAttributeKey.size] as? UInt64
+    }
+
+    private func jsonDataWithExpectedSizeHeader(data: Data, chunksCount: Int) -> ((_ request: URLRequest) -> Response) {
+        return { (request: URLRequest) in
+            let headers = [
+                "Content-Length": "\(data.count)"
+            ]
+
+            return http(200, headers: headers, download: .streamContent(data: data, inChunksOf: chunksCount))(request)
+        }
+    }
+
+    private func jsonDataWithEmptySizeHeader(data: Data, chunksCount: Int) -> ((_ request: URLRequest) -> Response) {
+        return { (request: URLRequest) in
+            return http(200, headers: [String: String](), download: .streamContent(data: data, inChunksOf: chunksCount))(request)
+        }
+    }
+
+    private func setUpNetworkStub() {
+        Nimble.AsyncDefaults.Timeout = 60
+        Nimble.AsyncDefaults.PollInterval = 0.05
+
+        self.stub(uri(DownloaderSpec.okFileLink), self.jsonDataWithEmptySizeHeader(
+            data: Data(count: Int(DownloaderSpec.fileSizeInBytes)),
+            chunksCount: DownloaderSpec.fileChunksCount
+        ))
+        self.stub(uri(DownloaderSpec.fileWithExpectedSizeLink), self.jsonDataWithExpectedSizeHeader(
+            data: Data(count: Int(DownloaderSpec.fileSizeInBytes)),
+            chunksCount: DownloaderSpec.fileChunksCount
+        ))
+        self.stub(uri(DownloaderSpec.notFoundLink), http(404))
+    }
+
+    override func spec() {
+        describe("Downloader") {
+
+            context("when task with correct url and without size in headers executed in downloader") {
+                var task: DownloaderTaskMock!
+
+                beforeEach {
+                    self.setUpNetworkStub()
+                    self.downloader = Downloader(session: .foreground)
+                    task = DownloaderTaskMock(url: URL(string: DownloaderSpec.okFileLink)!)
+                }
+
+                it("reports about completion with correct file") {
+                    waitUntil { done in
+                        task.completionReporter = { url in
+                            expect(self.isFileExists(url: url)) == true
+                            expect(self.getFileSize(url: url)) == DownloaderSpec.fileSizeInBytes
+
+                            done()
+                        }
+
+                        task.failureReporter = { _ in
+                            fail("task should finish correctly")
+
+                            done()
+                        }
+
+                        expect { try self.downloader.add(task: task) }.notTo(throwError())
+                        expect { try self.downloader.resume(task: task) }.notTo(throwError())
+                    }
+                }
+
+                it("reports nil progress") {
+                    waitUntil { done in
+                        task.progressReporter = { progress in
+                            expect(progress).to(beNil())
+                        }
+
+                        task.failureReporter = { _ in
+                            fail("task should finish correctly")
+
+                            done()
+                        }
+
+                        task.completionReporter = { _ in done() }
+
+                        expect { try self.downloader.add(task: task) }.notTo(throwError())
+                        expect { try self.downloader.resume(task: task) }.notTo(throwError())
+                    }
+                }
+            }
+
+            context("when task with 404 url executed in downloader") {
+                var task: DownloaderTaskMock!
+
+                beforeEach {
+                    self.setUpNetworkStub()
+                    task = DownloaderTaskMock(url: URL(string: "http://httpstat.us/404")!)
+                }
+
+                it("cancels task with error") {
+                    waitUntil { done in
+                        task.failureReporter = { error in
+                            expect(task.state) == .stopped
+                            if case DownloaderError.serverSide(_) = error { } else {
+                                fail("after server side error reported wrong error")
+                            }
+
+                            done()
+                        }
+
+                        task.completionReporter = { url in
+                            fail("completion reporter shouldn't be called")
+
+                            done()
+                        }
+
+                        expect { try self.downloader.add(task: task) }.notTo(throwError())
+                        expect { try self.downloader.resume(task: task) }.notTo(throwError())
+                    }
+                }
+            }
+
+            context("when task with correct url and with size in headers executed in downloader") {
+                var task: DownloaderTaskMock!
+
+                beforeEach {
+                    self.setUpNetworkStub()
+                    task = DownloaderTaskMock(url: URL(string: DownloaderSpec.fileWithExpectedSizeLink)!)
+                }
+
+                it("reports correct progress") {
+                    var progresses = [Float]()
+                    waitUntil { done in
+                        task.progressReporter = { progress in
+                            expect(progress).notTo(beNil())
+                            expect(progress!) >= 0.0
+                            expect(progress!) <= 1.0
+
+                            progresses += [progress!]
+                        }
+
+                        task.failureReporter = { _ in
+                            fail("task should finish correctly")
+
+                            done()
+                        }
+
+                        task.completionReporter = { _ in
+                            // Each next progress value should be greater then values before
+                            expect(progresses) == progresses.sorted()
+                            done()
+                        }
+
+                        expect { try self.downloader.add(task: task) }.notTo(throwError())
+                        expect { try self.downloader.resume(task: task) }.notTo(throwError())
+                    }
+                }
+
+                context("when pause called") {
+                    beforeEach {
+                        self.setUpNetworkStub()
+                        self.downloader = Downloader(session: .foreground)
+                    }
+
+                    it("pauses given task") {
+                        var didPauseCall = false
+                        var states = [DownloaderTaskState]()
+                        let semaphore = DispatchSemaphore(value: 1)
+                        task.progressReporter = { progress in
+                            // Some trick: pause task from first call of progress reporter
+                            if !didPauseCall {
+                                expect { try self.downloader.pause(task: task) }.notTo(throwError())
+                                didPauseCall = true
+                                semaphore.signal()
+                            }
+                        }
+                        task.stateReporter = { newState in
+                            states.append(newState)
+                        }
+                        task.failureReporter = { _ in
+                            fail("task should finish correctly")
+                            semaphore.signal()
+                        }
+
+                        waitUntil { done in
+                            task.completionReporter = { url in
+                                // Check states history
+                                expect(states) == [DownloaderTaskState.attached, DownloaderTaskState.active, DownloaderTaskState.paused, DownloaderTaskState.active]
+                                done()
+                            }
+
+                            semaphore.wait()
+                            expect { try self.downloader.add(task: task) }.notTo(throwError())
+                            expect { try self.downloader.resume(task: task) }.notTo(throwError())
+                            semaphore.wait()
+                            expect { try self.downloader.resume(task: task) }.notTo(throwError())
+                        }
+                    }
+                }
+
+                context("when cancel called") {
+                    beforeEach {
+                        self.setUpNetworkStub()
+                        self.downloader = Downloader(session: .foreground)
+                    }
+
+                    it("makes task unresumable") {
+                        var states = [DownloaderTaskState]()
+                        waitUntil { done in
+                            task.stateReporter = { state in
+                                states += [state]
+                                if state == .detached {
+                                    // Task should have state == .detached (not .stopped)
+                                    expect(states) == [DownloaderTaskState.attached, DownloaderTaskState.active, DownloaderTaskState.stopped, DownloaderTaskState.detached]
+                                    done()
+                                }
+                            }
+
+                            var didCancelCall = false
+                            task.progressReporter = { progress in
+                                if !didCancelCall {
+                                    expect { try self.downloader.cancel(task: task) }.notTo(throwError())
+                                    didCancelCall = true
+                                }
+                            }
+
+                            task.failureReporter = { _ in
+                                fail("task should finish correctly")
+
+                                done()
+                            }
+
+                            task.completionReporter = { url in
+                                fail("completion reporter shouldn't be called")
+
+                                done()
+                            }
+
+                            expect { try self.downloader.add(task: task) }.notTo(throwError())
+                            expect { try self.downloader.resume(task: task) }.notTo(throwError())
+                        }
+                    }
+                }
+            }
+
+            context("when multiple tasks executed in downloader simultaneously") {
+                beforeEach {
+                    self.setUpNetworkStub()
+                    self.downloader = Downloader(session: .foreground)
+                }
+
+                it("finish all tasks correctly") {
+                    let group = DispatchGroup()
+                    let queue = DispatchQueue.global(qos: .default)
+
+                    let tasks: [DownloaderTaskMock] = (0...5).map { _ in
+                        DownloaderTaskMock(url: URL(string: DownloaderSpec.fileWithExpectedSizeLink)!)
+                    }
+
+                    // Run all tasks simultaneously
+                    for task in tasks {
+                        task.completionReporter = { _ in
+                            task.isCompleted = true
+                            group.leave()
+                        }
+
+                        group.enter()
+                        expect { try self.downloader.add(task: task) }.notTo(throwError())
+                        expect { try self.downloader.resume(task: task) }.notTo(throwError())
+                    }
+
+                    waitUntil { done in
+                        group.notify(queue: queue) {
+                            for task in tasks {
+                                if task.state != .detached || !task.isCompleted {
+                                    fail("after execution task has invalid state = \(task.state), isCompleted = \(task.isCompleted)")
+                                }
+                            }
+
+                            done()
+                        }
+                    }
+                }
+            }
+
+            context("when try to resume detached task in downloader") {
+                var task: DownloaderTaskMock!
+
+                beforeEach {
+                    self.setUpNetworkStub()
+                    task = DownloaderTaskMock(url: URL(string: DownloaderSpec.fileWithExpectedSizeLink)!)
+                    self.downloader = Downloader(session: .foreground)
+                }
+
+                it("throws error") {
+                    expect { try self.downloader.resume(task: task) }.to(throwError())
+                }
+            }
+        }
+    }
+}

--- a/StepicTests/DownloaderTests.swift
+++ b/StepicTests/DownloaderTests.swift
@@ -300,7 +300,7 @@ class DownloaderSpec: QuickSpec {
                     self.downloader = Downloader(session: .foreground)
                 }
 
-                it("finish all tasks correctly") {
+                it("finishes all tasks correctly") {
                     let group = DispatchGroup()
                     let queue = DispatchQueue.global(qos: .default)
 


### PR DESCRIPTION
**Задача**: [#APPS-1958](https://vyahhi.myjetbrains.com/youtrack/issue/APPS-1958)

**Коротко для Release Notes, в формате «Сделали/Добавили/Исправили N»**: 
Переписан загрузчик файлов

**Описание**:
### Задачи
`DownloaderTaskProtocol` – обертка, через которую осуществляется работа с загрузками внутри загрузчика, без взаимодействия с сетевым слоем. Базовая реализация `DownloaderTask` (от которой планируется наследовать задачи для загрузки видео и прочего контента) не содержит сложной логики и является прокси для загрузчика.
Задача в загрузчике может находиться в следующих состояниях:
+    attached – для задачи задан загрузчик для исполнения
+    detached – для задачи не задан загрузчик для исполнения. Данное состояние задача имеет, например, сразу после инициализации, либо после отмены загрузки 
+    paused – задача приостановлена и ее можно продолжить
+    active – задача исполняется (идет загрузка)
+    stopped – задача остановлена и ее можно перезапустить (с дозагрузкой или сначала). Данное состояние задача имеет после возникшей ошибки 
### Загрузчик
Загрузчик может работать в двух режимах:
+ foreground – foreground сессия, которая не поддерживает загрузку в свернутом состоянии
+ background – background сессия, поддерживается загрузка в свернутом состоянии и восстановление из suspended состояния   

`DownloaderProtocol` – протокол загрузчика, который может работать в обоих режимах, но не поддерживает восстановление из suspended состояния. `RestorableBackgroundDownloaderProtocol: DownloaderProtocol` – протокол загрузчика, который поддерживает восстановление.
`Downloader` – реализация такого загрузчика. Логика, касающаяся обычных загрузок достаточно тривиальна – создаем URLSessionDownloadTask и работаем с ней через обертку. 
### Восстановление загрузок
Загрузчик умеет восстанавливать загрузки из фоновой сессии. Для этого необходимо пересоздать объект с типом сессии `.background` и указать id сессии, которую необходимо использовать. При инициализации будет загружена информация о существующих URLSessionDownloadTask и созданы обертки, которые можно получить с помощью поля `restoredTasks`, чтобы в дальнейшем управлять и отслеживать. После того, как над восстановленными задачами произведены необходимые действия (например, заданы коллбеки), необходимо вызвать метод `resumeRestoredTasks()`, чтобы продолжить получать от них события. Это необходимо, потому что методы делегата начинают вызываться сразу после создания экземпляра URLSession, ещё до создания оберток.
Параллельно с восстановленными загрузками можно исполнять новые задачи в обычном режиме.