### PR TITLE
Fix CongratulationViewController share URL

### DIFF
--- a/Stepic/Config.plist
+++ b/Stepic/Config.plist
@@ -22,6 +22,8 @@
 	</dict>
 	<key>url</key>
 	<dict>
+		<key>appId</key>
+		<string>1064581926</string>
 		<key>adaptiveRating</key>
 		<string>http://52.174.33.220</string>
 		<key>scheme</key>


### PR DESCRIPTION
**Описание**:
Добавил ключ `appId` в `Stepic`. 
`StepicApplicationsInfo.appId` возвращал пустую строку для схемы Stepic.