### PR TITLE
Fix downloads crash on 32-bit devices

### DIFF
--- a/Stepic/DownloaderTask.swift
+++ b/Stepic/DownloaderTask.swift
@@ -31,7 +31,7 @@ class DownloaderTask: DownloaderTaskProtocol {
     }
 
     convenience init(url: URL, priority: DownloaderTaskPriority = .default) {
-        let id = Int(arc4random()) &* url.hashValue
+        let id = Int(arc4random_uniform(UInt32(Int32.max))) &* url.hashValue
         self.init(id: id, url: url, executor: nil, priority: priority)
     }
 

--- a/Stepic/VideoDownloaderTask.swift
+++ b/Stepic/VideoDownloaderTask.swift
@@ -64,7 +64,7 @@ final class VideoDownloaderTask: DownloaderTask {
 
     init(videoId: Int, url: URL) {
         self.videoId = videoId
-        let id = videoId.hashValue &* Int(arc4random())
+        let id = videoId.hashValue &* Int(arc4random_uniform(UInt32(Int32.max)))
         super.init(id: id, url: url, executor: nil, priority: .default)
     }
 


### PR DESCRIPTION
**Задача**: [#APPS-1996](https://vyahhi.myjetbrains.com/youtrack/issue/APPS-1996)

**Описание**:
Исправили краш из-за переполнения инта на 32-битных устройствах.