### PR TITLE
Fix iOS 12 navigation controller crash

### DIFF
--- a/Stepic/Modules/CourseList/CourseListInteractor.swift
+++ b/Stepic/Modules/CourseList/CourseListInteractor.swift
@@ -203,7 +203,8 @@ final class CourseListInteractor: CourseListInteractorProtocol {
                     )
                 )
             }.catch { _ in
-
+                // FIXME: use dismiss with error
+                self.presenter.dismissWaitingState()
             }
         }
     }

--- a/Stepic/Modules/CourseList/CourseListInteractor.swift
+++ b/Stepic/Modules/CourseList/CourseListInteractor.swift
@@ -176,13 +176,13 @@ final class CourseListInteractor: CourseListInteractorProtocol {
 
         if targetCourse.enrolled {
             // Enrolled course -> open last step
+            self.presenter.dismissWaitingState()
             self.moduleOutput?.presentLastStep(
                 course: targetCourse,
                 isAdaptive: self.adaptiveStorageManager.canOpenInAdaptiveMode(
                     courseId: targetCourse.id
                 )
             )
-            self.presenter.dismissWaitingState()
         } else {
             // Unenrolled course -> join, open last step
             self.courseSubscriber.join(course: targetCourse, source: .widget).done { course in
@@ -195,13 +195,13 @@ final class CourseListInteractor: CourseListInteractorProtocol {
                     courseTitle: course.title
                 ).send()
 
+                self.presenter.dismissWaitingState()
                 self.moduleOutput?.presentLastStep(
                     course: targetCourse,
                     isAdaptive: self.adaptiveStorageManager.canOpenInAdaptiveMode(
                         courseId: targetCourse.id
                     )
                 )
-                self.presenter.dismissWaitingState()
             }.catch { _ in
 
             }
@@ -216,14 +216,11 @@ final class CourseListInteractor: CourseListInteractorProtocol {
             fatalError("Invalid module state")
         }
 
-        defer {
-            self.presenter.dismissWaitingState()
-        }
-
         if targetCourse.enrolled {
             // Enrolled course
             // - adaptive -> info
             // - normal -> syllabus
+            self.presenter.dismissWaitingState()
             if self.adaptiveStorageManager.canOpenInAdaptiveMode(courseId: targetCourse.id) {
                 self.moduleOutput?.presentCourseInfo(course: targetCourse)
             } else {
@@ -233,6 +230,7 @@ final class CourseListInteractor: CourseListInteractorProtocol {
             // Unenrolled course
             // - adaptive -> info
             // - normal -> info
+            self.presenter.dismissWaitingState()
             self.moduleOutput?.presentCourseInfo(course: targetCourse)
         }
     }
@@ -245,12 +243,9 @@ final class CourseListInteractor: CourseListInteractorProtocol {
             fatalError("Invalid module state")
         }
 
-        defer {
-            self.presenter.dismissWaitingState()
-        }
-
         if targetCourse.enrolled && self.userAccountService.isAuthorized {
             // Enrolled course -> open last step
+            self.presenter.dismissWaitingState()
             self.moduleOutput?.presentLastStep(
                 course: targetCourse,
                 isAdaptive: self.adaptiveStorageManager.canOpenInAdaptiveMode(
@@ -259,6 +254,7 @@ final class CourseListInteractor: CourseListInteractorProtocol {
             )
         } else {
             // Unenrolled course -> info
+            self.presenter.dismissWaitingState()
             self.moduleOutput?.presentCourseInfo(course: targetCourse)
         }
     }


### PR DESCRIPTION
**Задача**: [#APPS-2097](https://vyahhi.myjetbrains.com/youtrack/issue/APPS-2097)

**Описание**:
До этого блокирующий лоадер работал так:
1. CourseList показывает лоадер
2. CourseList дергает LastStepRouter
3. LastStepRouter показывает лоадер (лоадер показан, игнорится)
4. CourseList скрывает лоадер
5. LastStepRouter скрывает лоадер (действие игнорится) после асинхронной подгрузки. Между 4 и 5 шагами лоадер отсутствует и можно сколько угодно раз совершать действия с курслистом

Правильный порядок:
1. CourseList показывает лоадер
2. CourseList дергает LastStepRouter
3. CourseList скрывает лоадер
4. LastStepRouter показывает лоадер
5. LastStepRouter скрывает лоадер после асинхронной подгрузки