### PR TITLE
Minor fixes

### DIFF
--- a/Stepic/AmplitudeAnalyticsEvents.swift
+++ b/Stepic/AmplitudeAnalyticsEvents.swift
@@ -302,7 +302,7 @@ struct AmplitudeAnalyticsEvents {
 
         static func buttonPressed(id: Int, position: Int) -> AnalyticsEvent {
             return AnalyticsEvent(
-                name: "Button pressed",
+                name: "Story button pressed",
                 parameters: [
                     "id": id,
                     "position": position

--- a/Stepic/Modules/ContinueCourse/ContinueCourseViewController.swift
+++ b/Stepic/Modules/ContinueCourse/ContinueCourseViewController.swift
@@ -82,6 +82,8 @@ extension ContinueCourseViewController: ContinueCourseViewControllerProtocol {
         if viewModel.shouldShowTooltip {
             // Cause anchor should be in true position
             DispatchQueue.main.async { [weak self] in
+                self?.continueCourseView?.setNeedsLayout()
+                self?.continueCourseView?.layoutIfNeeded()
                 self?.continueLearningTooltip.show(
                     direction: .up,
                     in: continueCourseView,

--- a/Stepic/Modules/ContinueCourse/View/ContinueCourseView.swift
+++ b/Stepic/Modules/ContinueCourse/View/ContinueCourseView.swift
@@ -78,5 +78,7 @@ extension ContinueCourseView: ProgrammaticallyInitializableViewProtocol {
         self.lastStepView.snp.makeConstraints { make in
             make.edges.equalToSuperview()
         }
+        self.setNeedsLayout()
+        self.layoutIfNeeded()
     }
 }

--- a/Stepic/Modules/ContinueCourse/View/ContinueCourseView.swift
+++ b/Stepic/Modules/ContinueCourse/View/ContinueCourseView.swift
@@ -78,7 +78,5 @@ extension ContinueCourseView: ProgrammaticallyInitializableViewProtocol {
         self.lastStepView.snp.makeConstraints { make in
             make.edges.equalToSuperview()
         }
-        self.setNeedsLayout()
-        self.layoutIfNeeded()
     }
 }


### PR DESCRIPTION
**Описание**:
Здесь два фикса:
* Пофиксили название события для нажатия кнопки в истории
* Пофиксили багу, когда при открытии домашней страницы новым пользователем тултип уезжал куда-то в левый верхний угол