### PR TITLE
Report not determined push permission status before launch first time

### DIFF
--- a/Stepic/AppDelegate.swift
+++ b/Stepic/AppDelegate.swift
@@ -86,6 +86,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         if !DefaultsContainer.launch.didLaunch {
             ActiveSplitTestsContainer.setActiveTestsGroups()
+            AnalyticsUserProperties.shared.setPushPermissionStatus(.notDetermined)
             AnalyticsReporter.reportEvent(AnalyticsEvents.App.firstLaunch, parameters: nil)
             AmplitudeAnalyticsEvents.Launch.firstTime.send()
         }


### PR DESCRIPTION
**Описание**:
Установка `push_permission` в `not_determined` при первом запуске.