### PR TITLE
Sending open link event when branch link is opened

### DIFF
--- a/LaunchDefaultsContainer.swift
+++ b/LaunchDefaultsContainer.swift
@@ -12,6 +12,8 @@ class LaunchDefaultsContainer {
     fileprivate let defaults = UserDefaults.standard
 
     fileprivate let didLaunchKey = "didLaunchKey"
+    fileprivate let startVersionKey = "startVersionKey"
+    fileprivate let isFirstSessionKey: String = "isFirstSessionKey"
 
     var didLaunch: Bool {
         get {
@@ -28,8 +30,6 @@ class LaunchDefaultsContainer {
         }
     }
 
-    fileprivate let startVersionKey = "startVersionKey"
-
     var startVersion: String {
         get {
             if let startVersion = defaults.value(forKey: startVersionKey) as? String {
@@ -43,8 +43,6 @@ class LaunchDefaultsContainer {
             defaults.set(value, forKey: startVersionKey)
         }
     }
-
-    fileprivate let isFirstSessionKey: String = "isFirstSessionKey"
 
     var isFirstSession: Bool {
         get {

--- a/LaunchDefaultsContainer.swift
+++ b/LaunchDefaultsContainer.swift
@@ -44,6 +44,22 @@ class LaunchDefaultsContainer {
         }
     }
 
+    fileprivate let isFirstSessionKey: String = "isFirstSessionKey"
+
+    var isFirstSession: Bool {
+        get {
+            if let isFirstSession = defaults.value(forKey: isFirstSessionKey) as? Bool {
+                return isFirstSession
+            } else {
+                return true
+            }
+        }
+
+        set(value) {
+            defaults.set(value, forKey: isFirstSessionKey)
+        }
+    }
+
     @discardableResult func initStartVersion() -> String {
         let version = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "0"
         self.startVersion = version

--- a/Stepic/Analytics/AmplitudeAnalyticsEvents.swift
+++ b/Stepic/Analytics/AmplitudeAnalyticsEvents.swift
@@ -20,6 +20,18 @@ struct AmplitudeAnalyticsEvents {
         }
     }
 
+    struct Branch {
+        static func linkOpened(isFirstSession: Bool, campaign: String?) -> AnalyticsEvent {
+            return AnalyticsEvent(
+                name: "Branch link opened",
+                parameters: [
+                    "is_first_session": isFirstSession,
+                    "campaign": campaign as Any
+                ]
+            )
+        }
+    }
+
     struct Onboarding {
         static func screenOpened(screen: Int) -> AnalyticsEvent {
             return AnalyticsEvent(

--- a/Stepic/AppDelegate.swift
+++ b/Stepic/AppDelegate.swift
@@ -94,11 +94,15 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         if !DefaultsContainer.launch.didLaunch {
             self.didShowOnboarding = false
+            DefaultsContainer.launch.didLaunch = true
             DefaultsContainer.launch.initStartVersion()
             ActiveSplitTestsContainer.setActiveTestsGroups()
             AnalyticsUserProperties.shared.setPushPermissionStatus(.notDetermined)
             AnalyticsReporter.reportEvent(AnalyticsEvents.App.firstLaunch, parameters: nil)
             AmplitudeAnalyticsEvents.Launch.firstTime.send()
+            DefaultsContainer.launch.isFirstSession = true
+        } else {
+            DefaultsContainer.launch.isFirstSession = false
         }
 
         if StepicApplicationsInfo.inAppUpdatesAvailable {

--- a/Stepic/Services/Deep Links/BranchService.swift
+++ b/Stepic/Services/Deep Links/BranchService.swift
@@ -21,7 +21,8 @@ final class BranchService {
             guard let data = params as? [String: AnyObject] else {
                 return
             }
-
+            let campaign = data["~campaign"] as? String
+            AmplitudeAnalyticsEvents.Branch.linkOpened(isFirstSession: DefaultsContainer.launch.isFirstSession, campaign: campaign).send()
             DispatchQueue.main.async { [weak self] in
                 self?.deepLinkRoutingService.route(DeepLinkRoute(branchData: data))
             }

--- a/Stepic/StyledTabBarViewController.swift
+++ b/Stepic/StyledTabBarViewController.swift
@@ -11,6 +11,7 @@ import UIKit
 class StyledTabBarViewController: UITabBarController {
 
     let items = StepicApplicationsInfo.Modules.tabs?.compactMap { TabController(rawValue: $0)?.itemInfo } ?? []
+    var didShowOnboardingThisSession = false
 
     var notificationsBadgeNumber: Int {
         get {
@@ -56,10 +57,9 @@ class StyledTabBarViewController: UITabBarController {
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
 
-        if !DefaultsContainer.launch.didLaunch {
-            DefaultsContainer.launch.didLaunch = true
-
+        if DefaultsContainer.launch.isFirstSession && !didShowOnboardingThisSession {
             let onboardingVC = ControllerHelper.instantiateViewController(identifier: "Onboarding", storyboardName: "Onboarding")
+            didShowOnboardingThisSession = true
             present(onboardingVC, animated: true, completion: nil)
         }
     }


### PR DESCRIPTION
**Задача**: [#APPS-2139](https://vyahhi.myjetbrains.com/youtrack/issue/APPS-2139)

**Описание**:
Сделали бесплатно то, что бранч предлагает за денежку.
Отсылаем событие `Branch link opened` c параметрами `is_first_session` и `campaign` при открытии ссылки. Также немного изменил условия открытия онбординга и изменения параметра `didLaunch` в дефолтсах