### PR TITLE
Fix "continue course" widget progress

### DIFF
--- a/Stepic/Sources/Modules/ExploreSubmodules/ContinueCourse/ContinueCoursePresenter.swift
+++ b/Stepic/Sources/Modules/ExploreSubmodules/ContinueCourse/ContinueCoursePresenter.swift
@@ -27,8 +27,12 @@ final class ContinueCoursePresenter: ContinueCoursePresenterProtocol {
     private func makeViewModel(course: Course) -> ContinueCourseViewModel {
         let progress: ContinueCourseViewModel.ProgressDescription = {
             if let progress = course.progress {
-                let normalizedPercent = progress.percentPassed / 100.0
-                return (description: FormatterHelper.integerPercent(normalizedPercent), value: normalizedPercent)
+                var normalizedPercent = progress.percentPassed
+                normalizedPercent.round(.up)
+                return (
+                    description: FormatterHelper.integerPercent(Int(normalizedPercent)),
+                    value: normalizedPercent / 100
+                )
             }
             return nil
         }()


### PR DESCRIPTION
**Задача**: [#APPS-2312](https://vyahhi.myjetbrains.com/youtrack/issue/APPS-2312)

**Описание**:
Прогресс на виджете "Продолжить" округляется так же, как и в виджетах с курсом.
