### PR TITLE
Check for existing percent escapes first to prevent double-escaping

### DIFF
--- a/Stepic/DiscussionAlertConstructor.swift
+++ b/Stepic/DiscussionAlertConstructor.swift
@@ -8,45 +8,50 @@
 
 import Foundation
 
-class DiscussionAlertConstructor {
-    static func getCommentAlert(_ comment: Comment, replyBlock: @escaping (() -> Void), likeBlock: @escaping (() -> Void), abuseBlock: @escaping (() -> Void), openURLBlock: @escaping ((URL) -> Void)) -> UIAlertController {
+final class DiscussionAlertConstructor {
+    static func getCommentAlert(
+        _ comment: Comment,
+        replyBlock: @escaping (() -> Void),
+        likeBlock: @escaping (() -> Void),
+        abuseBlock: @escaping (() -> Void),
+        openURLBlock: @escaping ((URL) -> Void)
+    ) -> UIAlertController {
         let alert = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
 
-        let links = HTMLParsingUtil.getAllLinksWithText(comment.text)
-
-        for link in links {
-            alert.addAction(UIAlertAction(title: link.text, style: .default, handler: {
-                    _ in
-                    if let url = URL(string: link.link.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)!) {
-                        openURLBlock(url)
-                    }
-                })
-            )
+        let links = HTMLParsingUtil.getAllLinksWithText(comment.text).compactMap { item -> (url: URL, text: String)? in
+            if let url = URL(stringToEncode: item.link) {
+                return (url: url, text: item.text)
+            } else {
+                return nil
+            }
         }
 
-        alert.addAction(UIAlertAction(title: NSLocalizedString("Reply", comment: ""), style: .default, handler: {
-                _ in
-                replyBlock()
-        })
-        )
+        for link in links {
+            alert.addAction(UIAlertAction(title: link.text, style: .default, handler: { _ in
+                openURLBlock(link.url)
+            }))
+        }
+
+        alert.addAction(UIAlertAction(title: NSLocalizedString("Reply", comment: ""), style: .default, handler: { _ in
+            replyBlock()
+        }))
 
         if comment.userId != AuthInfo.shared.userId {
-
-            let likeTitle: String = (comment.vote.value == VoteValue.Epic) ? NSLocalizedString("Unlike", comment: "") : NSLocalizedString("Like", comment: "")
-
+            let likeTitle: String = (comment.vote.value == VoteValue.Epic)
+                ? NSLocalizedString("Unlike", comment: "")
+                : NSLocalizedString("Like", comment: "")
             alert.addAction(UIAlertAction(title: likeTitle, style: .default, handler: {
-                    _ in
-                    likeBlock()
-            })
-            )
+                _ in
+                likeBlock()
+            }))
 
-            let abuseTitle: String = (comment.vote.value == VoteValue.Abuse) ? NSLocalizedString("Unabuse", comment: "") : NSLocalizedString("Abuse", comment: "")
-
+            let abuseTitle: String = (comment.vote.value == VoteValue.Abuse)
+                ? NSLocalizedString("Unabuse", comment: "")
+                : NSLocalizedString("Abuse", comment: "")
             alert.addAction(UIAlertAction(title: abuseTitle, style: .destructive, handler: {
-                    _ in
-                    abuseBlock()
-                })
-            )
+                _ in
+                abuseBlock()
+            }))
         }
         alert.addAction(UIAlertAction(title: NSLocalizedString("Cancel", comment: ""), style: .cancel, handler: nil))
 

--- a/Stepic/DiscussionAlertConstructor.swift
+++ b/Stepic/DiscussionAlertConstructor.swift
@@ -19,7 +19,9 @@ final class DiscussionAlertConstructor {
         let alert = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
 
         let links = HTMLParsingUtil.getAllLinksWithText(comment.text).compactMap { item -> (url: URL, text: String)? in
-            if let url = URL(stringToEncode: item.link) {
+            if let decodedLink = item.link.removingPercentEncoding,
+               let encodedLink = decodedLink.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed),
+               let url = URL(string: encodedLink) {
                 return (url: url, text: item.text)
             } else {
                 return nil

--- a/Stepic/Extensions/URL+AppendQueryParameters.swift
+++ b/Stepic/Extensions/URL+AppendQueryParameters.swift
@@ -9,19 +9,6 @@
 import Foundation
 
 extension URL {
-    /// Check for existing percent escapes first to prevent double-escaping of % character and initialize with encoded string.
-    ///
-    /// Returns `nil` if a `URL` cannot be formed with the string.
-    init?(stringToEncode: String) {
-        if stringToEncode.range(of: "%[0-9A-Fa-f]{2}", options: .regularExpression) != nil {
-            self.init(string: stringToEncode)
-        } else if let encodedString = stringToEncode.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) {
-            self.init(string: encodedString)
-        } else {
-            return nil
-        }
-    }
-
     /// URL with appending query parameters.
     ///
     /// - Parameter parameters: parameters dictionary.

--- a/Stepic/Extensions/URL+AppendQueryParameters.swift
+++ b/Stepic/Extensions/URL+AppendQueryParameters.swift
@@ -9,6 +9,19 @@
 import Foundation
 
 extension URL {
+    /// Check for existing percent escapes first to prevent double-escaping of % character and initialize with encoded string.
+    ///
+    /// Returns `nil` if a `URL` cannot be formed with the string.
+    init?(stringToEncode: String) {
+        if stringToEncode.range(of: "%[0-9A-Fa-f]{2}", options: .regularExpression) != nil {
+            self.init(string: stringToEncode)
+        } else if let encodedString = stringToEncode.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) {
+            self.init(string: encodedString)
+        } else {
+            return nil
+        }
+    }
+
     /// URL with appending query parameters.
     ///
     /// - Parameter parameters: parameters dictionary.


### PR DESCRIPTION
**Задача**: [#2339](https://vyahhi.myjetbrains.com/youtrack/issue/APPS-2339)

**Описание**:
Исправили двойную конвертацию URL строки в комментариях к уроку.