### PR TITLE
Fix crash on lesson navigation

### DIFF
--- a/Stepic/Sources/Modules/NewLesson/NewLessonDataFlow.swift
+++ b/Stepic/Sources/Modules/NewLesson/NewLessonDataFlow.swift
@@ -86,6 +86,17 @@ enum NewLesson {
         }
     }
 
+    /// Handle HUD
+    enum BlockingWaitingIndicatorUpdate {
+        struct Response {
+            let shouldDismiss: Bool
+        }
+
+        struct ViewModel {
+            let shouldDismiss: Bool
+        }
+    }
+
     // MARK: Enums
 
     enum ViewControllerState {

--- a/Stepic/Sources/Modules/NewLesson/NewLessonInteractor.swift
+++ b/Stepic/Sources/Modules/NewLesson/NewLessonInteractor.swift
@@ -129,6 +129,8 @@ final class NewLessonInteractor: NewLessonInteractorProtocol {
             self.presenter.presentLessonTooltipInfo(
                 response: .init(lesson: lesson, steps: steps, progresses: progresses)
             )
+        }.ensure {
+            self.presenter.presentWaitingState(response: .init(shouldDismiss: true))
         }.catch { error in
             print("new lesson interactor: error while loading lesson = \(error)")
             self.presenter.presentLesson(response: .init(state: .failure(error)))
@@ -199,6 +201,7 @@ extension NewLessonInteractor: NewStepOutputProtocol {
             return
         }
 
+        self.presenter.presentWaitingState(response: .init(shouldDismiss: false))
         self.refresh(context: .unit(id: unit.id))
     }
 
@@ -207,6 +210,7 @@ extension NewLessonInteractor: NewStepOutputProtocol {
             return
         }
 
+        self.presenter.presentWaitingState(response: .init(shouldDismiss: false))
         self.refresh(context: .unit(id: unit.id))
     }
 

--- a/Stepic/Sources/Modules/NewLesson/NewLessonPresenter.swift
+++ b/Stepic/Sources/Modules/NewLesson/NewLessonPresenter.swift
@@ -7,6 +7,7 @@ protocol NewLessonPresenterProtocol {
     func presentStepTooltipInfoUpdate(response: NewLesson.StepTooltipInfoUpdate.Response)
     func presentStepPassedStatusUpdate(response: NewLesson.StepPassedStatusUpdate.Response)
     func presentCurrentStepUpdate(response: NewLesson.CurrentStepUpdate.Response)
+    func presentWaitingState(response: NewLesson.BlockingWaitingIndicatorUpdate.Response)
 }
 
 final class NewLessonPresenter: NewLessonPresenterProtocol {
@@ -67,6 +68,10 @@ final class NewLessonPresenter: NewLessonPresenterProtocol {
 
     func presentCurrentStepUpdate(response: NewLesson.CurrentStepUpdate.Response) {
         self.viewController?.displayCurrentStepUpdate(viewModel: .init(index: response.index))
+    }
+
+    func presentWaitingState(response: NewLesson.BlockingWaitingIndicatorUpdate.Response) {
+        self.viewController?.displayBlockingLoadingIndicator(viewModel: .init(shouldDismiss: response.shouldDismiss))
     }
 
     // MAKE: Private API

--- a/Stepic/Sources/Modules/NewLesson/NewLessonViewController.swift
+++ b/Stepic/Sources/Modules/NewLesson/NewLessonViewController.swift
@@ -1,6 +1,7 @@
 import EasyTipView
 import Pageboy
 import SnapKit
+import SVProgressHUD
 import Tabman
 import UIKit
 
@@ -11,6 +12,7 @@ protocol NewLessonViewControllerProtocol: class {
     func displayStepTooltipInfoUpdate(viewModel: NewLesson.StepTooltipInfoUpdate.ViewModel)
     func displayStepPassedStatusUpdate(viewModel: NewLesson.StepPassedStatusUpdate.ViewModel)
     func displayCurrentStepUpdate(viewModel: NewLesson.CurrentStepUpdate.ViewModel)
+    func displayBlockingLoadingIndicator(viewModel: NewLesson.BlockingWaitingIndicatorUpdate.ViewModel)
 }
 
 final class NewLessonViewController: TabmanViewController, ControllerWithStepikPlaceholder {
@@ -361,12 +363,17 @@ extension NewLessonViewController: PageboyViewControllerDataSource {
         for pageboyViewController: PageboyViewController,
         at index: PageboyViewController.PageIndex
     ) -> UIViewController? {
+        guard 0..<self.stepControllers.count ~= index else {
+            return nil
+        }
+
         let controller = self.loadStepIfNeeded(index: index)
         self.updateLessonNavigationInStep(
             index: index,
             hasNavigationToPreviousUnit: self.hasNavigationToPreviousUnit,
             hasNavigationToNextUnit: self.hasNavigationToNextUnit
         )
+
         return controller
     }
 
@@ -428,6 +435,14 @@ extension NewLessonViewController: NewLessonViewControllerProtocol {
 
     func displayCurrentStepUpdate(viewModel: NewLesson.CurrentStepUpdate.ViewModel) {
         self.scrollToPage(.at(index: viewModel.index), animated: true)
+    }
+
+    func displayBlockingLoadingIndicator(viewModel: NewLesson.BlockingWaitingIndicatorUpdate.ViewModel) {
+        if viewModel.shouldDismiss {
+            SVProgressHUD.dismiss()
+        } else {
+            SVProgressHUD.show()
+        }
     }
 }
 


### PR DESCRIPTION
**Задача**: [#APPS-2424](https://vyahhi.myjetbrains.com/youtrack/issue/APPS-2424)

**Описание**:
Исправили краш на экране урока, при навигировании на следующий/предыдущий урок, выполняемый одновременно с скроллом табов, в следствии чего возникало обращение к несуществующему индексу.