### PR TITLE
Hotfix web view content height

### DIFF
--- a/Stepic.xcodeproj/project.pbxproj
+++ b/Stepic.xcodeproj/project.pbxproj
@@ -7568,7 +7568,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 150;
+				CURRENT_PROJECT_VERSION = 151;
 				DEVELOPMENT_TEAM = UJ4KC2QN7B;
 				ENABLE_BITCODE = YES;
 				INFOPLIST_FILE = Stepic/Info.plist;
@@ -7598,7 +7598,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 150;
+				CURRENT_PROJECT_VERSION = 151;
 				DEVELOPMENT_TEAM = UJ4KC2QN7B;
 				ENABLE_BITCODE = YES;
 				INFOPLIST_FILE = Stepic/Info.plist;

--- a/Stepic/Info.plist
+++ b/Stepic/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.95</string>
+	<string>1.95.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>
@@ -54,7 +54,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>150</string>
+	<string>151</string>
 	<key>Fabric</key>
 	<dict>
 		<key>APIKey</key>

--- a/Stepic/ModalOrPushStackRouter.swift
+++ b/Stepic/ModalOrPushStackRouter.swift
@@ -52,7 +52,12 @@ final class ModalOrPushStackRouter: SourcelessRouter, RouterProtocol {
     }
 
     private func openWeb(path: String, from source: UIViewController) {
-        if let url = URL(string: path)?.appendingQueryParameters(["from_mobile_app": "true"]) {
+        guard let url = URL(string: path)?.appendingQueryParameters(["from_mobile_app": "true"]),
+              let scheme = url.scheme?.lowercased() else {
+            return
+        }
+
+        if ["http", "https"].contains(scheme) {
             source.present(SFSafariViewController(url: url), animated: true)
         }
     }

--- a/Stepic/Scripts.swift
+++ b/Stepic/Scripts.swift
@@ -31,9 +31,7 @@ struct Scripts {
     }
 
     static var localTex: String {
-        return RemoteConfig.shared.newLessonAvailable
-            ? loadScriptWithKey(localKaTeXScriptKey)
-            : "\(loadScriptWithKey(localTexScriptKey))\(mathJaxLocalPathScript)"
+        return "\(loadScriptWithKey(localTexScriptKey))\(mathJaxLocalPathScript)"
     }
 
     static var metaViewport: String {

--- a/Stepic/Sources/Frameworks/ContentProcessor/ContentProcessor.swift
+++ b/Stepic/Sources/Frameworks/ContentProcessor/ContentProcessor.swift
@@ -47,7 +47,6 @@ final class ContentProcessor: ContentProcessorProtocol {
         let bodyTailInjections = injectionsToInject.map { $0.bodyTailScript }.joined(separator: "\n")
 
         return """
-        <!DOCTYPE html>
         <html>
         <head>
             \(headInjections)

--- a/Stepic/Sources/Modules/Quizzes/NewChoiceQuiz/NewChoiceQuizView.swift
+++ b/Stepic/Sources/Modules/Quizzes/NewChoiceQuiz/NewChoiceQuizView.swift
@@ -139,6 +139,9 @@ final class NewChoiceQuizView: UIView {
 
         self.loadGroup = DispatchGroup()
         self.loadGroup?.notify(queue: .main) { [weak self] in
+            // dispatch_group_leave call isn't balanced with dispatch_group_enter, deinit dispatch_group_t here to
+            // prevent possible future call to leave onContentLoad.
+            self?.loadGroup = nil
             self?.endLoading()
         }
 

--- a/StepicTests/Info.plist
+++ b/StepicTests/Info.plist
@@ -15,10 +15,10 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.95</string>
+	<string>1.95.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>150</string>
+	<string>151</string>
 </dict>
 </plist>

--- a/StickerPackExtension/Info.plist
+++ b/StickerPackExtension/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.95</string>
+	<string>1.95.1</string>
 	<key>CFBundleVersion</key>
-	<string>150</string>
+	<string>151</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionPointIdentifier</key>


### PR DESCRIPTION
**Описание**:
- Откатили использование KaTeX для рендеринга математических формул, т.к. высота веб-вью на iOS 13 считается неверно, это происходит при добавление необходимого для работы KaTeX `<!DOCTYPE html>` тега.
- Пофиксили краш при попытке открыть неподдерживаемый тип URL в веб-контроллер.
- Пофиксили краш в новом choice квизе при несбалансированном входе и выходе из `DispatchGroup`.