### PR TITLE
Text steps as downloadable content

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -155,7 +155,7 @@ PODS:
     - PromiseKit/CorePromise
   - PromiseKit/UIKit (6.11.0):
     - PromiseKit/CorePromise
-  - Protobuf (3.10.0)
+  - Protobuf (3.11.0)
   - Quick (2.2.0)
   - Reveal-SDK (24)
   - SDWebImage (5.3.2):
@@ -370,7 +370,7 @@ SPEC CHECKSUMS:
   pop: d582054913807fd11fd50bfe6a539d91c7e1a55a
   Presentr: 7078d7eb5d1661ebeaae60c9e42a1e534de1b993
   PromiseKit: e4863d06976e7dee5e41c04fc7371c16b3600292
-  Protobuf: a4dc852ad69c027ca2166ed287b856697814375b
+  Protobuf: 394b2bf29ec303f4325e3ee4892c09e675647152
   Quick: 7fb19e13be07b5dfb3b90d4f9824c855a11af40e
   Reveal-SDK: 5d7e56b8f018c0a88b3a2c10bf68d598bbd3b071
   SDWebImage: 6ac2eb96571bff96ecde31a987172c5934a0eb7d

--- a/Stepic/Sources/Modules/CourseInfoSubmodules/CourseInfoTabSyllabus/Provider/SyllabusDownloadsService.swift
+++ b/Stepic/Sources/Modules/CourseInfoSubmodules/CourseInfoTabSyllabus/Provider/SyllabusDownloadsService.swift
@@ -332,9 +332,9 @@ final class SyllabusDownloadsService: SyllabusDownloadsServiceProtocol {
         let stepsWithVideoCount = steps
             .filter { $0.block.type == .video }
             .count
-        // Lesson has no steps with video
+        // Lesson has no steps with video and all steps cached -> return "cached" state.
         if stepsWithVideoCount == 0 {
-            return .notAvailable
+            return .available(isCached: true)
         }
 
         let stepsWithCachedVideoCount = steps


### PR DESCRIPTION
**Задача**: [#APPS-2551](https://vyahhi.myjetbrains.com/youtrack/issue/APPS-2551)

**Описание**:
Текстовые шаги считаются как загружаемый контент, т.е. для текстовых уроков/модулей/курсов теперь отображается закэшированный статус, когда они скачаны и их также можно удалять, как и шаги с видео.