### PR TITLE
Fix DownloadControlView circle rotation animation freezes

### DIFF
--- a/Stepic/Sources/Views/DownloadControlView.swift
+++ b/Stepic/Sources/Views/DownloadControlView.swift
@@ -123,6 +123,8 @@ final class DownloadControlView: UIControl {
         rotation.byValue = 2 * Float.pi
         rotation.duration = Animation.pendingDuration
         rotation.repeatCount = .infinity
+        // Prevents CABasicAnimation object being destroyed APPS-2587.
+        rotation.isRemovedOnCompletion = false
 
         self.pendingCircleLayer.add(rotation, forKey: "circleRotation")
     }


### PR DESCRIPTION
**Задача**: [#APPS-2587](https://vyahhi.myjetbrains.com/youtrack/issue/APPS-2587)

**Описание**:
Исправили 'зависание' анимации вращения кнопки скачивания.