### PR TITLE
Copy stripped text out of HTML in discussions 

### DIFF
--- a/Stepic/Sources/Modules/Discussions/DiscussionsPresenter.swift
+++ b/Stepic/Sources/Modules/Discussions/DiscussionsPresenter.swift
@@ -232,6 +232,7 @@ final class DiscussionsPresenter: DiscussionsPresenterProtocol {
                 return comment.text
             }
         }()
+        let strippedAndTrimmedText = strippedText.trimmingCharacters(in: .whitespacesAndNewlines)
 
         return DiscussionsCommentViewModel(
             id: comment.id,
@@ -241,7 +242,7 @@ final class DiscussionsPresenter: DiscussionsPresenterProtocol {
             isPinned: comment.isPinned,
             isSelected: isSelected,
             username: username,
-            strippedText: strippedText,
+            strippedText: strippedAndTrimmedText,
             processedText: text,
             isWebViewSupportNeeded: isWebViewSupportNeeded,
             formattedDate: formattedDate,

--- a/Stepic/Sources/Modules/Discussions/DiscussionsPresenter.swift
+++ b/Stepic/Sources/Modules/Discussions/DiscussionsPresenter.swift
@@ -1,3 +1,4 @@
+import Kanna
 import UIKit
 
 protocol DiscussionsPresenterProtocol {
@@ -223,6 +224,15 @@ final class DiscussionsPresenter: DiscussionsPresenterProtocol {
             return nil
         }()
 
+        let strippedText: String = {
+            do {
+                let htmlDocument = try Kanna.HTML(html: comment.text, encoding: .utf8)
+                return htmlDocument.css("*").first?.text ?? comment.text
+            } catch {
+                return comment.text
+            }
+        }()
+
         return DiscussionsCommentViewModel(
             id: comment.id,
             avatarImageURL: avatarImageURL,
@@ -231,7 +241,7 @@ final class DiscussionsPresenter: DiscussionsPresenterProtocol {
             isPinned: comment.isPinned,
             isSelected: isSelected,
             username: username,
-            rawText: comment.text,
+            strippedText: strippedText,
             processedText: text,
             isWebViewSupportNeeded: isWebViewSupportNeeded,
             formattedDate: formattedDate,

--- a/Stepic/Sources/Modules/Discussions/DiscussionsViewController.swift
+++ b/Stepic/Sources/Modules/Discussions/DiscussionsViewController.swift
@@ -420,7 +420,7 @@ extension DiscussionsViewController: DiscussionsTableViewDataSourceDelegate {
                 title: NSLocalizedString("Copy", comment: ""),
                 style: .default,
                 handler: { _ in
-                    UIPasteboard.general.string = viewModel.rawText
+                    UIPasteboard.general.string = viewModel.strippedText
                 }
             )
         )

--- a/Stepic/Sources/Modules/Discussions/DiscussionsViewModel.swift
+++ b/Stepic/Sources/Modules/Discussions/DiscussionsViewModel.swift
@@ -21,7 +21,7 @@ struct DiscussionsCommentViewModel {
     let isPinned: Bool
     let isSelected: Bool
     let username: String
-    let rawText: String
+    let strippedText: String
     let processedText: String
     let isWebViewSupportNeeded: Bool
     let formattedDate: String


### PR DESCRIPTION
**Задача**: [#APPS-2558](https://vyahhi.myjetbrains.com/youtrack/issue/APPS-2558)

**Описание**:
Заменили копирование сырого HTML текста на распарсенный.