### PR TITLE
Fix code badge not being visible in fullscreen code quiz

### DIFF
--- a/Stepic/Sources/Modules/Quizzes/NewCodeQuiz/Views/CodeEditor/CodeEditorView.swift
+++ b/Stepic/Sources/Modules/Quizzes/NewCodeQuiz/Views/CodeEditor/CodeEditorView.swift
@@ -28,7 +28,7 @@ extension CodeEditorViewDelegate {
 
 extension CodeEditorView {
     struct Appearance {
-        let languageNameLabelLayoutInsets = LayoutInsets(top: 8, right: 16)
+        var languageNameLabelLayoutInsets = LayoutInsets(top: 8, right: 16)
         let languageNameLabelTextColor = UIColor.mainDark
         let languageNameLabelBackgroundColor = UIColor(hex: 0xF6F6F6).withAlphaComponent(0.75)
         let languageNameLabelFont = UIFont.systemFont(ofSize: 10)

--- a/Stepic/Sources/Modules/Quizzes/NewCodeQuizFullscreen/Tabs/Instruction/NewCodeQuizFullscreenInstructionView.swift
+++ b/Stepic/Sources/Modules/Quizzes/NewCodeQuizFullscreen/Tabs/Instruction/NewCodeQuizFullscreenInstructionView.swift
@@ -100,7 +100,8 @@ extension NewCodeQuizFullscreenInstructionView: ProgrammaticallyInitializableVie
     func makeConstraints() {
         self.scrollableStackView.translatesAutoresizingMaskIntoConstraints = false
         self.scrollableStackView.snp.makeConstraints { make in
-            make.edges.equalToSuperview()
+            make.leading.trailing.equalTo(self.safeAreaLayoutGuide)
+            make.top.bottom.equalToSuperview()
         }
 
         self.loadingIndicatorView.translatesAutoresizingMaskIntoConstraints = false

--- a/Stepic/Sources/Modules/Quizzes/NewCodeQuizFullscreen/Tabs/NewCodeQuizFullscreenCodeViewController.swift
+++ b/Stepic/Sources/Modules/Quizzes/NewCodeQuizFullscreen/Tabs/NewCodeQuizFullscreenCodeViewController.swift
@@ -113,18 +113,23 @@ final class NewCodeQuizFullscreenCodeViewController: UIViewController {
         self.view.addSubview(self.codeEditorView)
         self.codeEditorView.translatesAutoresizingMaskIntoConstraints = false
         self.codeEditorView.snp.makeConstraints { make in
-            make.edges.equalToSuperview()
+            make.leading.top.trailing.equalTo(self.view.safeAreaLayoutGuide)
+            make.bottom.equalToSuperview()
         }
 
         self.view.addSubview(self.submitButton)
         self.submitButton.translatesAutoresizingMaskIntoConstraints = false
         self.submitButton.snp.makeConstraints { make in
-            make.leading.equalToSuperview().offset(Appearance.submitButtonInsets.left)
-            make.trailing.equalToSuperview().offset(-Appearance.submitButtonInsets.right)
-            make.height.equalTo(Appearance.submitButtonHeight)
+            make.leading
+                .equalTo(self.view.safeAreaLayoutGuide.snp.leading)
+                .offset(Appearance.submitButtonInsets.left)
+            make.trailing
+                .equalTo(self.view.safeAreaLayoutGuide.snp.trailing)
+                .offset(-Appearance.submitButtonInsets.right)
             make.bottom
                 .equalTo(self.view.safeAreaLayoutGuide.snp.bottom)
                 .offset(-Appearance.submitButtonInsets.bottom)
+            make.height.equalTo(Appearance.submitButtonHeight)
         }
     }
 

--- a/Stepic/Sources/Modules/Quizzes/NewCodeQuizFullscreen/Tabs/NewCodeQuizFullscreenCodeViewController.swift
+++ b/Stepic/Sources/Modules/Quizzes/NewCodeQuizFullscreen/Tabs/NewCodeQuizFullscreenCodeViewController.swift
@@ -1,6 +1,21 @@
 import SnapKit
 import UIKit
 
+extension NewCodeQuizFullscreenCodeViewController {
+    enum Appearance {
+        static let submitButtonBackgroundColor = UIColor.stepicGreen
+        static let submitButtonHeight: CGFloat = 44
+        static let submitButtonTextColor = UIColor.white
+        static let submitButtonCornerRadius: CGFloat = 6
+        static let submitButtonFont = UIFont.systemFont(ofSize: 16)
+        static let submitButtonInsets = LayoutInsets(left: 32, bottom: 16, right: 32)
+
+        static let codeEditorTextTopInset: CGFloat = 8
+
+        static let languageNameLabelLayoutInsets = LayoutInsets(top: 8, right: 8)
+    }
+}
+
 protocol NewCodeQuizFullscreenCodeViewControllerDelegate: class {
     func newCodeQuizFullscreenCodeViewController(
         _ viewController: NewCodeQuizFullscreenCodeViewController,
@@ -14,21 +29,13 @@ protocol NewCodeQuizFullscreenCodeViewControllerDelegate: class {
 }
 
 final class NewCodeQuizFullscreenCodeViewController: UIViewController {
-    enum Appearance {
-        static let submitButtonBackgroundColor = UIColor.stepicGreen
-        static let submitButtonHeight: CGFloat = 44
-        static let submitButtonTextColor = UIColor.white
-        static let submitButtonCornerRadius: CGFloat = 6
-        static let submitButtonFont = UIFont.systemFont(ofSize: 16)
-        static let submitButtonInsets = LayoutInsets(left: 32, bottom: 16, right: 32)
-
-        static let codeEditorTextTopInset: CGFloat = 8
-    }
-
     weak var delegate: NewCodeQuizFullscreenCodeViewControllerDelegate?
 
     private lazy var codeEditorView: CodeEditorView = {
-        let codeEditorView = CodeEditorView()
+        let appearance = CodeEditorView.Appearance(
+            languageNameLabelLayoutInsets: Appearance.languageNameLabelLayoutInsets
+        )
+        let codeEditorView = CodeEditorView(appearance: appearance)
         codeEditorView.isThemeAutoUpdating = true
         codeEditorView.delegate = self
         return codeEditorView


### PR DESCRIPTION
**Задача**: [#APPS-2585](https://vyahhi.myjetbrains.com/youtrack/issue/APPS-2585)

**Описание**:
Исправили отображение названия языка программирования в полноэкранном код квизе.