### PR TITLE
Disable HTML tags escaping for matching and sorting

### DIFF
--- a/Stepic/Sources/Modules/Quizzes/NewMatchingQuiz/NewMatchingQuizPresenter.swift
+++ b/Stepic/Sources/Modules/Quizzes/NewMatchingQuiz/NewMatchingQuizPresenter.swift
@@ -40,8 +40,6 @@ final class NewMatchingQuizPresenter: NewMatchingQuizPresenterProtocol {
     }
 
     private func processText(_ text: String) -> String {
-        let text = text.addingHTMLEntities()
-
         let processor = ContentProcessor(
             content: text,
             rules: [

--- a/Stepic/Sources/Modules/Quizzes/NewSortingQuiz/NewSortingQuizPresenter.swift
+++ b/Stepic/Sources/Modules/Quizzes/NewSortingQuiz/NewSortingQuizPresenter.swift
@@ -33,8 +33,6 @@ final class NewSortingQuizPresenter: NewSortingQuizPresenterProtocol {
     }
 
     private func processText(_ text: String) -> String {
-        let text = text.addingHTMLEntities()
-
         let processor = ContentProcessor(
             content: text,
             rules: [


### PR DESCRIPTION
**YouTrack task**: [#APPS-2629](https://vyahhi.myjetbrains.com/youtrack/issue/APPS-2629)

**Description**:
- Disable HTML tags escaping for matching and sorting quizzes.