### PR TITLE
Update dependencies 1.111

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -8,7 +8,7 @@ def shared_pods
     pod 'Alamofire', '4.9.1'
     pod 'Atributika', '4.9.4'
     pod 'SwiftyJSON', '5.0.0'
-    pod 'SDWebImage', '5.5.1'
+    pod 'SDWebImage', '5.5.2'
     pod 'SVGKit', :git => 'https://github.com/SVGKit/SVGKit.git', :branch => '2.x'
     pod 'Logging', '1.2.0'
     pod 'Fabric', '1.10.2'

--- a/Podfile
+++ b/Podfile
@@ -54,7 +54,7 @@ def all_pods
     
     pod 'Presentr', '1.9'
     
-    pod 'Agrume', '5.6.0'
+    pod 'Agrume', '5.6.1'
     pod 'Highlightr', '2.1.0'
     pod 'TTTAttributedLabel', '2.0.0'
     pod 'lottie-ios', '2.5.3'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
   - ActionSheetPicker-3.0 (2.4.0)
-  - Agrume (5.6.0):
+  - Agrume (5.6.1):
     - SwiftyGif
   - Alamofire (4.9.1)
   - Amplitude-iOS (4.9.3)
@@ -188,7 +188,7 @@ PODS:
 
 DEPENDENCIES:
   - ActionSheetPicker-3.0 (= 2.4.0)
-  - Agrume (= 5.6.0)
+  - Agrume (= 5.6.1)
   - Alamofire (= 4.9.1)
   - Amplitude-iOS (= 4.9.3)
   - Atributika (= 4.9.4)
@@ -319,7 +319,7 @@ CHECKOUT OPTIONS:
 
 SPEC CHECKSUMS:
   ActionSheetPicker-3.0: c68e1f8355828b4e1c823fa87185aacfef5e6fe3
-  Agrume: c3e5858b50bbfb32611898624d7da017f992f1db
+  Agrume: 101c9874313f9e33b70c477e094e40a2f7e56910
   Alamofire: 85e8a02c69d6020a0d734f6054870d7ecb75cf18
   Amplitude-iOS: 122e026c44db8460e5efcf84859aa290a0ae9786
   Atributika: 643a248e2dd8b4d74b23b53ea31393cab0a01d94
@@ -385,6 +385,6 @@ SPEC CHECKSUMS:
   VK-ios-sdk: 62a10b6571fbcda0657f455fedce7fedf55b4cd0
   YandexMobileMetrica: edb00e8af2903290e142ba4c488adf8d394e828a
 
-PODFILE CHECKSUM: 3e43a3df91eb33600114d63953ca5fce1b690fe4
+PODFILE CHECKSUM: c2be7fc1245e747fb75a579749c1bc0cb6c2b054
 
 COCOAPODS: 1.8.4

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -158,9 +158,9 @@ PODS:
   - Protobuf (3.11.2)
   - Quick (2.2.0)
   - Reveal-SDK (24)
-  - SDWebImage (5.5.1):
-    - SDWebImage/Core (= 5.5.1)
-  - SDWebImage/Core (5.5.1)
+  - SDWebImage (5.5.2):
+    - SDWebImage/Core (= 5.5.2)
+  - SDWebImage/Core (5.5.2)
   - SnapKit (5.0.1)
   - STRegex (2.1.0)
   - SVGKit (2.1.0):
@@ -220,7 +220,7 @@ DEPENDENCIES:
   - PromiseKit (= 6.13.0)
   - Quick (= 2.2.0)
   - Reveal-SDK
-  - SDWebImage (= 5.5.1)
+  - SDWebImage (= 5.5.2)
   - SnapKit (= 5.0.1)
   - STRegex (= 2.1.0)
   - SVGKit (from `https://github.com/SVGKit/SVGKit.git`, branch `2.x`)
@@ -368,7 +368,7 @@ SPEC CHECKSUMS:
   Protobuf: dd1aaea7140debfe4dd0683fb8ef208e527ae153
   Quick: 7fb19e13be07b5dfb3b90d4f9824c855a11af40e
   Reveal-SDK: 5d7e56b8f018c0a88b3a2c10bf68d598bbd3b071
-  SDWebImage: 1245d058b7b8f59adef7a6da6bbafd4f1ab67041
+  SDWebImage: 4d5c027c935438f341ed33dbac53ff9f479922ca
   SnapKit: 97b92857e3df3a0c71833cce143274bf6ef8e5eb
   STRegex: dfa420d93d8c1402956233b3879ec1fc14b45fbe
   SVGKit: 8a2fc74258bdb2abb54d3b65f3dd68b0277a9c4d
@@ -385,6 +385,6 @@ SPEC CHECKSUMS:
   VK-ios-sdk: 62a10b6571fbcda0657f455fedce7fedf55b4cd0
   YandexMobileMetrica: edb00e8af2903290e142ba4c488adf8d394e828a
 
-PODFILE CHECKSUM: ddd8fc897562a54318454d89332f656049ae9093
+PODFILE CHECKSUM: 3e43a3df91eb33600114d63953ca5fce1b690fe4
 
 COCOAPODS: 1.8.4


### PR DESCRIPTION
Bumps:
- [SDWebImage](https://github.com/SDWebImage/SDWebImage) from 5.5.1 to 5.5.2
- [Agrume](https://github.com/JanGorman/Agrume) from 5.6.0 to 5.6.1