### PR TITLE
Fetch sections in syllabus silently

### DIFF
--- a/Stepic/Sources/Modules/CourseInfoSubmodules/CourseInfoTabSyllabus/Views/CourseInfoTabSyllabusTableViewDataSource.swift
+++ b/Stepic/Sources/Modules/CourseInfoSubmodules/CourseInfoTabSyllabus/Views/CourseInfoTabSyllabusTableViewDataSource.swift
@@ -140,19 +140,7 @@ final class CourseInfoTabSyllabusTableViewDataSource: NSObject, UITableViewDeleg
 
     func tableView(_ tableView: UITableView, willDisplayHeaderView view: UIView, forSection section: Int) {
         self.visibleSectionHeaders[section] = view
-
-        // If section has no unit-placeholders then skip request
-        let hasUnitPlaceholders = self.viewModels[section].units.contains(
-            where: { unit in
-                if case .placeholder = unit {
-                    return true
-                }
-                return false
-            }
-        )
-        if hasUnitPlaceholders {
-            self.delegate?.sectionWillDisplay(self.viewModels[section])
-        }
+        self.delegate?.sectionWillDisplay(self.viewModels[section])
     }
 
     func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {


### PR DESCRIPTION
**YouTrack task**: [#APPS-2606](https://vyahhi.myjetbrains.com/youtrack/issue/APPS-2606)

**Description**:
Previously when syllabus content displayed from the cache, next it was replaced by placeholders. Now it updates content in the background.