### PR TITLE
Fix VK iOS SDK opens webview after success external auth

### DIFF
--- a/Stepic/AppDelegate.swift
+++ b/Stepic/AppDelegate.swift
@@ -232,8 +232,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     ) -> Bool {
         print("opened app via url \(url.absoluteString)")
 
-        if let sourceApplication = options[.sourceApplication] as? String,
-           VKSdk.processOpen(url, fromApplication: sourceApplication) {
+        let sourceApplicationOrNil = options[.sourceApplication] as? String
+
+        if VKSdk.processOpen(url, fromApplication: sourceApplicationOrNil) {
             return true
         }
         if ApplicationDelegate.shared.application(app, open: url, options: options) {


### PR DESCRIPTION
**YouTrack task**: [#APPS-2716](https://vyahhi.myjetbrains.com/youtrack/issue/APPS-2716)

**Description**:
- Fixes an issue when webview opened after successful external auth through VK app.