### PR TITLE
Support mobile & iOS platform in course-lists API

### DIFF
--- a/Stepic/Legacy/Model/Network/Endpoints/CourseListsAPI.swift
+++ b/Stepic/Legacy/Model/Network/Endpoints/CourseListsAPI.swift
@@ -16,7 +16,7 @@ final class CourseListsAPI: APIEndpoint {
 
     func retrieve(language: ContentLanguage, page: Int = 1) -> Promise<([CourseListModel], Meta)> {
         let params: Parameters = [
-            "platform": "mobile",
+            "platform": "mobile,ios",
             "language": language.languageString,
             "page": page
         ]

--- a/Stepic/Legacy/Model/RemoteConfig/RemoteConfig.swift
+++ b/Stepic/Legacy/Model/RemoteConfig/RemoteConfig.swift
@@ -26,8 +26,7 @@ final class RemoteConfig {
         Key.supportedInAdaptiveModeCourses.rawValue: StepikApplicationsInfo.adaptiveSupportedCourses as NSObject,
         Key.newLessonAvailable.rawValue: true as NSObject,
         Key.darkModeAvailable.rawValue: true as NSObject,
-        Key.arQuickLookAvailable.rawValue: false as NSObject,
-        Key.hiddenCourseLists.rawValue: [Int]() as NSObject
+        Key.arQuickLookAvailable.rawValue: false as NSObject
     ]
 
     var showStreaksNotificationTrigger: ShowStreaksNotificationTrigger {
@@ -98,18 +97,6 @@ final class RemoteConfig {
             .boolValue
     }
 
-    var hiddenCourseListsIDs: [CourseListModel.IdType] {
-        guard let configStringValue = FirebaseRemoteConfig.RemoteConfig.remoteConfig().configValue(
-            forKey: Key.hiddenCourseLists.rawValue
-        ).stringValue else {
-            return []
-        }
-
-        return configStringValue
-            .components(separatedBy: ",")
-            .compactMap { Int($0) }
-    }
-
     init() {
         self.loadDefaultValues()
         self.fetchCloudValues()
@@ -164,6 +151,5 @@ final class RemoteConfig {
         case newLessonAvailable = "new_lesson_available_ios"
         case darkModeAvailable = "is_dark_mode_available_ios"
         case arQuickLookAvailable = "is_ar_quick_look_available_ios"
-        case hiddenCourseLists = "hidden_course_lists_ios"
     }
 }

--- a/Stepic/Sources/Modules/ExploreSubmodules/CourseListsCollection/CourseListsCollectionAssembly.swift
+++ b/Stepic/Sources/Modules/ExploreSubmodules/CourseListsCollection/CourseListsCollectionAssembly.swift
@@ -22,11 +22,7 @@ final class CourseListsCollectionAssembly: Assembly {
             )
         )
         let presenter = CourseListsCollectionPresenter()
-        let interactor = CourseListsCollectionInteractor(
-            presenter: presenter,
-            provider: provider,
-            remoteConfig: .shared
-        )
+        let interactor = CourseListsCollectionInteractor(presenter: presenter, provider: provider)
         let viewController = CourseListsCollectionViewController(interactor: interactor)
         presenter.viewController = viewController
         interactor.moduleOutput = self.moduleOutput

--- a/Stepic/Sources/Modules/ExploreSubmodules/CourseListsCollection/CourseListsCollectionInteractor.swift
+++ b/Stepic/Sources/Modules/ExploreSubmodules/CourseListsCollection/CourseListsCollectionInteractor.swift
@@ -14,26 +14,22 @@ final class CourseListsCollectionInteractor: CourseListsCollectionInteractorProt
     private let presenter: CourseListsCollectionPresenterProtocol
     private let provider: CourseListsCollectionProviderProtocol
 
-    private let remoteConfig: RemoteConfig
-
     init(
         presenter: CourseListsCollectionPresenterProtocol,
-        provider: CourseListsCollectionProviderProtocol,
-        remoteConfig: RemoteConfig
+        provider: CourseListsCollectionProviderProtocol
     ) {
         self.presenter = presenter
         self.provider = provider
-        self.remoteConfig = remoteConfig
     }
 
     func doCourseListsFetch(request: CourseListsCollection.CourseListsLoad.Request) {
         self.provider.fetchCachedCourseLists().then { cachedCourseLists -> Promise<[CourseListModel]> in
             // Pass cached data to presenter and start fetching from remote
-            self.presentAvailableCourseLists(cachedCourseLists)
+            self.presenter.presentCourses(response: .init(result: .success(cachedCourseLists)))
 
             return self.provider.fetchRemoteCourseLists()
         }.done { remoteCourseLists in
-            self.presentAvailableCourseLists(remoteCourseLists)
+            self.presenter.presentCourses(response: .init(result: .success(remoteCourseLists)))
         }.catch { _ in }
     }
 
@@ -48,15 +44,6 @@ final class CourseListsCollectionInteractor: CourseListsCollectionInteractorProt
             presentationDescription: request.presentationDescription,
             type: collectionCourseListType
         )
-    }
-
-    private func presentAvailableCourseLists(_ courseLists: [CourseListModel]) {
-        let hiddenCourseListsIDs = Set(self.remoteConfig.hiddenCourseListsIDs)
-        let finalCourseLists = hiddenCourseListsIDs.isEmpty
-            ? courseLists
-            : courseLists.filter { !hiddenCourseListsIDs.contains($0.id) }
-
-        self.presenter.presentCourses(response: .init(result: .success(finalCourseLists)))
     }
 
     enum Error: Swift.Error {


### PR DESCRIPTION
**YouTrack task**: [#APPS-2902](https://vyahhi.myjetbrains.com/youtrack/issue/APPS-2902)

**Description**:
- Updates `CourseListsAPI` `platform` query parameter from `mobile` to `mobile,ios`.
- Removes `RemoteConfig.hiddenCourseListsIDs`.