### PR TITLE
Fix delete device catch handler dynamic cast crash

### DIFF
--- a/Stepic/Legacy/Model/ExecutionQueue/Executable.swift
+++ b/Stepic/Legacy/Model/ExecutionQueue/Executable.swift
@@ -15,7 +15,7 @@ protocol Executable {
     var type: ExecutableTaskType { get }
     var id: String { get }
 
-    func execute(success: @escaping (() -> Void), failure: @escaping ((ExecutionError) -> Void))
+    func execute(success: @escaping () -> Void, failure: @escaping (ExecutionError) -> Void)
 }
 
 enum ExecutionError: Error {

--- a/Stepic/Legacy/Model/ExecutionQueue/TasksSerializers/Views/PostViewsExecutableTask.swift
+++ b/Stepic/Legacy/Model/ExecutionQueue/TasksSerializers/Views/PostViewsExecutableTask.swift
@@ -61,7 +61,7 @@ final class PostViewsExecutableTask: Executable, DictionarySerializable {
         "\(type.rawValue) \(userId) \(stepId) \(String(describing: assignmentId))"
     }
 
-    func execute(success: @escaping (() -> Void), failure: @escaping ((ExecutionError) -> Void)) {
+    func execute(success: @escaping () -> Void, failure: @escaping (ExecutionError) -> Void) {
         let recoveryManager = PersistentUserTokenRecoveryManager(baseName: "Users")
 
         guard let token = recoveryManager.recoverStepicToken(userId: userId) else {

--- a/Stepic/Legacy/Model/Network/Endpoints/DevicesAPI.swift
+++ b/Stepic/Legacy/Model/Network/Endpoints/DevicesAPI.swift
@@ -41,9 +41,9 @@ final class DevicesAPI: APIEndpoint {
                     seal.reject(NetworkError(error: error))
                 case .success(let json):
                     if let r = response.response,
-                        !(200...299 ~= r.statusCode) {
+                       !(200...299 ~= r.statusCode) {
                         switch r.statusCode {
-                        // when we pass wrong (but existing) device id we get 403 with error presented in field "detail"
+                            // when we pass wrong (but existing) device id we get 403 with error presented in field "detail"
                         case 403, 404:
                             return seal.reject(DeviceError.notFound)
                         default:
@@ -81,7 +81,7 @@ final class DevicesAPI: APIEndpoint {
                     seal.reject(error)
                 case .success(let json):
                     if let r = response.response,
-                        !(200...299 ~= r.statusCode) {
+                       !(200...299 ~= r.statusCode) {
                         switch r.statusCode {
                         case 404:
                             return seal.reject(DeviceError.notFound)
@@ -114,7 +114,7 @@ final class DevicesAPI: APIEndpoint {
                     seal.reject(error)
                 case .success(let json):
                     if let r = response.response,
-                        !(200...299 ~= r.statusCode) {
+                       !(200...299 ~= r.statusCode) {
                         switch r.statusCode {
                         case 404:
                             return seal.reject(DeviceError.notFound)
@@ -147,7 +147,7 @@ final class DevicesAPI: APIEndpoint {
                     seal.reject(error)
                 case .success(let json):
                     if let r = response.response,
-                        !(200...299 ~= r.statusCode) {
+                       !(200...299 ~= r.statusCode) {
                         switch r.statusCode {
                         case 404:
                             return seal.reject(DeviceError.notFound)
@@ -210,8 +210,8 @@ extension DevicesAPI {
     func create(
         _ device: Device,
         headers: HTTPHeaders = APIDefaults.Headers.bearer,
-        success: @escaping ((Device) -> Void),
-        error errorHandler: @escaping ((String) -> Void)
+        success: @escaping (Device) -> Void,
+        error errorHandler: @escaping (String) -> Void
     ) -> Request? {
         self.create(device, headers: headers).done { success($0) }.catch { errorHandler($0.localizedDescription) }
         return nil
@@ -240,8 +240,8 @@ extension DevicesAPI {
     func retrieve(
         _ deviceId: Int,
         headers: HTTPHeaders = APIDefaults.Headers.bearer,
-        success: @escaping ((Device) -> Void),
-        error errorHandler: @escaping ((String) -> Void)
+        success: @escaping (Device) -> Void,
+        error errorHandler: @escaping (String) -> Void
     ) -> Request? {
         self.retrieve(deviceId: deviceId, headers: headers)
             .done { success($0) }

--- a/Stepic/Legacy/Model/Network/Endpoints/DevicesAPI.swift
+++ b/Stepic/Legacy/Model/Network/Endpoints/DevicesAPI.swift
@@ -221,10 +221,18 @@ extension DevicesAPI {
     func delete(
         _ deviceId: Int,
         headers: HTTPHeaders = APIDefaults.Headers.bearer,
-        success: @escaping (() -> Void),
-        error errorHandler: @escaping ((DeviceError) -> Void)
+        success: @escaping () -> Void,
+        error errorHandler: @escaping (DeviceError) -> Void
     ) -> Request? {
-        self.delete(deviceId, headers: headers).done { success() }.catch { errorHandler($0 as! DeviceError) }
+        self.delete(deviceId, headers: headers).done {
+            success()
+        }.catch { error in
+            if let deviceError = error as? DeviceError {
+                errorHandler(deviceError)
+            } else {
+                errorHandler(.other(error: error, code: nil, message: nil))
+            }
+        }
         return nil
     }
 


### PR DESCRIPTION
**YouTrack task**: [#APPS-2954](https://vyahhi.myjetbrains.com/youtrack/issue/APPS-2954)

**Description**:
- Fixes crash in `DevicesAPI.delete(,headers:, success:, error:)`.