### PR TITLE
Send course cards analytics to metrics

### DIFF
--- a/Stepic.xcodeproj/project.pbxproj
+++ b/Stepic.xcodeproj/project.pbxproj
@@ -456,6 +456,7 @@
 		2C2F0BE92186EF87007DCA0A /* CommonNotificationsRequestAlertDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C2F0BE82186EF87007DCA0A /* CommonNotificationsRequestAlertDataSource.swift */; };
 		2C2F0BEC2186F0C3007DCA0A /* NotificationsRequestAlertPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C2F0BEB2186F0C3007DCA0A /* NotificationsRequestAlertPresenter.swift */; };
 		2C2F0BEE2186F196007DCA0A /* NotificationsRequestAlertDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C2F0BED2186F196007DCA0A /* NotificationsRequestAlertDataSource.swift */; };
+		2C2F6E6024DD3E69000E8844 /* StepikAnalyticsEvents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C2F6E5F24DD3E69000E8844 /* StepikAnalyticsEvents.swift */; };
 		2C30505B24574B1F005DCD81 /* CourseListDataBackUpdateService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C30505A24574B1F005DCD81 /* CourseListDataBackUpdateService.swift */; };
 		2C30A6A024A29B6D0074693D /* Queue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C30A69F24A29B6D0074693D /* Queue.swift */; };
 		2C32E71320FF6C1D008BB909 /* Auth.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 2CC351841F6827BE004255B6 /* Auth.storyboard */; };
@@ -1838,6 +1839,7 @@
 		2C2F0BE82186EF87007DCA0A /* CommonNotificationsRequestAlertDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommonNotificationsRequestAlertDataSource.swift; sourceTree = "<group>"; };
 		2C2F0BEB2186F0C3007DCA0A /* NotificationsRequestAlertPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationsRequestAlertPresenter.swift; sourceTree = "<group>"; };
 		2C2F0BED2186F196007DCA0A /* NotificationsRequestAlertDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationsRequestAlertDataSource.swift; sourceTree = "<group>"; };
+		2C2F6E5F24DD3E69000E8844 /* StepikAnalyticsEvents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StepikAnalyticsEvents.swift; sourceTree = "<group>"; };
 		2C30505A24574B1F005DCD81 /* CourseListDataBackUpdateService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseListDataBackUpdateService.swift; sourceTree = "<group>"; };
 		2C30A69F24A29B6D0074693D /* Queue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Queue.swift; sourceTree = "<group>"; };
 		2C32664224B00BEF0013C473 /* Model_course_purchases_v54.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = Model_course_purchases_v54.xcdatamodel; sourceTree = "<group>"; };
@@ -3433,6 +3435,7 @@
 				081A14FE20D963090016364E /* AmplitudeAnalyticsEvents.swift */,
 				08D035201D65A252003515C6 /* AnalyticsEvents.swift */,
 				2C998ACF246EC83800AAFDE4 /* NotificationAlertsAnalytics.swift */,
+				2C2F6E5F24DD3E69000E8844 /* StepikAnalyticsEvents.swift */,
 			);
 			path = Events;
 			sourceTree = "<group>";
@@ -8473,6 +8476,7 @@
 				2C698C9524CEA90100979661 /* NewProfileCoverView.swift in Sources */,
 				62E9870EF451D397B27AB075 /* CourseInfoTabSyllabusCellStatsView.swift in Sources */,
 				62E9893B98E774DA8141AD0F /* CourseInfoTabSyllabusCellView.swift in Sources */,
+				2C2F6E6024DD3E69000E8844 /* StepikAnalyticsEvents.swift in Sources */,
 				62E98C92B0827BEB4E28A8D9 /* CourseInfoTabSyllabusTableViewCell.swift in Sources */,
 				62E98212665FE6C08C3736DA /* CourseInfoTabSyllabusHeaderView.swift in Sources */,
 				62E988C6B635993C63C66666 /* CourseInfoTabSyllabusSectionDeadlinesView.swift in Sources */,

--- a/Stepic/Legacy/Analytics/Events/StepikAnalyticsEvents.swift
+++ b/Stepic/Legacy/Analytics/Events/StepikAnalyticsEvents.swift
@@ -1,0 +1,67 @@
+import Foundation
+
+extension AnalyticsEvent {
+    static func catalogDisplay(
+        courseID: Course.IdType,
+        viewSource: CourseViewSource,
+        contentLanguage: ContentLanguage = ContentLanguageService().globalContentLanguage
+    ) -> StepikAnalyticsEvent {
+        let dataParams = self.makeCourseCardDataParameters(
+            courseID: courseID,
+            viewSource: viewSource,
+            contentLanguage: contentLanguage
+        )
+
+        let name = "catalog-display"
+
+        let params: [String: Any] = [
+            "data": dataParams,
+            "name": name,
+            "timestamp": Date().timeIntervalSince1970
+        ]
+
+        return StepikAnalyticsEvent(name: name, parameters: params)
+    }
+
+    static func catalogClick(
+        courseID: Course.IdType,
+        viewSource: CourseViewSource,
+        contentLanguage: ContentLanguage = ContentLanguageService().globalContentLanguage
+    ) -> StepikAnalyticsEvent {
+        let dataParams = self.makeCourseCardDataParameters(
+            courseID: courseID,
+            viewSource: viewSource,
+            contentLanguage: contentLanguage
+        )
+
+        let name = "catalog-click"
+
+        let params: [String: Any] = [
+            "data": dataParams,
+            "name": name,
+            "timestamp": Date().timeIntervalSince1970
+        ]
+
+        return StepikAnalyticsEvent(name: name, parameters: params)
+    }
+
+    private static func makeCourseCardDataParameters(
+        courseID: Course.IdType,
+        viewSource: CourseViewSource,
+        contentLanguage: ContentLanguage
+    ) -> JSONDictionary {
+        var params: JSONDictionary = [
+            "course": courseID,
+            "platform": "ios",
+            "source": viewSource.name,
+            "position": 1,
+            "language": contentLanguage.languageString
+        ]
+
+        if let viewSourceParams = viewSource.params {
+            params["data"] = viewSourceParams
+        }
+
+        return params
+    }
+}

--- a/Stepic/Sources/Frameworks/Analytics/AnalyticsEngine.swift
+++ b/Stepic/Sources/Frameworks/Analytics/AnalyticsEngine.swift
@@ -152,10 +152,8 @@ final class StepikAnalyticsEngine: AnalyticsEngine {
 
     private func listenForChangesInNetworkReachabilityStatus() {
         self.networkReachabilityService.startListening { networkReachabilityStatus in
-            self.synchronizationQueue.async {
-                if networkReachabilityStatus == .reachable {
-                    self.sendEventsIfNeeded()
-                }
+            if networkReachabilityStatus == .reachable {
+                self.sendEventsIfNeeded()
             }
         }
     }

--- a/Stepic/Sources/Frameworks/Analytics/AnalyticsEngine.swift
+++ b/Stepic/Sources/Frameworks/Analytics/AnalyticsEngine.swift
@@ -85,6 +85,7 @@ final class StepikAnalyticsEngine: AnalyticsEngine {
     func sendAnalyticsEvent(named name: String, parameters: [String: Any]?, forceSend: Bool) {
         self.synchronizationQueue.async {
             self.handleEvent(name: name, parameters: parameters, forceSend: forceSend)
+            print("Logging Stepik event: \(name), parameters: \(String(describing: parameters))")
         }
     }
 
@@ -143,6 +144,8 @@ final class StepikAnalyticsEngine: AnalyticsEngine {
 
             self.serializeQueueState()
             self.sendEventsIfNeeded()
+
+            print("StepikAnalyticsEngine :: done send batch metrics")
         }.ensure {
             self.requestSemaphore.signal()
         }.catch { _ in

--- a/Stepic/Sources/Modules/CourseList/Views/CourseListCollectionViewDataSource.swift
+++ b/Stepic/Sources/Modules/CourseList/Views/CourseListCollectionViewDataSource.swift
@@ -42,6 +42,7 @@ final class CourseListCollectionViewDataSource: NSObject, UICollectionViewDataSo
         cell.layer.rasterizationScale = UIScreen.main.scale
 
         self.analytics.send(.courseCardSeen(courseID: viewModel.courseID, viewSource: viewModel.viewSource))
+        self.analytics.send(.catalogDisplay(courseID: viewModel.courseID, viewSource: viewModel.viewSource))
 
         return cell
     }

--- a/Stepic/Sources/Modules/CourseList/Views/CourseListCollectionViewDelegate.swift
+++ b/Stepic/Sources/Modules/CourseList/Views/CourseListCollectionViewDelegate.swift
@@ -5,8 +5,14 @@ final class CourseListCollectionViewDelegate: NSObject, UICollectionViewDelegate
 
     var viewModels: [CourseWidgetViewModel]
 
-    init(viewModels: [CourseWidgetViewModel] = []) {
+    private let analytics: Analytics
+
+    init(
+        viewModels: [CourseWidgetViewModel] = [],
+        analytics: Analytics = StepikAnalytics.shared
+    ) {
         self.viewModels = viewModels
+        self.analytics = analytics
     }
 
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
@@ -19,5 +25,6 @@ final class CourseListCollectionViewDelegate: NSObject, UICollectionViewDelegate
         }
 
         self.delegate?.itemDidSelected(viewModel: viewModel)
+        self.analytics.send(.catalogClick(courseID: viewModel.courseID, viewSource: viewModel.viewSource))
     }
 }

--- a/Stepic/Sources/Modules/Downloads/DownloadsViewController.swift
+++ b/Stepic/Sources/Modules/Downloads/DownloadsViewController.swift
@@ -109,6 +109,8 @@ extension DownloadsViewController: DownloadsViewDelegate {
             courseViewSource: .downloads
         )
         self.present(module: assembly.makeModule(), embedInNavigation: true, modalPresentationStyle: .fullScreen)
+
+        self.analytics.send(.catalogClick(courseID: selectedViewModel.id, viewSource: .downloads))
     }
 }
 

--- a/Stepic/Sources/Modules/Downloads/Views/DownloadsTableViewDataSource.swift
+++ b/Stepic/Sources/Modules/Downloads/Views/DownloadsTableViewDataSource.swift
@@ -44,6 +44,7 @@ extension DownloadsTableViewDataSource: UITableViewDataSource {
         cell.configure(viewModel: viewModel)
 
         self.analytics.send(.courseCardSeen(courseID: viewModel.id, viewSource: .downloads))
+        self.analytics.send(.catalogDisplay(courseID: viewModel.id, viewSource: .downloads))
 
         return cell
     }


### PR DESCRIPTION
**YouTrack task**: [#APPS-2972](https://vyahhi.myjetbrains.com/youtrack/issue/APPS-2972)

**Description**:
- Sends `CatalogDisplay ` and `CatalogClick` events to metrics.