### PR TITLE
Fix send is_vote_notifications_enabled on profile update

### DIFF
--- a/Stepic.xcodeproj/project.pbxproj
+++ b/Stepic.xcodeproj/project.pbxproj
@@ -1964,6 +1964,7 @@
 		2C7545A724C01C00004F9074 /* AchievementProgressesNetworkService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AchievementProgressesNetworkService.swift; sourceTree = "<group>"; };
 		2C7545A924C01F06004F9074 /* AchievementsRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AchievementsRepository.swift; sourceTree = "<group>"; };
 		2C7545AB24C034CB004F9074 /* NewProfileAchievementsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewProfileAchievementsViewModel.swift; sourceTree = "<group>"; };
+		2C78573B24DE1EC40042AD2C /* Model_is_vote_notifications_enabled_v60.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = Model_is_vote_notifications_enabled_v60.xcdatamodel; sourceTree = "<group>"; };
 		2C79F61721873CD9004CC082 /* NotificationsRequestOnlySettingsAlertPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationsRequestOnlySettingsAlertPresenter.swift; sourceTree = "<group>"; };
 		2C7EFCEC24D08CFF003A4E93 /* NewProfileSocialProfilesSkeletonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewProfileSocialProfilesSkeletonView.swift; sourceTree = "<group>"; };
 		2C7EFCEE24D08D80003A4E93 /* NewProfileSocialProfilesSkeletonProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewProfileSocialProfilesSkeletonProfileView.swift; sourceTree = "<group>"; };
@@ -9880,6 +9881,7 @@
 		08D1EF6E1BB5618700BE84E6 /* Model.xcdatamodeld */ = {
 			isa = XCVersionGroup;
 			children = (
+				2C78573B24DE1EC40042AD2C /* Model_is_vote_notifications_enabled_v60.xcdatamodel */,
 				2C619A7824CFF9DC007D3529 /* Model_social_profiles_v59.xcdatamodel */,
 				2C46417A24CFD23400FB6696 /* Model_lessons_demo_access_v58.xcdatamodel */,
 				2CC8683624CAD452004845AB /* Model_new_profile_organization_v57.xcdatamodel */,
@@ -9941,7 +9943,7 @@
 				0802AC531C7222B200C4F3E6 /* Model_v2.xcdatamodel */,
 				08D1EF6F1BB5618700BE84E6 /* Model.xcdatamodel */,
 			);
-			currentVersion = 2C619A7824CFF9DC007D3529 /* Model_social_profiles_v59.xcdatamodel */;
+			currentVersion = 2C78573B24DE1EC40042AD2C /* Model_is_vote_notifications_enabled_v60.xcdatamodel */;
 			path = Model.xcdatamodeld;
 			sourceTree = "<group>";
 			versionGroupType = wrapper.xcdatamodel;

--- a/Stepic/Legacy/Model/Entities/Profile/Profile+CoreDataProperties.swift
+++ b/Stepic/Legacy/Model/Entities/Profile/Profile+CoreDataProperties.swift
@@ -16,6 +16,7 @@ extension Profile {
     @NSManaged var managedShortBio: String?
     @NSManaged var managedDetails: String?
     @NSManaged var managedSubscribedForMail: NSNumber?
+    @NSManaged var managedIsVoteNotificationsEnabled: NSNumber?
     @NSManaged var managedIsStaff: NSNumber?
 
     @NSManaged var managedEmailAddressesArray: NSObject?
@@ -92,6 +93,15 @@ extension Profile {
         }
         get {
              managedSubscribedForMail?.boolValue ?? true
+        }
+    }
+
+    var isVoteNotificationsEnabled: Bool {
+        get {
+            self.managedIsVoteNotificationsEnabled?.boolValue ?? true
+        }
+        set {
+            self.managedIsVoteNotificationsEnabled = NSNumber(value: newValue)
         }
     }
 

--- a/Stepic/Legacy/Model/Entities/Profile/Profile.swift
+++ b/Stepic/Legacy/Model/Entities/Profile/Profile.swift
@@ -13,35 +13,37 @@ import SwiftyJSON
 final class Profile: NSManagedObject, JSONSerializable {
     typealias IdType = Int
 
+    var json: JSON {
+        [
+            JSONKey.id.rawValue: self.id,
+            JSONKey.firstName.rawValue: self.firstName,
+            JSONKey.lastName.rawValue: self.lastName,
+            JSONKey.subscribedForMail.rawValue: self.subscribedForMail,
+            JSONKey.shortBio.rawValue: self.shortBio,
+            JSONKey.details.rawValue: self.details,
+            JSONKey.isVoteNotificationsEnabled.rawValue: self.isVoteNotificationsEnabled
+        ]
+    }
+
     required convenience init(json: JSON) {
         self.init()
         self.initialize(json)
     }
 
     func initialize(_ json: JSON) {
-        self.id = json["id"].intValue
-        self.firstName = json["first_name"].stringValue
-        self.lastName = json["last_name"].stringValue
-        self.subscribedForMail = json["subscribed_for_mail"].boolValue
-        self.isStaff = json["is_staff"].boolValue
-        self.shortBio = json["short_bio"].stringValue
-        self.details = json["details"].stringValue
-        self.emailAddressesArray = json["email_addresses"].arrayObject as? [Int] ?? []
+        self.id = json[JSONKey.id.rawValue].intValue
+        self.firstName = json[JSONKey.firstName.rawValue].stringValue
+        self.lastName = json[JSONKey.lastName.rawValue].stringValue
+        self.subscribedForMail = json[JSONKey.subscribedForMail.rawValue].boolValue
+        self.isVoteNotificationsEnabled = json[JSONKey.isVoteNotificationsEnabled.rawValue].boolValue
+        self.isStaff = json[JSONKey.isStaff.rawValue].boolValue
+        self.shortBio = json[JSONKey.shortBio.rawValue].stringValue
+        self.details = json[JSONKey.details.rawValue].stringValue
+        self.emailAddressesArray = json[JSONKey.emailAddresses.rawValue].arrayObject as? [Int] ?? []
     }
 
     func update(json: JSON) {
         self.initialize(json)
-    }
-
-    var json: JSON {
-        [
-            "id": self.id as AnyObject,
-            "first_name": self.firstName as AnyObject,
-            "last_name": self.lastName as AnyObject,
-            "subscribed_for_mail": self.subscribedForMail as AnyObject,
-            "short_bio": self.shortBio as AnyObject,
-            "details": self.details as AnyObject
-        ]
     }
 
     static func fetchById(_ id: Int) -> [Profile]? {
@@ -54,5 +56,17 @@ final class Profile: NSManagedObject, JSONSerializable {
         } catch {
             return nil
         }
+    }
+
+    enum JSONKey: String {
+        case id
+        case firstName = "first_name"
+        case lastName = "last_name"
+        case subscribedForMail = "subscribed_for_mail"
+        case isStaff = "is_staff"
+        case shortBio = "short_bio"
+        case details
+        case emailAddresses = "email_addresses"
+        case isVoteNotificationsEnabled = "is_vote_notifications_enabled"
     }
 }

--- a/Stepic/Legacy/Model/Model.xcdatamodeld/.xccurrentversion
+++ b/Stepic/Legacy/Model/Model.xcdatamodeld/.xccurrentversion
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>_XCCurrentVersionName</key>
-	<string>Model_social_profiles_v59.xcdatamodel</string>
+	<string>Model_is_vote_notifications_enabled_v60.xcdatamodel</string>
 </dict>
 </plist>

--- a/Stepic/Legacy/Model/Model.xcdatamodeld/Model_is_vote_notifications_enabled_v60.xcdatamodel/contents
+++ b/Stepic/Legacy/Model/Model.xcdatamodeld/Model_is_vote_notifications_enabled_v60.xcdatamodel/contents
@@ -1,0 +1,405 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="16119" systemVersion="19G73" minimumToolsVersion="Xcode 7.0" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+    <entity name="Assignment" representedClassName=".Assignment" syncable="YES">
+        <attribute name="managedId" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedStepId" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedUnitId" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <relationship name="managedUnit" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Unit" inverseName="managedAssignments" inverseEntity="Unit" syncable="YES"/>
+    </entity>
+    <entity name="AttemptEntity" representedClassName=".AttemptEntity" syncable="YES">
+        <attribute name="managedDataset" optional="YES" attributeType="Transformable" customClassName=".Dataset" syncable="YES"/>
+        <attribute name="managedDatasetURL" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="managedID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedStatus" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="managedStepID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedTime" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="managedTimeLeft" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="managedUserID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <relationship name="managedStep" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Step" inverseName="managedAttempt" inverseEntity="Step" syncable="YES"/>
+        <relationship name="managedSubmission" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="SubmissionEntity" inverseName="managedAttempt" inverseEntity="SubmissionEntity" syncable="YES"/>
+        <relationship name="managedUser" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="User" inverseName="managedAttempts" inverseEntity="User" syncable="YES"/>
+    </entity>
+    <entity name="Block" representedClassName=".Block" syncable="YES">
+        <attribute name="managedName" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="managedText" optional="YES" attributeType="String" syncable="YES"/>
+        <relationship name="managedStep" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Step" inverseName="managedBlock" inverseEntity="Step" syncable="YES"/>
+        <relationship name="managedVideo" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="Video" inverseName="managedBlock" inverseEntity="Video" syncable="YES"/>
+    </entity>
+    <entity name="Certificate" representedClassName=".Certificate" syncable="YES">
+        <attribute name="managedCourseId" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedGrade" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedId" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedisPublic" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedIssueDate" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedIsWithScore" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedType" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="managedUpdateDate" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedURL" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="managedUserId" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <relationship name="managedCourse" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Course" inverseName="managedCertificateEntity" inverseEntity="Course" syncable="YES"/>
+    </entity>
+    <entity name="CodeLimit" representedClassName=".CodeLimit" syncable="YES">
+        <attribute name="managedLanguage" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="managedMemory" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedTime" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="NO" syncable="YES"/>
+        <relationship name="managedOptions" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="StepOptions" inverseName="managedLimits" inverseEntity="StepOptions" syncable="YES"/>
+    </entity>
+    <entity name="CodeSample" representedClassName=".CodeSample" syncable="YES">
+        <attribute name="managedInput" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="managedOutput" optional="YES" attributeType="String" syncable="YES"/>
+        <relationship name="managedOptions" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="StepOptions" inverseName="managedSamples" inverseEntity="StepOptions" syncable="YES"/>
+    </entity>
+    <entity name="CodeTemplate" representedClassName=".CodeTemplate" syncable="YES">
+        <attribute name="managedIsUserGenerated" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedLanguage" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="managedTemplateString" optional="YES" attributeType="String" syncable="YES"/>
+        <relationship name="managedOptions" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="StepOptions" inverseName="managedTemplates" inverseEntity="StepOptions" syncable="YES"/>
+    </entity>
+    <entity name="Course" representedClassName=".Course" syncable="YES">
+        <attribute name="managedAudience" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="managedAuthorsArray" optional="YES" attributeType="Transformable" syncable="YES"/>
+        <attribute name="managedBeginDate" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedCertificate" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="managedCertificateDistinctionThreshold" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedCertificateRegularThreshold" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedCourseDescription" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="managedDisplayPrice" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="managedEndDate" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedEnrolled" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedFeatured" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedFormat" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="managedId" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedImageURL" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="managedInstructorsArray" optional="YES" attributeType="Transformable" syncable="YES"/>
+        <attribute name="managedIntroURL" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="managedIsArchived" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedIsCertificateAutoIssued" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedIsCertificateIssued" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedIsFavorite" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedIsPaid" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedLanguageCode" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="managedLastStepId" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="managedLearnersCount" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedPriceTier" optional="YES" attributeType="Integer 64" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedProgressId" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="managedPublic" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedReadiness" optional="YES" attributeType="Float" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedRequirements" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="managedReviewSummaryId" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedScheduleType" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="managedSectionsArray" optional="YES" attributeType="Transformable" syncable="YES"/>
+        <attribute name="managedSlug" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="managedSummary" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="managedTimeToComplete" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedTitle" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="managedTotalUnits" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedWorkload" optional="YES" attributeType="String" syncable="YES"/>
+        <relationship name="managedAuthors" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="User" inverseName="managedAuthoredCourses" inverseEntity="User" syncable="YES"/>
+        <relationship name="managedCertificateEntity" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Certificate" inverseName="managedCourse" inverseEntity="Certificate" syncable="YES"/>
+        <relationship name="managedCoursePurchases" optional="YES" toMany="YES" deletionRule="Cascade" ordered="YES" destinationEntity="CoursePurchase" inverseName="managedCourse" inverseEntity="CoursePurchase" syncable="YES"/>
+        <relationship name="managedInstructors" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="User" inverseName="managedInstructedCourses" inverseEntity="User" syncable="YES"/>
+        <relationship name="managedIntroVideo" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Video" syncable="YES"/>
+        <relationship name="managedLastCodeLanguage" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="LastCodeLanguage" inverseName="managedCourse" inverseEntity="LastCodeLanguage" syncable="YES"/>
+        <relationship name="managedLastStep" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="LastStep" inverseName="managedCourse" inverseEntity="LastStep" syncable="YES"/>
+        <relationship name="managedProgress" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Progress" inverseName="managedCourse" inverseEntity="Progress" syncable="YES"/>
+        <relationship name="managedReviewSummary" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="CourseReviewSummary" inverseName="managedCourse" inverseEntity="CourseReviewSummary" syncable="YES"/>
+        <relationship name="managedSections" optional="YES" toMany="YES" deletionRule="Cascade" ordered="YES" destinationEntity="Section" inverseName="managedCourse" inverseEntity="Section" syncable="YES"/>
+        <relationship name="managedUserCourse" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="UserCourse" inverseName="managedCourse" inverseEntity="UserCourse" syncable="YES"/>
+    </entity>
+    <entity name="CourseList" representedClassName=".CourseListModel" syncable="YES">
+        <attribute name="managedCoursesArray" optional="YES" attributeType="Transformable" syncable="YES"/>
+        <attribute name="managedDescription" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="managedId" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedLanguage" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="managedPosition" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedTitle" optional="YES" attributeType="String" syncable="YES"/>
+    </entity>
+    <entity name="CoursePurchase" representedClassName=".CoursePurchase" syncable="YES">
+        <attribute name="managedCourseId" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedId" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedIsActive" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedPaymentId" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedUserId" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <relationship name="managedCourse" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Course" inverseName="managedCoursePurchases" inverseEntity="Course" syncable="YES"/>
+    </entity>
+    <entity name="CourseReview" representedClassName=".CourseReview" syncable="YES">
+        <attribute name="managedCourseId" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedCreateDate" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedId" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedScore" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedText" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="managedUserId" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <relationship name="managedCourse" optional="YES" maxCount="1" deletionRule="No Action" destinationEntity="Course" syncable="YES"/>
+        <relationship name="managedUser" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="User" syncable="YES"/>
+    </entity>
+    <entity name="CourseReviewSummary" representedClassName=".CourseReviewSummary" syncable="YES">
+        <attribute name="managedAverage" optional="YES" attributeType="Float" defaultValueString="0.0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedCount" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedDistribution" optional="YES" attributeType="Transformable" syncable="YES"/>
+        <attribute name="managedId" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <relationship name="managedCourse" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Course" inverseName="managedReviewSummary" inverseEntity="Course" syncable="YES"/>
+    </entity>
+    <entity name="DiscussionThread" representedClassName=".DiscussionThread" syncable="YES">
+        <attribute name="managedDiscussionProxy" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="managedDiscussionsCount" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedId" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="managedThread" optional="YES" attributeType="String" syncable="YES"/>
+        <relationship name="managedStep" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Step" inverseName="managedDiscussionThreads" inverseEntity="Step" syncable="YES"/>
+    </entity>
+    <entity name="EmailAddress" representedClassName=".EmailAddress" syncable="YES">
+        <attribute name="managedEmail" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="managedId" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedIsPrimary" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedIsVerified" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedUserId" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <relationship name="managedProfile" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Profile" inverseName="managedEmailAddresses" inverseEntity="Profile" syncable="YES"/>
+    </entity>
+    <entity name="LastCodeLanguage" representedClassName=".LastCodeLanguage" syncable="YES">
+        <attribute name="managedLanguage" optional="YES" attributeType="String" syncable="YES"/>
+        <relationship name="managedCourse" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Course" inverseName="managedLastCodeLanguage" inverseEntity="Course" syncable="YES"/>
+    </entity>
+    <entity name="LastStep" representedClassName=".LastStep" syncable="YES">
+        <attribute name="managedId" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="managedStepId" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedUnitId" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <relationship name="managedCourse" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Course" inverseName="managedLastStep" inverseEntity="Course" syncable="YES"/>
+    </entity>
+    <entity name="Lesson" representedClassName=".Lesson" syncable="YES">
+        <attribute name="managedCanEdit" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedCanLearnLesson" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedCoverURL" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="managedFeatured" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedId" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedPassedBy" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedPublic" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedSlug" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="managedStepsArray" optional="YES" attributeType="Transformable" syncable="YES"/>
+        <attribute name="managedTimeToComplete" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedTitle" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="managedVoteDelta" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <relationship name="managedSteps" optional="YES" toMany="YES" deletionRule="Cascade" ordered="YES" destinationEntity="Step" inverseName="managedLesson" inverseEntity="Step" syncable="YES"/>
+        <relationship name="managedUnit" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Unit" inverseName="managedLesson" inverseEntity="Unit" syncable="YES"/>
+    </entity>
+    <entity name="Notification" representedClassName=".Notification" syncable="YES">
+        <attribute name="managedAction" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="managedHtmlText" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="managedId" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedIsFavorite" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedIsMuted" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedLevel" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="managedPriority" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="managedStatus" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="managedTime" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedType" optional="YES" attributeType="String" syncable="YES"/>
+    </entity>
+    <entity name="Profile" representedClassName=".Profile" syncable="YES">
+        <attribute name="managedDetails" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="managedEmailAddressesArray" optional="YES" attributeType="Transformable" syncable="YES"/>
+        <attribute name="managedFirstName" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="managedId" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedIsStaff" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedIsVoteNotificationsEnabled" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedLastName" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="managedShortBio" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="managedSubscribedForMail" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <relationship name="managedEmailAddresses" optional="YES" toMany="YES" deletionRule="Cascade" ordered="YES" destinationEntity="EmailAddress" inverseName="managedProfile" inverseEntity="EmailAddress" syncable="YES"/>
+        <relationship name="managedUser" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="User" inverseName="managedProfileEntity" inverseEntity="User" syncable="YES"/>
+        <relationship name="managedUserActivity" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="UserActivityEntity" inverseName="managedProfile" inverseEntity="UserActivityEntity" syncable="YES"/>
+    </entity>
+    <entity name="Progress" representedClassName=".Progress" syncable="YES">
+        <attribute name="managedCost" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedId" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="managedIsPassed" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedLastViewed" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedNumberOfSteps" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedNumberOfStepsPassed" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedScore" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <relationship name="managedCourse" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Course" inverseName="managedProgress" inverseEntity="Course" syncable="YES"/>
+        <relationship name="managedSection" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Section" inverseName="managedProgress" inverseEntity="Section" syncable="YES"/>
+        <relationship name="managedStep" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Step" inverseName="managedProgress" inverseEntity="Step" syncable="YES"/>
+        <relationship name="managedUnit" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Unit" inverseName="managedProgress" inverseEntity="Unit" syncable="YES"/>
+    </entity>
+    <entity name="Section" representedClassName=".Section" syncable="YES">
+        <attribute name="managedActive" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedBeginDate" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedCourseId" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedDiscountingPolicy" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="managedEndDate" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedHardDeadline" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedId" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedIsCached" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedIsExam" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedIsRequirementSatisfied" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedPosition" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedProgressId" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="managedRequiredPercent" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedRequiredSectionID" optional="YES" attributeType="Integer 64" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedSoftDeadline" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedTestSectionAction" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="managedTitle" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="managedUnitsArray" optional="YES" attributeType="Transformable" syncable="YES"/>
+        <relationship name="managedCourse" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Course" inverseName="managedSections" inverseEntity="Course" syncable="YES"/>
+        <relationship name="managedProgress" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Progress" inverseName="managedSection" inverseEntity="Progress" syncable="YES"/>
+        <relationship name="managedUnits" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="Unit" inverseName="managedSection" inverseEntity="Unit" syncable="YES"/>
+    </entity>
+    <entity name="SocialProfile" representedClassName=".SocialProfile" syncable="YES">
+        <attribute name="managedId" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedName" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="managedProvider" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="managedURL" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="managedUserId" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <relationship name="managedUser" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="User" inverseName="managedSocialProfiles" inverseEntity="User" syncable="YES"/>
+    </entity>
+    <entity name="Step" representedClassName=".Step" syncable="YES">
+        <attribute name="managedCorrectRatio" optional="YES" attributeType="Float" defaultValueString="0.0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedDiscussionProxy" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="managedDiscussionsCount" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedDiscussionThreadsArray" optional="YES" attributeType="Transformable" syncable="YES"/>
+        <attribute name="managedHasSubmissionRestrictions" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedId" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedLessonId" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedMaxSubmissionsCount" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedPassedBy" optional="YES" attributeType="Integer 64" defaultValueString="0.0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedPosition" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedProgressId" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="managedStatus" optional="YES" attributeType="String" syncable="YES"/>
+        <relationship name="managedAttempt" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="AttemptEntity" inverseName="managedStep" inverseEntity="AttemptEntity" syncable="YES"/>
+        <relationship name="managedBlock" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="Block" inverseName="managedStep" inverseEntity="Block" syncable="YES"/>
+        <relationship name="managedDiscussionThreads" optional="YES" toMany="YES" deletionRule="Cascade" ordered="YES" destinationEntity="DiscussionThread" inverseName="managedStep" inverseEntity="DiscussionThread" syncable="YES"/>
+        <relationship name="managedLesson" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Lesson" inverseName="managedSteps" inverseEntity="Lesson" syncable="YES"/>
+        <relationship name="managedOptions" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="StepOptions" inverseName="managedStep" inverseEntity="StepOptions" syncable="YES"/>
+        <relationship name="managedProgress" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Progress" inverseName="managedStep" inverseEntity="Progress" syncable="YES"/>
+    </entity>
+    <entity name="StepOptions" representedClassName=".StepOptions" syncable="YES">
+        <attribute name="managedExecutionMemoryLimit" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedExecutionTimeLimit" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedIsRunUserCodeAllowed" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <relationship name="managedLimits" optional="YES" toMany="YES" deletionRule="Cascade" ordered="YES" destinationEntity="CodeLimit" inverseName="managedOptions" inverseEntity="CodeLimit" syncable="YES"/>
+        <relationship name="managedSamples" optional="YES" toMany="YES" deletionRule="Cascade" ordered="YES" destinationEntity="CodeSample" inverseName="managedOptions" inverseEntity="CodeSample" syncable="YES"/>
+        <relationship name="managedStep" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Step" inverseName="managedOptions" inverseEntity="Step" syncable="YES"/>
+        <relationship name="managedTemplates" optional="YES" toMany="YES" deletionRule="Cascade" ordered="YES" destinationEntity="CodeTemplate" inverseName="managedOptions" inverseEntity="CodeTemplate" syncable="YES"/>
+    </entity>
+    <entity name="SubmissionEntity" representedClassName=".SubmissionEntity" syncable="YES">
+        <attribute name="managedAttemptID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedFeedback" optional="YES" attributeType="Transformable" customClassName=".SubmissionFeedback" syncable="YES"/>
+        <attribute name="managedHint" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="managedID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedLocal" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedReply" optional="YES" attributeType="Transformable" customClassName=".Reply" syncable="YES"/>
+        <attribute name="managedStatus" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="managedTime" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <relationship name="managedAttempt" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="AttemptEntity" inverseName="managedSubmission" inverseEntity="AttemptEntity" syncable="YES"/>
+    </entity>
+    <entity name="Unit" representedClassName=".Unit" syncable="YES">
+        <attribute name="managedActive" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedAssignmentsArray" optional="YES" attributeType="Transformable" syncable="YES"/>
+        <attribute name="managedBeginDate" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedHardDeadline" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedId" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedLessonId" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedPosition" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedProgressId" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="managedSectionId" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedSoftDeadline" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <relationship name="managedAssignments" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="Assignment" inverseName="managedUnit" inverseEntity="Assignment" syncable="YES"/>
+        <relationship name="managedLesson" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Lesson" inverseName="managedUnit" inverseEntity="Lesson" syncable="YES"/>
+        <relationship name="managedProgress" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="Progress" inverseName="managedUnit" inverseEntity="Progress" syncable="YES"/>
+        <relationship name="managedSection" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Section" inverseName="managedUnits" inverseEntity="Section" syncable="YES"/>
+    </entity>
+    <entity name="User" representedClassName=".User" syncable="YES">
+        <attribute name="managedActive" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedAvatarURL" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="managedBio" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="managedCover" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="managedCreatedCoursesArray" optional="YES" attributeType="Transformable" syncable="YES"/>
+        <attribute name="managedCreatedCoursesCount" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedCreatedLessonsCount" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedDetails" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="managedFirstName" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="managedFollowersCount" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedId" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedIssuedCertificatesCount" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedJoinDate" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedKnowledge" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedKnowledgeRank" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedLastName" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="managedLevel" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedOrganization" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedPrivate" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedProfile" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedReputation" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedReputationRank" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedSocialProfilesArray" optional="YES" attributeType="Transformable" syncable="YES"/>
+        <attribute name="managedSolvedStepsCount" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <relationship name="managedAttempts" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="AttemptEntity" inverseName="managedUser" inverseEntity="AttemptEntity" syncable="YES"/>
+        <relationship name="managedAuthoredCourses" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Course" inverseName="managedAuthors" inverseEntity="Course" syncable="YES"/>
+        <relationship name="managedInstructedCourses" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Course" inverseName="managedInstructors" inverseEntity="Course" syncable="YES"/>
+        <relationship name="managedProfileEntity" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Profile" inverseName="managedUser" inverseEntity="Profile" syncable="YES"/>
+        <relationship name="managedSocialProfiles" optional="YES" toMany="YES" deletionRule="Cascade" ordered="YES" destinationEntity="SocialProfile" inverseName="managedUser" inverseEntity="SocialProfile" syncable="YES"/>
+        <relationship name="managedUserCourse" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="UserCourse" inverseName="managedUser" inverseEntity="UserCourse" syncable="YES"/>
+    </entity>
+    <entity name="UserActivityEntity" representedClassName=".UserActivityEntity" syncable="YES">
+        <attribute name="managedId" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedPinsArray" optional="YES" attributeType="Transformable" syncable="YES"/>
+        <relationship name="managedProfile" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Profile" inverseName="managedUserActivity" inverseEntity="Profile" syncable="YES"/>
+    </entity>
+    <entity name="UserCourse" representedClassName=".UserCourse" syncable="YES">
+        <attribute name="managedCourseId" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedId" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedIsArchived" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedIsFavorite" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedIsPinned" optional="YES" attributeType="Boolean" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedLastViewed" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedUserId" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <relationship name="managedCourse" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Course" inverseName="managedUserCourse" inverseEntity="Course" syncable="YES"/>
+        <relationship name="managedUser" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="User" inverseName="managedUserCourse" inverseEntity="User" syncable="YES"/>
+    </entity>
+    <entity name="Video" representedClassName=".Video" syncable="YES">
+        <attribute name="managedCachedPath" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="managedCachedQuality" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedId" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedPlayTime" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managedStatus" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="managedThumbnailURL" optional="YES" attributeType="String" syncable="YES"/>
+        <relationship name="managedBlock" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Block" inverseName="managedVideo" inverseEntity="Block" syncable="YES"/>
+        <relationship name="managedURLs" optional="YES" toMany="YES" deletionRule="Cascade" ordered="YES" destinationEntity="VideoURL" inverseName="managedVideo" inverseEntity="VideoURL" syncable="YES"/>
+    </entity>
+    <entity name="VideoURL" representedClassName=".VideoURL" syncable="YES">
+        <attribute name="managedQuality" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="managedURL" optional="YES" attributeType="String" syncable="YES"/>
+        <relationship name="managedVideo" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Video" inverseName="managedURLs" inverseEntity="Video" syncable="YES"/>
+    </entity>
+    <elements>
+        <element name="Assignment" positionX="182.73046875" positionY="260.6640625" width="128" height="105"/>
+        <element name="AttemptEntity" positionX="-450" positionY="-234" width="128" height="208"/>
+        <element name="Block" positionX="-85.77734375" positionY="236.91796875" width="128" height="105"/>
+        <element name="Certificate" positionX="-372.0390625" positionY="364.015625" width="128" height="208"/>
+        <element name="CodeLimit" positionX="-286.51171875" positionY="-387.5234375" width="128" height="105"/>
+        <element name="CodeSample" positionX="-651.484375" positionY="-311.640625" width="128" height="90"/>
+        <element name="CodeTemplate" positionX="-492.8984375" positionY="-359.9921875" width="128" height="105"/>
+        <element name="Course" positionX="-594.50390625" positionY="49.8359375" width="128" height="778"/>
+        <element name="CourseList" positionX="-14.1953125" positionY="793.859375" width="128" height="135"/>
+        <element name="CoursePurchase" positionX="-450" positionY="-234" width="128" height="133"/>
+        <element name="CourseReview" positionX="-441" positionY="-234" width="128" height="165"/>
+        <element name="CourseReviewSummary" positionX="-389.45703125" positionY="795.01171875" width="128" height="120"/>
+        <element name="DiscussionThread" positionX="-450" positionY="-234" width="128" height="118"/>
+        <element name="EmailAddress" positionX="-450" positionY="-234" width="128" height="135"/>
+        <element name="LastCodeLanguage" positionX="-450" positionY="-234" width="128" height="75"/>
+        <element name="LastStep" positionX="-361.27734375" positionY="646.40625" width="128" height="105"/>
+        <element name="Lesson" positionX="-201.69140625" positionY="-66.22265625" width="128" height="253"/>
+        <element name="Notification" positionX="-208.453125" positionY="793.484375" width="128" height="195"/>
+        <element name="Profile" positionX="-547.68359375" positionY="-119.4140625" width="128" height="223"/>
+        <element name="Progress" positionX="210.40234375" positionY="32.89453125" width="128" height="210"/>
+        <element name="Section" positionX="-88.1484375" positionY="379.60546875" width="128" height="28"/>
+        <element name="SocialProfile" positionX="-450" positionY="-234" width="128" height="133"/>
+        <element name="Step" positionX="76.40625" positionY="-309.26953125" width="128" height="28"/>
+        <element name="StepOptions" positionX="-301.69921875" positionY="-199.52734375" width="128" height="148"/>
+        <element name="SubmissionEntity" positionX="-441" positionY="-225" width="128" height="178"/>
+        <element name="Unit" positionX="396.875" positionY="76.44140625" width="128" height="255"/>
+        <element name="User" positionX="-368.4296875" positionY="90.0234375" width="128" height="493"/>
+        <element name="UserActivityEntity" positionX="-450" positionY="-234" width="128" height="88"/>
+        <element name="UserCourse" positionX="-450" positionY="-234" width="128" height="178"/>
+        <element name="Video" positionX="259.9609375" positionY="505.1015625" width="128" height="165"/>
+        <element name="VideoURL" positionX="445.92578125" positionY="580.05078125" width="128" height="90"/>
+    </elements>
+</model>


### PR DESCRIPTION
**YouTrack task**: [#APPS-2980](https://vyahhi.myjetbrains.com/youtrack/issue/APPS-2980)

**Description**:
- Persists and parses`is_vote_notifications_enabled` attribute.
- Sends `is_vote_notifications_enabled` on profile update API request.