### PR TITLE
Certificates deep link

### DIFF
--- a/Stepic/Legacy/Analytics/Events/AmplitudeAnalyticsEvents.swift
+++ b/Stepic/Legacy/Analytics/Events/AmplitudeAnalyticsEvents.swift
@@ -745,6 +745,8 @@ extension AnalyticsEvent {
                 return "course"
             case .coursePromo:
                 return "coursePromo"
+            case .certificates:
+                return "certificates"
             }
         }()
 

--- a/Stepic/Legacy/Controllers/Notifications/Helpers/NotificationReactionHandler.swift
+++ b/Stepic/Legacy/Controllers/Notifications/Helpers/NotificationReactionHandler.swift
@@ -22,8 +22,7 @@ final class NotificationReactionHandler {
 
         if notification.action == .issuedCertificate,
            let currentUserID = self.userAccountService.currentUserID {
-            let route = DeepLinkRoute.certificates(userID: currentUserID)
-            DeepLinkRoutingService().route(route, fallbackPath: route.path)
+            DeepLinkRoutingService().route(.certificates(userID: currentUserID))
         } else {
             let deepLinkRoutingService = DeepLinkRoutingService(courseViewSource: .notification)
 

--- a/Stepic/Legacy/Controllers/Notifications/Helpers/NotificationReactionHandler.swift
+++ b/Stepic/Legacy/Controllers/Notifications/Helpers/NotificationReactionHandler.swift
@@ -20,24 +20,25 @@ final class NotificationReactionHandler {
             return
         }
 
-        if notification.action == .issuedCertificate {
-            // TODO: Route to certificates.
-            return TabBarRouter(tab: .profile).route()
-        }
+        if notification.action == .issuedCertificate,
+           let currentUserID = self.userAccountService.currentUserID {
+            let route = DeepLinkRoute.certificates(userID: currentUserID)
+            DeepLinkRoutingService().route(route, fallbackPath: route.path)
+        } else {
+            let deepLinkRoutingService = DeepLinkRoutingService(courseViewSource: .notification)
 
-        let deepLinkRoutingService = DeepLinkRoutingService(courseViewSource: .notification)
-
-        switch notification.type {
-        case .comments:
-            deepLinkRoutingService.route(.notifications(section: .comments))
-        case .learn:
-            deepLinkRoutingService.route(.notifications(section: .learning))
-        case .default:
-            deepLinkRoutingService.route(.notifications(section: .all))
-        case .review:
-            deepLinkRoutingService.route(.notifications(section: .reviews))
-        case .teach:
-            deepLinkRoutingService.route(.notifications(section: .teaching))
+            switch notification.type {
+            case .comments:
+                deepLinkRoutingService.route(.notifications(section: .comments))
+            case .learn:
+                deepLinkRoutingService.route(.notifications(section: .learning))
+            case .default:
+                deepLinkRoutingService.route(.notifications(section: .all))
+            case .review:
+                deepLinkRoutingService.route(.notifications(section: .reviews))
+            case .teach:
+                deepLinkRoutingService.route(.notifications(section: .teaching))
+            }
         }
     }
 }

--- a/Stepic/Legacy/Services/DeepLinks/DeepLinkRoute.swift
+++ b/Stepic/Legacy/Services/DeepLinks/DeepLinkRoute.swift
@@ -20,6 +20,7 @@ enum DeepLinkRoute {
     case home
     case course(courseID: Int)
     case coursePromo(courseID: Int)
+    case certificates(userID: Int)
 
     var path: String {
         let path: String
@@ -58,6 +59,8 @@ enum DeepLinkRoute {
             path = "course/\(courseID)"
         case .coursePromo(let courseID):
             path = "course/\(courseID)/promo"
+        case .certificates(let userID):
+            path = "users/\(userID)/certificates"
         }
 
         return "\(StepikApplicationsInfo.stepikURL)/\(path)"
@@ -136,6 +139,13 @@ enum DeepLinkRoute {
             return
         }
 
+        if let match = Pattern.certificates.regex.firstMatch(in: path),
+           let userIDString = match.captures[0], let userID = Int(userIDString),
+           match.matchedString == path {
+            self = .certificates(userID: userID)
+            return
+        }
+
         return nil
     }
 
@@ -149,6 +159,7 @@ enum DeepLinkRoute {
         case lesson
         case discussions
         case solutions
+        case certificates
 
         var regex: Regex {
             try! Regex(string: self.pattern, options: [.ignoreCase])
@@ -179,6 +190,8 @@ enum DeepLinkRoute {
                 return #"\#(stepik)\#(lesson)step\/(\d+)(?:\?discussion=(\d+))(?:\&unit=(\d+))?\/?\#(queryComponents)"#
             case .solutions:
                 return #"\#(stepik)\#(lesson)step\/(\d+)(?:\?discussion=(\d+))(?:\&unit=(\d+))?&amp;thread=solutions.*"#
+            case .certificates:
+                return #"\#(stepik)users\/(\d+)\/certificates\/?\#(queryComponents)"#
             }
         }
     }

--- a/Stepic/Legacy/Services/DeepLinks/DeepLinkRoutingService.swift
+++ b/Stepic/Legacy/Services/DeepLinks/DeepLinkRoutingService.swift
@@ -44,12 +44,13 @@ final class DeepLinkRoutingService {
     }
 
     func route(_ route: DeepLinkRoute?, fallbackPath: String = "", from source: UIViewController? = nil) {
-        self.getModuleStack(route: route, urlPath: fallbackPath).done { moduleStack in
+        let fallbackURLPath = fallbackPath.isEmpty ? (route?.path ?? "") : fallbackPath
+        self.getModuleStack(route: route, urlPath: fallbackURLPath).done { moduleStack in
             let router = self.makeRouter(
                 route: route,
                 from: source,
                 moduleStack: moduleStack,
-                fallbackPath: fallbackPath
+                fallbackPath: fallbackURLPath
             )
             router.route()
         }.catch { _ in

--- a/Stepic/Legacy/Services/DeepLinks/DeepLinkRoutingService.swift
+++ b/Stepic/Legacy/Services/DeepLinks/DeepLinkRoutingService.swift
@@ -80,7 +80,7 @@ final class DeepLinkRoutingService {
             return TabBarRouter(tab: .catalog)
         case .notifications(let section):
             return TabBarRouter(notificationsSection: section)
-        case .course, .coursePromo, .discussions, .solutions, .lesson, .profile, .syllabus:
+        case .course, .coursePromo, .discussions, .solutions, .lesson, .profile, .syllabus, .certificates:
             return ModalOrPushStackRouter(
                 source: source,
                 destinationStack: moduleStack,
@@ -152,6 +152,8 @@ final class DeepLinkRoutingService {
                         seal.fulfill(moduleStack)
                     }
                 )
+            case .certificates(let userID):
+                seal.fulfill([CertificatesLegacyAssembly(userID: userID).makeModule()])
             }
         }
     }

--- a/StepicTests/DeepLinkRouteTests.swift
+++ b/StepicTests/DeepLinkRouteTests.swift
@@ -258,6 +258,23 @@ class DeepLinkRouteSpec: QuickSpec {
                     }
                 }
             }
+
+            context("certificates") {
+                it("matches certificates deep link with given paths") {
+                    let paths = [
+                        "http://stepik.org/users/21612976/certificates",
+                        "https://stepik.org/users/21612976/certificates",
+                        "https://stepik.org/users/21612976/certificates/",
+                        "https://stepik.org/users/21612976/certificates?from_mobile_app=true"
+                    ]
+                    self.checkPaths(paths) { route in
+                        guard case let .certificates(userID) = route else {
+                            return .failed(reason: "wrong enum case, expected `certificates`, got \(route)")
+                        }
+                        return userID == 21612976 ? .succeeded : .failed(reason: "wrong user id")
+                    }
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
**YouTrack task**: [#APPS-2453](https://vyahhi.myjetbrains.com/youtrack/issue/APPS-2453)

**Description**:
- Adds `DeepLinkRoute.certificates(userID:)` case.
- `DeepLinkRoutingService` supports routing to certificates.
- Route to certificates screen on notification receive.