### PR TITLE
Fix application icon badge number

### DIFF
--- a/Stepic/Legacy/AppDelegate.swift
+++ b/Stepic/Legacy/AppDelegate.swift
@@ -325,7 +325,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     private func checkNotificationsCount() {
         guard AuthInfo.shared.isAuthorized else {
-            return
+            return NotificationsBadgesManager.shared.set(number: 0)
         }
 
         ApiDataDownloader.notificationsStatusAPI.retrieve().done { result in


### PR DESCRIPTION
**YouTrack task**: [#APPS-2831](https://vyahhi.myjetbrains.com/youtrack/issue/APPS-2831)

**Description**:
- Clears `applicationIconBadgeNumber` when user unauthorized.