### PR TITLE
Fix crash when video URLs is empty

### DIFF
--- a/Stepic/Legacy/Controllers/VideoPlayer/Player.swift
+++ b/Stepic/Legacy/Controllers/VideoPlayer/Player.swift
@@ -262,22 +262,29 @@ public class Player: UIViewController {
             self.avplayer.removeTimeObserver(obs)
         }
 
-        self.avplayer.removeTimeObserver(timeObserver!)
+        if self.timeObserver != nil {
+            self.avplayer.removeTimeObserver(timeObserver!)
+        }
         self.delegate = nil
 
         NotificationCenter.default.removeObserver(self)
 
-        self.playerView.layer.removeObserver(
-            self,
-            forKeyPath: PlayerReadyForDisplayKey,
-            context: &PlayerLayerObserverContext
-        )
-        self.playerView.player = nil
+        if self.playerView != nil {
+            self.playerView.layer.removeObserver(
+                self,
+                forKeyPath: PlayerReadyForDisplayKey,
+                context: &PlayerLayerObserverContext
+            )
+            self.playerView.player = nil
+        }
 
-        self.avplayer.removeObserver(self, forKeyPath: PlayerRateKey, context: &PlayerObserverContext)
+        if self.avplayer.observationInfo != nil {
+            self.avplayer.removeObserver(self, forKeyPath: PlayerRateKey, context: &PlayerObserverContext)
+        }
 
         self.avplayer.pause()
         self.setupPlayerItem(nil)
+
         print("player is deinitialized")
     }
 

--- a/Stepic/Legacy/Model/Entities/Video/Video.swift
+++ b/Stepic/Legacy/Model/Entities/Video/Video.swift
@@ -66,7 +66,11 @@ final class Video: NSManagedObject, JSONSerializable {
         return res
     }
 
-    func getUrlForQuality(_ quality: String) -> URL {
+    func getUrlForQuality(_ quality: String) -> URL? {
+        if self.urls.isEmpty {
+            return nil
+        }
+
         var urlToReturn: VideoURL?
         var minDifference = 10000
         for url in urls {
@@ -77,9 +81,9 @@ final class Video: NSManagedObject, JSONSerializable {
         }
 
         if let url = urlToReturn {
-            return URL(string: url.url)!
+            return URL(string: url.url)
         } else {
-            return URL(string: urls[0].url)!
+            return URL(string: self.urls[0].url)
         }
     }
 

--- a/Stepic/Sources/Frameworks/Downloader/DownloadingService/VideoDownloadingService.swift
+++ b/Stepic/Sources/Frameworks/Downloader/DownloadingService/VideoDownloadingService.swift
@@ -89,7 +89,11 @@ final class VideoDownloadingService: VideoDownloadingServiceProtocol {
 
         let globalDownloadVideoQuality = self.downloadVideoQualityStorageManager.globalDownloadVideoQuality
         let nearestQuality = video.getNearestQualityToDefault(globalDownloadVideoQuality.uniqueIdentifier)
-        let url = video.getUrlForQuality(nearestQuality)
+
+        guard let url = video.getUrlForQuality(nearestQuality) else {
+            throw Error.videoURLNotFound
+        }
+
         let task = DownloaderTask(url: url)
 
         self.setupReporters(for: task)
@@ -266,6 +270,7 @@ final class VideoDownloadingService: VideoDownloadingServiceProtocol {
         case videoNotFound
         case videoTemporaryFileNotSavedAsVideoFile
         case videoDownloadingStopped
+        case videoURLNotFound
         case alreadyDownloading
     }
 }

--- a/Stepic/Sources/Modules/CourseInfoSubmodules/CourseInfoTabSyllabus/Provider/SyllabusDownloadsService.swift
+++ b/Stepic/Sources/Modules/CourseInfoSubmodules/CourseInfoTabSyllabus/Provider/SyllabusDownloadsService.swift
@@ -150,7 +150,8 @@ final class SyllabusDownloadsService: SyllabusDownloadsServiceProtocol {
     private func startDownloading(section: Section? = nil, unit: Unit, steps: [Step]) throws {
         let uncachedVideos = steps.compactMap { step -> Video? in
             guard step.block.type == .video,
-                  let video = step.block.video else {
+                  let video = step.block.video,
+                  !video.urls.isEmpty else {
                 return nil
             }
             return self.videoFileManager.getVideoStoredFile(videoID: video.id) == nil ? video : nil
@@ -471,7 +472,7 @@ final class SyllabusDownloadsService: SyllabusDownloadsServiceProtocol {
 
         // Iterate through steps and determine final state
         let stepsWithVideoCount = steps
-            .filter { $0.block.type == .video }
+            .filter { $0.block.type == .video && !($0.block.video?.urls.isEmpty ?? true) }
             .count
         let stepsWithImagesCount = steps
             .filter { !$0.block.imageSourceURLs.isEmpty }

--- a/Stepic/en.lproj/Localizable.strings
+++ b/Stepic/en.lproj/Localizable.strings
@@ -855,6 +855,8 @@ VideoQuality = "Video quality";
 Downloaded = "Downloaded";
 VideoPlayerAutoplayPreferenceTitle = "Auto-transition to next step";
 VideoPlayerAutoplayCancelTitle = "Stay on this step";
+VideoPlayerInvalidVideoAlertTitle = "Playback error";
+VideoPlayerInvalidVideoAlertMessage = "Video has not been uploaded or processed yet. Please, try again later.";
 
 StepikSocialNetworksTitle = "Our social networks";
 

--- a/Stepic/ru.lproj/Localizable.strings
+++ b/Stepic/ru.lproj/Localizable.strings
@@ -856,6 +856,8 @@ VideoRate = "Скорость воспроизведения";
 VideoQuality = "Качество видео";
 VideoPlayerAutoplayPreferenceTitle = "Автопереход на следующий шаг";
 VideoPlayerAutoplayCancelTitle = "Остаться на этом шаге";
+VideoPlayerInvalidVideoAlertTitle = "Ошибка воспроизведения";
+VideoPlayerInvalidVideoAlertMessage = "Видео ещё не было загружено преподавателем или обработано. Пожалуйста, попробуйте воспроизвести видео позже.";
 
 StepikSocialNetworksTitle = "Наши аккаунты в соцсетях";
 


### PR DESCRIPTION
**YouTrack task**: [#APPS-3019](https://vyahhi.myjetbrains.com/youtrack/issue/APPS-3019)

**Description**:
- Fixes crash in `Video.getUrlForQuality(_:)` that invoked by`VideoDownloadingService.download(video:)` and `StepikVideoPlayerViewController.getInitialVideoQualityURL()`.