### PR TITLE
Update dependencies 1.145

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -29,11 +29,11 @@ def all_pods
     pod 'SnapKit', '5.0.1'
 
     # Firebase
-    pod 'Firebase/Core', '6.33.0'
-    pod 'Firebase/Messaging', '6.33.0'
-    pod 'Firebase/Analytics', '6.33.0'
-    pod 'Firebase/Crashlytics', '6.33.0'
-    pod 'Firebase/RemoteConfig', '6.33.0'
+    pod 'Firebase/Core', '6.34.0'
+    pod 'Firebase/Messaging', '6.34.0'
+    pod 'Firebase/Analytics', '6.34.0'
+    pod 'Firebase/Crashlytics', '6.34.0'
+    pod 'Firebase/RemoteConfig', '6.34.0'
 
     pod 'YandexMobileMetrica/Dynamic', '3.11.1'
     pod 'Amplitude-iOS', '4.9.3'

--- a/Podfile
+++ b/Podfile
@@ -72,7 +72,7 @@ end
 
 def testing_pods
     pod 'Quick', '3.0.0'
-    pod 'Nimble', '9.0.0-rc.3'
+    pod 'Nimble', '9.0.0'
     pod 'Mockingjay', '3.0.0-alpha.1'
 end
 

--- a/Podfile
+++ b/Podfile
@@ -43,7 +43,7 @@ def all_pods
 
     pod 'IQKeyboardManagerSwift', '6.5.4'
 
-    pod 'Kanna', '5.2.2'
+    pod 'Kanna', '5.2.3'
     # Remove after NotificationsService refactoring
     pod 'CRToast', '0.0.9'
     pod 'TUSafariActivity', '1.0.4'

--- a/Podfile
+++ b/Podfile
@@ -63,7 +63,7 @@ def all_pods
     pod 'Koloda', '5.0'
     pod 'Charts', '3.6.0'
     pod 'EasyTipView', '2.0.4'
-    pod 'ActionSheetPicker-3.0', '2.6.0'
+    pod 'ActionSheetPicker-3.0', '2.6.1'
     pod 'Nuke', '9.1.2'
     pod 'STRegex', '2.1.1'
     pod 'Tabman', '2.8.0'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -142,7 +142,7 @@ PODS:
   - HexColors (2.3.0)
   - Highlightr (2.1.0)
   - IQKeyboardManagerSwift (6.5.4)
-  - Kanna (5.2.2)
+  - Kanna (5.2.3)
   - Koloda (5.0):
     - pop (~> 1.0)
   - lottie-ios (2.5.3)
@@ -226,7 +226,7 @@ DEPENDENCIES:
   - GoogleSignIn (= 5.0.2)
   - Highlightr (= 2.1.0)
   - IQKeyboardManagerSwift (= 6.5.4)
-  - Kanna (= 5.2.2)
+  - Kanna (= 5.2.3)
   - Koloda (= 5.0)
   - lottie-ios (= 2.5.3)
   - Mockingjay (= 3.0.0-alpha.1)
@@ -369,7 +369,7 @@ SPEC CHECKSUMS:
   HexColors: 6ad3947c3447a055a3aa8efa859def096351fe5f
   Highlightr: 595f3e100737c8de41113385da8bd0b5b65212c6
   IQKeyboardManagerSwift: 2dde0fc70110e8eac7ccce2a46fdbec6a850b414
-  Kanna: 2c4eddaaa4bfb9a1ed19e53c0b3d42ef02838046
+  Kanna: 113d111e95d7e903efe0c3eb7221f7635716084c
   Koloda: 75302d21882cc3e274c1561b1155805ea5919dab
   lottie-ios: a50d5c0160425cd4b01b852bb9578963e6d92d31
   Mockingjay: 0f7c5aa49c7f1b95621cee3c79b557141f5a225c
@@ -401,6 +401,6 @@ SPEC CHECKSUMS:
   VK-ios-sdk: 62a10b6571fbcda0657f455fedce7fedf55b4cd0
   YandexMobileMetrica: e985e1f77e405390a2d13f11741d86ff2f00c4ce
 
-PODFILE CHECKSUM: 7f4df533b699de8c0a371992eb674b13a7bba76b
+PODFILE CHECKSUM: b8001335110580b613b061dc8ece823d667333de
 
 COCOAPODS: 1.9.3

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -34,34 +34,34 @@ PODS:
     - FBSDKLoginKit/Login (= 8.0.0)
   - FBSDKLoginKit/Login (8.0.0):
     - FBSDKCoreKit (~> 8.0.0)
-  - Firebase/Analytics (6.33.0):
+  - Firebase/Analytics (6.34.0):
     - Firebase/Core
-  - Firebase/Core (6.33.0):
+  - Firebase/Core (6.34.0):
     - Firebase/CoreOnly
-    - FirebaseAnalytics (= 6.8.3)
-  - Firebase/CoreOnly (6.33.0):
-    - FirebaseCore (= 6.10.3)
-  - Firebase/Crashlytics (6.33.0):
+    - FirebaseAnalytics (= 6.9.0)
+  - Firebase/CoreOnly (6.34.0):
+    - FirebaseCore (= 6.10.4)
+  - Firebase/Crashlytics (6.34.0):
     - Firebase/CoreOnly
-    - FirebaseCrashlytics (~> 4.6.1)
-  - Firebase/Messaging (6.33.0):
+    - FirebaseCrashlytics (~> 4.6.2)
+  - Firebase/Messaging (6.34.0):
     - Firebase/CoreOnly
-    - FirebaseMessaging (~> 4.7.0)
-  - Firebase/RemoteConfig (6.33.0):
+    - FirebaseMessaging (~> 4.7.1)
+  - Firebase/RemoteConfig (6.34.0):
     - Firebase/CoreOnly
-    - FirebaseRemoteConfig (~> 4.9.0)
+    - FirebaseRemoteConfig (~> 4.9.1)
   - FirebaseABTesting (4.2.0):
     - FirebaseCore (~> 6.10)
-  - FirebaseAnalytics (6.8.3):
+  - FirebaseAnalytics (6.9.0):
     - FirebaseCore (~> 6.10)
-    - FirebaseInstallations (~> 1.6)
-    - GoogleAppMeasurement (= 6.8.3)
+    - FirebaseInstallations (~> 1.7)
+    - GoogleAppMeasurement (= 6.9.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 6.7)
     - GoogleUtilities/MethodSwizzler (~> 6.7)
     - GoogleUtilities/Network (~> 6.7)
     - "GoogleUtilities/NSData+zlib (~> 6.7)"
     - nanopb (~> 1.30906.0)
-  - FirebaseCore (6.10.3):
+  - FirebaseCore (6.10.4):
     - FirebaseCoreDiagnostics (~> 1.6)
     - GoogleUtilities/Environment (~> 6.7)
     - GoogleUtilities/Logger (~> 6.7)
@@ -70,7 +70,7 @@ PODS:
     - GoogleUtilities/Environment (~> 6.7)
     - GoogleUtilities/Logger (~> 6.7)
     - nanopb (~> 1.30906.0)
-  - FirebaseCrashlytics (4.6.1):
+  - FirebaseCrashlytics (4.6.2):
     - FirebaseCore (~> 6.10)
     - FirebaseInstallations (~> 1.6)
     - GoogleDataTransport (~> 7.2)
@@ -81,12 +81,12 @@ PODS:
     - GoogleUtilities/Environment (~> 6.7)
     - GoogleUtilities/UserDefaults (~> 6.7)
     - PromisesObjC (~> 1.2)
-  - FirebaseInstanceID (4.7.0):
+  - FirebaseInstanceID (4.8.0):
     - FirebaseCore (~> 6.10)
     - FirebaseInstallations (~> 1.6)
     - GoogleUtilities/Environment (~> 6.7)
     - GoogleUtilities/UserDefaults (~> 6.7)
-  - FirebaseMessaging (4.7.0):
+  - FirebaseMessaging (4.7.1):
     - FirebaseCore (~> 6.10)
     - FirebaseInstanceID (~> 4.7)
     - GoogleUtilities/AppDelegateSwizzler (~> 6.7)
@@ -94,19 +94,19 @@ PODS:
     - GoogleUtilities/Reachability (~> 6.7)
     - GoogleUtilities/UserDefaults (~> 6.7)
     - Protobuf (>= 3.9.2, ~> 3.9)
-  - FirebaseRemoteConfig (4.9.0):
+  - FirebaseRemoteConfig (4.9.1):
     - FirebaseABTesting (~> 4.2)
     - FirebaseCore (~> 6.10)
     - FirebaseInstallations (~> 1.6)
     - GoogleUtilities/Environment (~> 6.7)
     - "GoogleUtilities/NSData+zlib (~> 6.7)"
-  - GoogleAppMeasurement (6.8.3):
+  - GoogleAppMeasurement (6.9.0):
     - GoogleUtilities/AppDelegateSwizzler (~> 6.7)
     - GoogleUtilities/MethodSwizzler (~> 6.7)
     - GoogleUtilities/Network (~> 6.7)
     - "GoogleUtilities/NSData+zlib (~> 6.7)"
     - nanopb (~> 1.30906.0)
-  - GoogleDataTransport (7.4.0):
+  - GoogleDataTransport (7.5.1):
     - nanopb (~> 1.30906.0)
   - GoogleSignIn (5.0.2):
     - AppAuth (~> 1.2)
@@ -172,7 +172,7 @@ PODS:
     - PromiseKit/CorePromise
   - PromiseKit/UIKit (6.13.1):
     - PromiseKit/CorePromise
-  - PromisesObjC (1.2.10)
+  - PromisesObjC (1.2.11)
   - Protobuf (3.13.0)
   - Quick (3.0.0)
   - Reveal-SDK (26)
@@ -218,11 +218,11 @@ DEPENDENCIES:
   - EasyTipView (= 2.0.4)
   - FBSDKCoreKit (= 8.0.0)
   - FBSDKLoginKit (= 8.0.0)
-  - Firebase/Analytics (= 6.33.0)
-  - Firebase/Core (= 6.33.0)
-  - Firebase/Crashlytics (= 6.33.0)
-  - Firebase/Messaging (= 6.33.0)
-  - Firebase/RemoteConfig (= 6.33.0)
+  - Firebase/Analytics (= 6.34.0)
+  - Firebase/Core (= 6.34.0)
+  - Firebase/Crashlytics (= 6.34.0)
+  - Firebase/Messaging (= 6.34.0)
+  - Firebase/RemoteConfig (= 6.34.0)
   - GoogleSignIn (= 5.0.2)
   - Highlightr (= 2.1.0)
   - IQKeyboardManagerSwift (= 6.5.4)
@@ -350,18 +350,18 @@ SPEC CHECKSUMS:
   EasyTipView: 4f8beae0a82db2ca4a9b5fd658785fc5f61d296b
   FBSDKCoreKit: 9d27fe97a2fa2abe5eeefea8240e837623ab88e0
   FBSDKLoginKit: 2cbaf5405379731b22f2ebc224f7c30f62378171
-  Firebase: 8db6f2d1b2c5e2984efba4949a145875a8f65fe5
+  Firebase: c23a36d9e4cdf7877dfcba8dd0c58add66358999
   FirebaseABTesting: 8a9d8df3acc2b43f4a22014ddf9f601bca6af699
-  FirebaseAnalytics: 5dd088bd2e67bb9d13dbf792d1164ceaf3052193
-  FirebaseCore: d889d9e12535b7f36ac8bfbf1713a0836a3012cd
+  FirebaseAnalytics: 3bb096873ee0d7fa4b6c70f5e9166b6da413cc7f
+  FirebaseCore: d3a978a3cfa3240bf7e4ba7d137fdf5b22b628ec
   FirebaseCoreDiagnostics: 770ac5958e1372ce67959ae4b4f31d8e127c3ac1
-  FirebaseCrashlytics: 5777d3462fb8c3ab9e80a2473bd7d667a2e8411c
+  FirebaseCrashlytics: 1a747c9cc084a24dc6d9511c991db1cd078154eb
   FirebaseInstallations: 466c7b4d1f58fe16707693091da253726a731ed2
-  FirebaseInstanceID: ac5a82fcd21f804dbfc8f318eff9e1d7a9916e49
-  FirebaseMessaging: fc1f98b4592f8f2ea538169b1c317c6e76f81300
-  FirebaseRemoteConfig: e40f9e084658210c4d9c341cfa9f6cab6ad4f67e
-  GoogleAppMeasurement: 966e88df9d19c15715137bb2ddaf52373f111436
-  GoogleDataTransport: b7f406340a291370045a270c599e53c6fa6ec20f
+  FirebaseInstanceID: bd3ffc24367f901a43c063b36c640b345a4a5dd1
+  FirebaseMessaging: 5eca4ef173de76253352511aafef774caa1cba2a
+  FirebaseRemoteConfig: 35a729305f254fb15a2e541d4b36f3a379da7fdc
+  GoogleAppMeasurement: a6a3a066369828db64eda428cb2856dc1cdc7c4e
+  GoogleDataTransport: f56af7caa4ed338dc8e138a5d7c5973e66440833
   GoogleSignIn: 7137d297ddc022a7e0aa4619c86d72c909fa7213
   GoogleUtilities: 7f2f5a07f888cdb145101d6042bc4422f57e70b3
   GTMAppAuth: 4deac854479704f348309e7b66189e604cf5e01e
@@ -380,7 +380,7 @@ SPEC CHECKSUMS:
   pop: d582054913807fd11fd50bfe6a539d91c7e1a55a
   Presentr: 7078d7eb5d1661ebeaae60c9e42a1e534de1b993
   PromiseKit: 28fda91c973cc377875d8c0ea4f973013c05b6db
-  PromisesObjC: b14b1c6b68e306650688599de8a45e49fae81151
+  PromisesObjC: 8c196f5a328c2cba3e74624585467a557dcb482f
   Protobuf: 3dac39b34a08151c6d949560efe3f86134a3f748
   Quick: 6d9559f40647bc4d510103842ef2fdd882d753e2
   Reveal-SDK: 5f94f14aff3d5f2a49f246edcd266fa4472679e9
@@ -401,6 +401,6 @@ SPEC CHECKSUMS:
   VK-ios-sdk: 62a10b6571fbcda0657f455fedce7fedf55b4cd0
   YandexMobileMetrica: e985e1f77e405390a2d13f11741d86ff2f00c4ce
 
-PODFILE CHECKSUM: 47e91f9d0b9df64138164911b0edcefe412d7d71
+PODFILE CHECKSUM: 7f4df533b699de8c0a371992eb674b13a7bba76b
 
 COCOAPODS: 1.9.3

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -158,7 +158,7 @@ PODS:
     - nanopb/encode (= 1.30906.0)
   - nanopb/decode (1.30906.0)
   - nanopb/encode (1.30906.0)
-  - Nimble (9.0.0-rc.3)
+  - Nimble (9.0.0)
   - Nuke (9.1.2)
   - Pageboy (3.5.1)
   - pop (1.0.12)
@@ -230,7 +230,7 @@ DEPENDENCIES:
   - Koloda (= 5.0)
   - lottie-ios (= 2.5.3)
   - Mockingjay (= 3.0.0-alpha.1)
-  - Nimble (= 9.0.0-rc.3)
+  - Nimble (= 9.0.0)
   - Nuke (= 9.1.2)
   - Presentr (= 1.9)
   - PromiseKit (= 6.13.1)
@@ -374,7 +374,7 @@ SPEC CHECKSUMS:
   lottie-ios: a50d5c0160425cd4b01b852bb9578963e6d92d31
   Mockingjay: 0f7c5aa49c7f1b95621cee3c79b557141f5a225c
   nanopb: 59317e09cf1f1a0af72f12af412d54edf52603fc
-  Nimble: 1b5fa99320d0d87ed72bb0add38dc696aa77f556
+  Nimble: 3b4ec3fd40f1dc178058e0981107721c615643d8
   Nuke: dd2e6be6a34c042a7861e190632781d11f253026
   Pageboy: 288353d4cc848c24deec2f7542f325089247c136
   pop: d582054913807fd11fd50bfe6a539d91c7e1a55a
@@ -401,6 +401,6 @@ SPEC CHECKSUMS:
   VK-ios-sdk: 62a10b6571fbcda0657f455fedce7fedf55b4cd0
   YandexMobileMetrica: e985e1f77e405390a2d13f11741d86ff2f00c4ce
 
-PODFILE CHECKSUM: a864ba1ed94e28ea6c7a7110961912f3a2f0239e
+PODFILE CHECKSUM: 47e91f9d0b9df64138164911b0edcefe412d7d71
 
 COCOAPODS: 1.9.3

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - ActionSheetPicker-3.0 (2.6.0)
+  - ActionSheetPicker-3.0 (2.6.1)
   - Agrume (5.6.10):
     - SwiftyGif
   - Alamofire (5.2.2)
@@ -204,7 +204,7 @@ PODS:
     - YandexMobileMetrica/Dynamic/Core
 
 DEPENDENCIES:
-  - ActionSheetPicker-3.0 (= 2.6.0)
+  - ActionSheetPicker-3.0 (= 2.6.1)
   - Agrume (= 5.6.10)
   - Alamofire (= 5.2.2)
   - Amplitude-iOS (= 4.9.3)
@@ -334,7 +334,7 @@ CHECKOUT OPTIONS:
     :git: https://github.com/KrauseFx/TSMessages.git
 
 SPEC CHECKSUMS:
-  ActionSheetPicker-3.0: f47ea288343f6fb86285f1cca1f849bd2a40a54e
+  ActionSheetPicker-3.0: d7a91adbc3aa8126aadc070f1276b14216bfadd4
   Agrume: bed8984d8644d9f9228e65ca22cfc5f6ab95947f
   Alamofire: 814429acc853c6c54ff123fc3d2ef66803823ce0
   Amplitude-iOS: 122e026c44db8460e5efcf84859aa290a0ae9786
@@ -401,6 +401,6 @@ SPEC CHECKSUMS:
   VK-ios-sdk: 62a10b6571fbcda0657f455fedce7fedf55b4cd0
   YandexMobileMetrica: e985e1f77e405390a2d13f11741d86ff2f00c4ce
 
-PODFILE CHECKSUM: 29ca009767a298a3fd8103d04058b4518eb5efe0
+PODFILE CHECKSUM: a864ba1ed94e28ea6c7a7110961912f3a2f0239e
 
 COCOAPODS: 1.9.3


### PR DESCRIPTION
**Description**:
Bumps:
- [ActionSheetPicker-3.0](https://github.com/skywinder/ActionSheetPicker-3.0) from 2.6.0 to 2.6.1
- [Nimble](https://github.com/Quick/Nimble) from 9.0.0-rc.3 to 9.0.0
- [Firebase](https://github.com/firebase/firebase-ios-sdk) from 6.33.0 to 6.34.0
- [Kanna](https://github.com/tid-kijyun/Kanna) from 5.2.2 to 5.2.3