### PR TITLE
Update dependencies 1.151

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 ruby "2.6.5"
 
-gem "fastlane", "2.166.0"
+gem "fastlane", "2.167.0"
 gem "cocoapods", "1.10.0"
 
 plugins_path = File.join(File.dirname(__FILE__), 'fastlane', 'Pluginfile')

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,8 +14,8 @@ GEM
       json (>= 1.5.1)
     atomos (0.1.3)
     aws-eventstream (1.1.0)
-    aws-partitions (1.390.0)
-    aws-sdk-core (3.109.2)
+    aws-partitions (1.394.0)
+    aws-sdk-core (3.109.3)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.239.0)
       aws-sigv4 (~> 1.1)
@@ -94,7 +94,7 @@ GEM
     faraday_middleware (1.0.0)
       faraday (~> 1.0)
     fastimage (2.2.0)
-    fastlane (2.166.0)
+    fastlane (2.167.0)
       CFPropertyList (>= 2.3, < 4.0.0)
       addressable (>= 2.3, < 3.0.0)
       aws-sdk-s3 (~> 1.0)
@@ -240,7 +240,7 @@ PLATFORMS
 
 DEPENDENCIES
   cocoapods (= 1.10.0)
-  fastlane (= 2.166.0)
+  fastlane (= 2.167.0)
   fastlane-plugin-firebase_app_distribution
 
 RUBY VERSION

--- a/Podfile
+++ b/Podfile
@@ -10,7 +10,7 @@ def shared_pods
     pod 'Alamofire', '5.4.0'
     pod 'Atributika', '4.9.10'
     pod 'SwiftyJSON', '5.0.0'
-    pod 'SDWebImage', '5.9.4'
+    pod 'SDWebImage', '5.9.5'
     pod 'SVGKit', :git => 'https://github.com/SVGKit/SVGKit.git', :branch => '2.x'
     pod 'DeviceKit', '4.2.1'
     pod 'PromiseKit', '6.13.1'

--- a/Podfile
+++ b/Podfile
@@ -35,7 +35,7 @@ def all_pods
     pod 'Firebase/Crashlytics', '7.0.0'
     pod 'Firebase/RemoteConfig', '7.0.0'
 
-    pod 'YandexMobileMetrica/Dynamic', '3.11.1'
+    pod 'YandexMobileMetrica/Dynamic', '3.12.0'
     pod 'Amplitude-iOS', '4.9.3'
     pod 'Branch', '0.31.0'
         

--- a/Podfile
+++ b/Podfile
@@ -29,11 +29,11 @@ def all_pods
     pod 'SnapKit', '5.0.1'
 
     # Firebase
-    pod 'Firebase/Core', '7.0.0'
-    pod 'Firebase/Messaging', '7.0.0'
-    pod 'Firebase/Analytics', '7.0.0'
-    pod 'Firebase/Crashlytics', '7.0.0'
-    pod 'Firebase/RemoteConfig', '7.0.0'
+    pod 'Firebase/Core', '7.1.0'
+    pod 'Firebase/Messaging', '7.1.0'
+    pod 'Firebase/Analytics', '7.1.0'
+    pod 'Firebase/Crashlytics', '7.1.0'
+    pod 'Firebase/RemoteConfig', '7.1.0'
 
     pod 'YandexMobileMetrica/Dynamic', '3.12.0'
     pod 'Amplitude-iOS', '4.9.3'

--- a/Podfile
+++ b/Podfile
@@ -50,8 +50,8 @@ def all_pods
     
     # Social SDKs
     pod 'VK-ios-sdk', '1.5.1'
-    pod 'FBSDKCoreKit', '8.1.0'
-    pod 'FBSDKLoginKit', '8.1.0'
+    pod 'FBSDKCoreKit', '8.2.0'
+    pod 'FBSDKLoginKit', '8.2.0'
     pod 'GoogleSignIn', '5.0.2'
     
     pod 'Presentr', '1.9'

--- a/Podfile
+++ b/Podfile
@@ -57,7 +57,7 @@ def all_pods
     pod 'Presentr', '1.9'
     pod 'PanModal', '1.2.7'
     
-    pod 'Agrume', '5.6.10'
+    pod 'Agrume', '5.6.11'
     pod 'Highlightr', '2.1.0'
     pod 'TTTAttributedLabel', '2.0.0'
     pod 'lottie-ios', '2.5.3'

--- a/Podfile
+++ b/Podfile
@@ -14,7 +14,7 @@ def shared_pods
     pod 'SVGKit', :git => 'https://github.com/SVGKit/SVGKit.git', :branch => '2.x'
     pod 'DeviceKit', '4.2.1'
     pod 'PromiseKit', '6.13.1'
-    pod 'SwiftLint', '0.40.3'
+    pod 'SwiftLint', '0.41.0'
     pod 'Reveal-SDK', :configurations => ['Production Debug', 'Release Debug', 'Develop Debug']
 end
 

--- a/Podfile
+++ b/Podfile
@@ -65,7 +65,7 @@ def all_pods
     pod 'Charts', '3.6.0'
     pod 'EasyTipView', '2.0.4'
     pod 'ActionSheetPicker-3.0', '2.7.1'
-    pod 'Nuke', '9.1.2'
+    pod 'Nuke', '9.1.3'
     pod 'STRegex', '2.1.1'
     pod 'Tabman', '2.8.0'
     pod 'SwiftDate', '6.3.0'

--- a/Podfile
+++ b/Podfile
@@ -68,7 +68,7 @@ def all_pods
     pod 'Nuke', '9.1.2'
     pod 'STRegex', '2.1.1'
     pod 'Tabman', '2.8.0'
-    pod 'SwiftDate', '6.2.0'
+    pod 'SwiftDate', '6.3.0'
 end
 
 def testing_pods

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -158,7 +158,7 @@ PODS:
   - nanopb/decode (2.30906.0)
   - nanopb/encode (2.30906.0)
   - Nimble (9.0.0)
-  - Nuke (9.1.2)
+  - Nuke (9.1.3)
   - Pageboy (3.5.1)
   - PanModal (1.2.7)
   - pop (1.0.12)
@@ -230,7 +230,7 @@ DEPENDENCIES:
   - lottie-ios (= 2.5.3)
   - Mockingjay (= 3.0.0-alpha.1)
   - Nimble (= 9.0.0)
-  - Nuke (= 9.1.2)
+  - Nuke (= 9.1.3)
   - PanModal (= 1.2.7)
   - Presentr (= 1.9)
   - PromiseKit (= 6.13.1)
@@ -375,7 +375,7 @@ SPEC CHECKSUMS:
   Mockingjay: 0f7c5aa49c7f1b95621cee3c79b557141f5a225c
   nanopb: 1bf24dd71191072e120b83dd02d08f3da0d65e53
   Nimble: 3b4ec3fd40f1dc178058e0981107721c615643d8
-  Nuke: dd2e6be6a34c042a7861e190632781d11f253026
+  Nuke: ee78dff29ad68cfd70a292a7960952f72cc6af6a
   Pageboy: 288353d4cc848c24deec2f7542f325089247c136
   PanModal: 3e16ead1a907fb06f4df3f13492fd00149fa4974
   pop: d582054913807fd11fd50bfe6a539d91c7e1a55a
@@ -401,6 +401,6 @@ SPEC CHECKSUMS:
   VK-ios-sdk: 62a10b6571fbcda0657f455fedce7fedf55b4cd0
   YandexMobileMetrica: 7ba67267e1ef841f77d5db17a5091b8e9eba911f
 
-PODFILE CHECKSUM: 7ee61c9dd2ddc25b44d3bc609aae158c44a989b5
+PODFILE CHECKSUM: 5ab384304b486013594f6c9383026abafbb40f3a
 
 COCOAPODS: 1.10.0

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -175,9 +175,9 @@ PODS:
   - PromisesObjC (1.2.11)
   - Quick (3.0.0)
   - Reveal-SDK (26)
-  - SDWebImage (5.9.4):
-    - SDWebImage/Core (= 5.9.4)
-  - SDWebImage/Core (5.9.4)
+  - SDWebImage (5.9.5):
+    - SDWebImage/Core (= 5.9.5)
+  - SDWebImage/Core (5.9.5)
   - SnapKit (5.0.1)
   - STRegex (2.1.1)
   - SVGKit (2.1.0):
@@ -236,7 +236,7 @@ DEPENDENCIES:
   - PromiseKit (= 6.13.1)
   - Quick (= 3.0.0)
   - Reveal-SDK
-  - SDWebImage (= 5.9.4)
+  - SDWebImage (= 5.9.5)
   - SnapKit (= 5.0.1)
   - STRegex (= 2.1.1)
   - SVGKit (from `https://github.com/SVGKit/SVGKit.git`, branch `2.x`)
@@ -384,7 +384,7 @@ SPEC CHECKSUMS:
   PromisesObjC: 8c196f5a328c2cba3e74624585467a557dcb482f
   Quick: 6d9559f40647bc4d510103842ef2fdd882d753e2
   Reveal-SDK: 5f94f14aff3d5f2a49f246edcd266fa4472679e9
-  SDWebImage: b69257f4ab14e9b6a2ef53e910fdf914d8f757c1
+  SDWebImage: 0b2ba0d56479bf6a45ecddbfd5558bea93150d25
   SnapKit: 97b92857e3df3a0c71833cce143274bf6ef8e5eb
   STRegex: d49e88d0fe58538d3175fdd989bc1243b9be2a07
   SVGKit: 8a2fc74258bdb2abb54d3b65f3dd68b0277a9c4d
@@ -401,6 +401,6 @@ SPEC CHECKSUMS:
   VK-ios-sdk: 62a10b6571fbcda0657f455fedce7fedf55b4cd0
   YandexMobileMetrica: 7ba67267e1ef841f77d5db17a5091b8e9eba911f
 
-PODFILE CHECKSUM: 7aea51f171592875998610724718d62f448e795c
+PODFILE CHECKSUM: 2f3b041e40afd5f2c142b4bc382fe66ee3066914
 
 COCOAPODS: 1.10.0

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
   - ActionSheetPicker-3.0 (2.7.1)
-  - Agrume (5.6.10):
+  - Agrume (5.6.11):
     - SwiftyGif
   - Alamofire (5.4.0)
   - Amplitude-iOS (4.9.3)
@@ -204,7 +204,7 @@ PODS:
 
 DEPENDENCIES:
   - ActionSheetPicker-3.0 (= 2.7.1)
-  - Agrume (= 5.6.10)
+  - Agrume (= 5.6.11)
   - Alamofire (= 5.4.0)
   - Amplitude-iOS (= 4.9.3)
   - Atributika (= 4.9.10)
@@ -335,7 +335,7 @@ CHECKOUT OPTIONS:
 
 SPEC CHECKSUMS:
   ActionSheetPicker-3.0: 36da254b97a09ff89679ecb8b8510bd3e5bdc773
-  Agrume: bed8984d8644d9f9228e65ca22cfc5f6ab95947f
+  Agrume: 085e64c6884fae11d3f3650fad3ebcb2c3df7597
   Alamofire: 3b6a534a3df22db367e4dedeeca73d1ddfcf0e2f
   Amplitude-iOS: 122e026c44db8460e5efcf84859aa290a0ae9786
   AppAuth: 31bcec809a638d7bd2f86ea8a52bd45f6e81e7c7
@@ -401,6 +401,6 @@ SPEC CHECKSUMS:
   VK-ios-sdk: 62a10b6571fbcda0657f455fedce7fedf55b4cd0
   YandexMobileMetrica: 7ba67267e1ef841f77d5db17a5091b8e9eba911f
 
-PODFILE CHECKSUM: 0193ddc5e33023d04d4547f978e0fbbd072e5334
+PODFILE CHECKSUM: 7ee61c9dd2ddc25b44d3bc609aae158c44a989b5
 
 COCOAPODS: 1.10.0

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -195,11 +195,11 @@ PODS:
   - TUSafariActivity (1.0.4)
   - URITemplate (3.0.0)
   - VK-ios-sdk (1.5.1)
-  - YandexMobileMetrica/Dynamic (3.11.1):
-    - YandexMobileMetrica/Dynamic/Core (= 3.11.1)
-    - YandexMobileMetrica/Dynamic/Crashes (= 3.11.1)
-  - YandexMobileMetrica/Dynamic/Core (3.11.1)
-  - YandexMobileMetrica/Dynamic/Crashes (3.11.1):
+  - YandexMobileMetrica/Dynamic (3.12.0):
+    - YandexMobileMetrica/Dynamic/Core (= 3.12.0)
+    - YandexMobileMetrica/Dynamic/Crashes (= 3.12.0)
+  - YandexMobileMetrica/Dynamic/Core (3.12.0)
+  - YandexMobileMetrica/Dynamic/Crashes (3.12.0):
     - YandexMobileMetrica/Dynamic/Core
 
 DEPENDENCIES:
@@ -249,7 +249,7 @@ DEPENDENCIES:
   - TTTAttributedLabel (= 2.0.0)
   - TUSafariActivity (= 1.0.4)
   - VK-ios-sdk (= 1.5.1)
-  - YandexMobileMetrica/Dynamic (= 3.11.1)
+  - YandexMobileMetrica/Dynamic (= 3.12.0)
 
 SPEC REPOS:
   https://github.com/CocoaPods/Specs.git:
@@ -399,8 +399,8 @@ SPEC CHECKSUMS:
   TUSafariActivity: afc55a00965377939107ce4fdc7f951f62454546
   URITemplate: 58e0d47f967006c5d59888af5356c4a8ed3b197d
   VK-ios-sdk: 62a10b6571fbcda0657f455fedce7fedf55b4cd0
-  YandexMobileMetrica: e985e1f77e405390a2d13f11741d86ff2f00c4ce
+  YandexMobileMetrica: 7ba67267e1ef841f77d5db17a5091b8e9eba911f
 
-PODFILE CHECKSUM: 530bd1b86c1d66c58b31c39d0588f6cf9e3bcb01
+PODFILE CHECKSUM: e637556d9dafa076b36854952a61e3d7ac371147
 
 COCOAPODS: 1.10.0

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -34,101 +34,101 @@ PODS:
     - FBSDKLoginKit/Login (= 8.1.0)
   - FBSDKLoginKit/Login (8.1.0):
     - FBSDKCoreKit (~> 8.1.0)
-  - Firebase/Analytics (7.0.0):
+  - Firebase/Analytics (7.1.0):
     - Firebase/Core
-  - Firebase/Core (7.0.0):
+  - Firebase/Core (7.1.0):
     - Firebase/CoreOnly
-    - FirebaseAnalytics (= 7.0.0)
-  - Firebase/CoreOnly (7.0.0):
-    - FirebaseCore (= 7.0.0)
-  - Firebase/Crashlytics (7.0.0):
+    - FirebaseAnalytics (= 7.1.0)
+  - Firebase/CoreOnly (7.1.0):
+    - FirebaseCore (= 7.1.0)
+  - Firebase/Crashlytics (7.1.0):
     - Firebase/CoreOnly
-    - FirebaseCrashlytics (~> 7.0.0)
-  - Firebase/Messaging (7.0.0):
+    - FirebaseCrashlytics (~> 7.1.0)
+  - Firebase/Messaging (7.1.0):
     - Firebase/CoreOnly
-    - FirebaseMessaging (~> 7.0.0)
-  - Firebase/RemoteConfig (7.0.0):
+    - FirebaseMessaging (~> 7.1.0)
+  - Firebase/RemoteConfig (7.1.0):
     - Firebase/CoreOnly
-    - FirebaseRemoteConfig (~> 7.0.0)
-  - FirebaseABTesting (7.0.0):
+    - FirebaseRemoteConfig (~> 7.1.0)
+  - FirebaseABTesting (7.1.0):
     - FirebaseCore (~> 7.0)
-  - FirebaseAnalytics (7.0.0):
+  - FirebaseAnalytics (7.1.0):
     - FirebaseCore (~> 7.0)
     - FirebaseInstallations (~> 7.0)
-    - GoogleAppMeasurement (= 7.0.0)
+    - GoogleAppMeasurement (= 7.1.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 7.0)
     - GoogleUtilities/MethodSwizzler (~> 7.0)
     - GoogleUtilities/Network (~> 7.0)
     - "GoogleUtilities/NSData+zlib (~> 7.0)"
     - nanopb (~> 2.30906.0)
-  - FirebaseCore (7.0.0):
+  - FirebaseCore (7.1.0):
     - FirebaseCoreDiagnostics (~> 7.0)
     - GoogleUtilities/Environment (~> 7.0)
     - GoogleUtilities/Logger (~> 7.0)
-  - FirebaseCoreDiagnostics (7.0.0):
+  - FirebaseCoreDiagnostics (7.1.0):
     - GoogleDataTransport (~> 8.0)
     - GoogleUtilities/Environment (~> 7.0)
     - GoogleUtilities/Logger (~> 7.0)
     - nanopb (~> 2.30906.0)
-  - FirebaseCrashlytics (7.0.0):
+  - FirebaseCrashlytics (7.1.0):
     - FirebaseCore (~> 7.0)
     - FirebaseInstallations (~> 7.0)
     - GoogleDataTransport (~> 8.0)
     - nanopb (~> 2.30906.0)
     - PromisesObjC (~> 1.2)
-  - FirebaseInstallations (7.0.0):
+  - FirebaseInstallations (7.1.0):
     - FirebaseCore (~> 7.0)
     - GoogleUtilities/Environment (~> 7.0)
     - GoogleUtilities/UserDefaults (~> 7.0)
     - PromisesObjC (~> 1.2)
-  - FirebaseInstanceID (7.0.0):
+  - FirebaseInstanceID (7.1.0):
     - FirebaseCore (~> 7.0)
     - FirebaseInstallations (~> 7.0)
     - GoogleUtilities/Environment (~> 7.0)
     - GoogleUtilities/UserDefaults (~> 7.0)
-  - FirebaseMessaging (7.0.0):
+  - FirebaseMessaging (7.1.0):
     - FirebaseCore (~> 7.0)
     - FirebaseInstanceID (~> 7.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 7.0)
     - GoogleUtilities/Environment (~> 7.0)
     - GoogleUtilities/Reachability (~> 7.0)
     - GoogleUtilities/UserDefaults (~> 7.0)
-  - FirebaseRemoteConfig (7.0.0):
+  - FirebaseRemoteConfig (7.1.0):
     - FirebaseABTesting (~> 7.0)
     - FirebaseCore (~> 7.0)
     - FirebaseInstallations (~> 7.0)
     - GoogleUtilities/Environment (~> 7.0)
     - "GoogleUtilities/NSData+zlib (~> 7.0)"
-  - GoogleAppMeasurement (7.0.0):
+  - GoogleAppMeasurement (7.1.0):
     - GoogleUtilities/AppDelegateSwizzler (~> 7.0)
     - GoogleUtilities/MethodSwizzler (~> 7.0)
     - GoogleUtilities/Network (~> 7.0)
     - "GoogleUtilities/NSData+zlib (~> 7.0)"
     - nanopb (~> 2.30906.0)
-  - GoogleDataTransport (8.0.0):
+  - GoogleDataTransport (8.0.1):
     - nanopb (~> 2.30906.0)
   - GoogleSignIn (5.0.2):
     - AppAuth (~> 1.2)
     - GTMAppAuth (~> 1.0)
     - GTMSessionFetcher/Core (~> 1.1)
-  - GoogleUtilities/AppDelegateSwizzler (7.0.0):
+  - GoogleUtilities/AppDelegateSwizzler (7.1.0):
     - GoogleUtilities/Environment
     - GoogleUtilities/Logger
     - GoogleUtilities/Network
-  - GoogleUtilities/Environment (7.0.0):
+  - GoogleUtilities/Environment (7.1.0):
     - PromisesObjC (~> 1.2)
-  - GoogleUtilities/Logger (7.0.0):
+  - GoogleUtilities/Logger (7.1.0):
     - GoogleUtilities/Environment
-  - GoogleUtilities/MethodSwizzler (7.0.0):
+  - GoogleUtilities/MethodSwizzler (7.1.0):
     - GoogleUtilities/Logger
-  - GoogleUtilities/Network (7.0.0):
+  - GoogleUtilities/Network (7.1.0):
     - GoogleUtilities/Logger
     - "GoogleUtilities/NSData+zlib"
     - GoogleUtilities/Reachability
-  - "GoogleUtilities/NSData+zlib (7.0.0)"
-  - GoogleUtilities/Reachability (7.0.0):
+  - "GoogleUtilities/NSData+zlib (7.1.0)"
+  - GoogleUtilities/Reachability (7.1.0):
     - GoogleUtilities/Logger
-  - GoogleUtilities/UserDefaults (7.0.0):
+  - GoogleUtilities/UserDefaults (7.1.0):
     - GoogleUtilities/Logger
   - GTMAppAuth (1.0.0):
     - AppAuth/Core (~> 1.0)
@@ -217,11 +217,11 @@ DEPENDENCIES:
   - EasyTipView (= 2.0.4)
   - FBSDKCoreKit (= 8.1.0)
   - FBSDKLoginKit (= 8.1.0)
-  - Firebase/Analytics (= 7.0.0)
-  - Firebase/Core (= 7.0.0)
-  - Firebase/Crashlytics (= 7.0.0)
-  - Firebase/Messaging (= 7.0.0)
-  - Firebase/RemoteConfig (= 7.0.0)
+  - Firebase/Analytics (= 7.1.0)
+  - Firebase/Core (= 7.1.0)
+  - Firebase/Crashlytics (= 7.1.0)
+  - Firebase/Messaging (= 7.1.0)
+  - Firebase/RemoteConfig (= 7.1.0)
   - GoogleSignIn (= 5.0.2)
   - Highlightr (= 2.1.0)
   - IQKeyboardManagerSwift (= 6.5.4)
@@ -350,20 +350,20 @@ SPEC CHECKSUMS:
   EasyTipView: 4f8beae0a82db2ca4a9b5fd658785fc5f61d296b
   FBSDKCoreKit: b3ca27e124dae67122d3bb47c8f96800b39986a6
   FBSDKLoginKit: a3a92ba9380759cd0c1aa8319465fb5f2857c602
-  Firebase: 50be68416f50eb4eb2ecb0e78acab9a051ef95df
-  FirebaseABTesting: b78ae653b7658b8f1c076eaa21029c936d58f758
-  FirebaseAnalytics: c1166b7990bae464c6436132510bb718c6680f80
-  FirebaseCore: cf3122185fce1cf71cedbbc498ea84d2b3e7cb69
-  FirebaseCoreDiagnostics: 5f4aa04fdb04923693cc704c7ef9158bdf41a48b
-  FirebaseCrashlytics: bd430b7323e8b49492a93e563e81899d0615f917
-  FirebaseInstallations: c28d4bcbb5c6884d1a39afbc0bd7fc590e31e9b7
-  FirebaseInstanceID: c03b49743725092f7eb9d4b96ff40efadd830426
-  FirebaseMessaging: ecf9e04716b7ff1f1d92debab4d6f0e6bdb490aa
-  FirebaseRemoteConfig: ff8d3542cbd919c9d3851fd544690b8848fc0402
-  GoogleAppMeasurement: 7790ef975d1d463c8614cd949a847e612edf087a
-  GoogleDataTransport: 6ce8004a961db1b905740d7be106c61ba7e89c21
+  Firebase: 78e8dd2e39d653de6270432ad84fe8b59f7bf4e8
+  FirebaseABTesting: aaea04ea67858a4a9dce0d22ef645477dff50146
+  FirebaseAnalytics: 7f165a56dea86ddd5b8ce02af3bee982c683405c
+  FirebaseCore: 20046127eef0fcb8fa25df7fc12f7b97d4e48611
+  FirebaseCoreDiagnostics: 872cdb9b749b23346dddd5c1014d1babd2257de3
+  FirebaseCrashlytics: c722e4ca283272eb90eb5bc245fdc6588e2f22c2
+  FirebaseInstallations: 3de38553e86171b5f81d83cdeef63473d37bfdb0
+  FirebaseInstanceID: 61e8d10a4192a582c6239378169d10e504ca8d91
+  FirebaseMessaging: 076054895c9260f82c7304cc7709dbf19b8f3e4a
+  FirebaseRemoteConfig: 04cd72851dad51780aa66f05b01a7dd0b85cdbf5
+  GoogleAppMeasurement: 89e1a64593f968713b0506ba1b53b38a154bf9a5
+  GoogleDataTransport: e4085e6762f36a6141738f46b0153473ce57fb18
   GoogleSignIn: 7137d297ddc022a7e0aa4619c86d72c909fa7213
-  GoogleUtilities: ffb2f4159f2c897c6e8992bd7fbcdef8a300589c
+  GoogleUtilities: f734da554aade8cc7928a31c2f3311897933a1bd
   GTMAppAuth: 4deac854479704f348309e7b66189e604cf5e01e
   GTMSessionFetcher: 6f5c8abbab8a9bce4bb3f057e317728ec6182b10
   HexColors: 6ad3947c3447a055a3aa8efa859def096351fe5f
@@ -401,6 +401,6 @@ SPEC CHECKSUMS:
   VK-ios-sdk: 62a10b6571fbcda0657f455fedce7fedf55b4cd0
   YandexMobileMetrica: 7ba67267e1ef841f77d5db17a5091b8e9eba911f
 
-PODFILE CHECKSUM: 6c72dd72ea5f4d29007713912bb914eeb01eafde
+PODFILE CHECKSUM: 7aea51f171592875998610724718d62f448e795c
 
 COCOAPODS: 1.10.0

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -183,7 +183,7 @@ PODS:
   - SVGKit (2.1.0):
     - CocoaLumberjack (~> 3.0)
   - SVProgressHUD (2.2.5)
-  - SwiftDate (6.2.0)
+  - SwiftDate (6.3.0)
   - SwiftLint (0.41.0)
   - SwiftyGif (5.3.0)
   - SwiftyJSON (5.0.0)
@@ -241,7 +241,7 @@ DEPENDENCIES:
   - STRegex (= 2.1.1)
   - SVGKit (from `https://github.com/SVGKit/SVGKit.git`, branch `2.x`)
   - SVProgressHUD (= 2.2.5)
-  - SwiftDate (= 6.2.0)
+  - SwiftDate (= 6.3.0)
   - SwiftLint (= 0.41.0)
   - SwiftyJSON (= 5.0.0)
   - Tabman (= 2.8.0)
@@ -389,7 +389,7 @@ SPEC CHECKSUMS:
   STRegex: d49e88d0fe58538d3175fdd989bc1243b9be2a07
   SVGKit: 8a2fc74258bdb2abb54d3b65f3dd68b0277a9c4d
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
-  SwiftDate: d117c3eb6beed72e47d3f4d1e3bc63fa1e66d7c3
+  SwiftDate: ec6c0e173627a3ae6dd1671888a7f175956ebb94
   SwiftLint: c585ebd615d9520d7fbdbe151f527977b0534f1e
   SwiftyGif: e466e86c660d343357ab944a819a101c4127cb40
   SwiftyJSON: 36413e04c44ee145039d332b4f4e2d3e8d6c4db7
@@ -401,6 +401,6 @@ SPEC CHECKSUMS:
   VK-ios-sdk: 62a10b6571fbcda0657f455fedce7fedf55b4cd0
   YandexMobileMetrica: 7ba67267e1ef841f77d5db17a5091b8e9eba911f
 
-PODFILE CHECKSUM: 3dfac899b2fe20652c36f162f48e8e3bed3bb00e
+PODFILE CHECKSUM: 0193ddc5e33023d04d4547f978e0fbbd072e5334
 
 COCOAPODS: 1.10.0

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -24,16 +24,16 @@ PODS:
   - DeviceKit (4.2.1)
   - DownloadButton (0.1.0)
   - EasyTipView (2.0.4)
-  - FBSDKCoreKit (8.1.0):
-    - FBSDKCoreKit/Basics (= 8.1.0)
-    - FBSDKCoreKit/Core (= 8.1.0)
-  - FBSDKCoreKit/Basics (8.1.0)
-  - FBSDKCoreKit/Core (8.1.0):
+  - FBSDKCoreKit (8.2.0):
+    - FBSDKCoreKit/Basics (= 8.2.0)
+    - FBSDKCoreKit/Core (= 8.2.0)
+  - FBSDKCoreKit/Basics (8.2.0)
+  - FBSDKCoreKit/Core (8.2.0):
     - FBSDKCoreKit/Basics
-  - FBSDKLoginKit (8.1.0):
-    - FBSDKLoginKit/Login (= 8.1.0)
-  - FBSDKLoginKit/Login (8.1.0):
-    - FBSDKCoreKit (~> 8.1.0)
+  - FBSDKLoginKit (8.2.0):
+    - FBSDKLoginKit/Login (= 8.2.0)
+  - FBSDKLoginKit/Login (8.2.0):
+    - FBSDKCoreKit (~> 8.2.0)
   - Firebase/Analytics (7.1.0):
     - Firebase/Core
   - Firebase/Core (7.1.0):
@@ -215,8 +215,8 @@ DEPENDENCIES:
   - DeviceKit (= 4.2.1)
   - DownloadButton (= 0.1.0)
   - EasyTipView (= 2.0.4)
-  - FBSDKCoreKit (= 8.1.0)
-  - FBSDKLoginKit (= 8.1.0)
+  - FBSDKCoreKit (= 8.2.0)
+  - FBSDKLoginKit (= 8.2.0)
   - Firebase/Analytics (= 7.1.0)
   - Firebase/Core (= 7.1.0)
   - Firebase/Crashlytics (= 7.1.0)
@@ -348,8 +348,8 @@ SPEC CHECKSUMS:
   DeviceKit: cadb5ff25d45fe186778bf2d0fd2ea4750542189
   DownloadButton: 49a21a89e0d7d1b42d9134f79aaa40e727cd57c3
   EasyTipView: 4f8beae0a82db2ca4a9b5fd658785fc5f61d296b
-  FBSDKCoreKit: b3ca27e124dae67122d3bb47c8f96800b39986a6
-  FBSDKLoginKit: a3a92ba9380759cd0c1aa8319465fb5f2857c602
+  FBSDKCoreKit: 4afd6ff53d8133a433dbcda44451c9498f8c6ce4
+  FBSDKLoginKit: 7181765f2524d7ebf82d9629066c8e6caafc99d0
   Firebase: 78e8dd2e39d653de6270432ad84fe8b59f7bf4e8
   FirebaseABTesting: aaea04ea67858a4a9dce0d22ef645477dff50146
   FirebaseAnalytics: 7f165a56dea86ddd5b8ce02af3bee982c683405c
@@ -401,6 +401,6 @@ SPEC CHECKSUMS:
   VK-ios-sdk: 62a10b6571fbcda0657f455fedce7fedf55b4cd0
   YandexMobileMetrica: 7ba67267e1ef841f77d5db17a5091b8e9eba911f
 
-PODFILE CHECKSUM: 2f3b041e40afd5f2c142b4bc382fe66ee3066914
+PODFILE CHECKSUM: 3dfac899b2fe20652c36f162f48e8e3bed3bb00e
 
 COCOAPODS: 1.10.0

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -184,7 +184,7 @@ PODS:
     - CocoaLumberjack (~> 3.0)
   - SVProgressHUD (2.2.5)
   - SwiftDate (6.2.0)
-  - SwiftLint (0.40.3)
+  - SwiftLint (0.41.0)
   - SwiftyGif (5.3.0)
   - SwiftyJSON (5.0.0)
   - Tabman (2.8.0):
@@ -242,7 +242,7 @@ DEPENDENCIES:
   - SVGKit (from `https://github.com/SVGKit/SVGKit.git`, branch `2.x`)
   - SVProgressHUD (= 2.2.5)
   - SwiftDate (= 6.2.0)
-  - SwiftLint (= 0.40.3)
+  - SwiftLint (= 0.41.0)
   - SwiftyJSON (= 5.0.0)
   - Tabman (= 2.8.0)
   - TSMessages (from `https://github.com/KrauseFx/TSMessages.git`)
@@ -390,7 +390,7 @@ SPEC CHECKSUMS:
   SVGKit: 8a2fc74258bdb2abb54d3b65f3dd68b0277a9c4d
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
   SwiftDate: d117c3eb6beed72e47d3f4d1e3bc63fa1e66d7c3
-  SwiftLint: dfd554ff0dff17288ee574814ccdd5cea85d76f7
+  SwiftLint: c585ebd615d9520d7fbdbe151f527977b0534f1e
   SwiftyGif: e466e86c660d343357ab944a819a101c4127cb40
   SwiftyJSON: 36413e04c44ee145039d332b4f4e2d3e8d6c4db7
   Tabman: f62ad94ee54a7d96e3fbab34f677d9ea4d38ece6
@@ -401,6 +401,6 @@ SPEC CHECKSUMS:
   VK-ios-sdk: 62a10b6571fbcda0657f455fedce7fedf55b4cd0
   YandexMobileMetrica: 7ba67267e1ef841f77d5db17a5091b8e9eba911f
 
-PODFILE CHECKSUM: e637556d9dafa076b36854952a61e3d7ac371147
+PODFILE CHECKSUM: 6c72dd72ea5f4d29007713912bb914eeb01eafde
 
 COCOAPODS: 1.10.0

--- a/Stepic/Sources/Modules/CourseInfoSubmodules/CourseInfoTabInfo/Views/Blocks/CourseInfoTabInfoHeaderBlockView.swift
+++ b/Stepic/Sources/Modules/CourseInfoSubmodules/CourseInfoTabInfo/Views/Blocks/CourseInfoTabInfoHeaderBlockView.swift
@@ -30,7 +30,7 @@ final class CourseInfoTabInfoHeaderBlockView: UIView {
         label.font = self.appearance.titleLabelFont
         label.textColor = self.appearance.titleLabelTextColor
         label.numberOfLines = self.appearance.titleLabelNumberOfLines
-        label.onClick = { [weak self] label, detection in
+        label.onClick = { [weak self] _, detection in
             guard let strongSelf = self else {
                 return
             }

--- a/Stepic/Sources/Modules/Settings/SettingsViewController.swift
+++ b/Stepic/Sources/Modules/Settings/SettingsViewController.swift
@@ -434,7 +434,10 @@ extension SettingsViewController: SettingsViewControllerProtocol {
 
         let learningSectionCellsViewModels = settingsViewModel.isApplicationThemeSettingAvailable
             ? [autoplayCellViewModel, adaptiveModeCellViewModel]
-            : [stepTextSizeCellViewModel, codeEditorSettingsCellViewModel, autoplayCellViewModel, adaptiveModeCellViewModel]
+            : [
+                stepTextSizeCellViewModel, codeEditorSettingsCellViewModel, autoplayCellViewModel,
+                adaptiveModeCellViewModel
+            ]
 
         var sectionsViewModels: [SettingsTableSectionViewModel] = [
             .init(

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,4 +1,4 @@
-fastlane_version "2.166.0"
+fastlane_version "2.167.0"
 
 default_platform :ios
 


### PR DESCRIPTION
Bumps:
- [YandexMobileMetrica](https://github.com/yandexmobile/metrica-sdk-ios) from 3.11.1 to 3.12.0
- [SwiftLint](https://github.com/realm/SwiftLint) from 0.40.3 to 0.41.0
- [Firebase](https://github.com/firebase/firebase-ios-sdk) from 7.0.0 to 7.1.0
- [SDWebImage](https://github.com/SDWebImage/SDWebImage) from from 5.9.4 to 5.9.5
- [fastlane](https://github.com/fastlane/fastlane) from 2.166.0 to 2.167.0
- [Facebook SDK](https://github.com/facebook/facebook-ios-sdk) from 8.1.0 to 8.2.0
- [SwiftDate](https://github.com/malcommac/SwiftDate) from 6.2.0 to 6.3.0
- [Agrume](https://github.com/JanGorman/Agrume) from 5.6.10 to 5.6.11
- [Nuke](https://github.com/kean/Nuke) from 9.1.2 to 9.1.3