### PR TITLE
Fix HTML tags are visible in course widget summary label

### DIFF
--- a/Stepic/Sources/Modules/CourseList/Views/Widget/CourseWidgetView.swift
+++ b/Stepic/Sources/Modules/CourseList/Views/Widget/CourseWidgetView.swift
@@ -94,7 +94,7 @@ final class CourseWidgetView: UIView, CourseWidgetViewProtocol {
         self.coverView.coverImageURL = viewModel.coverImageURL
         self.coverView.shouldShowAdaptiveMark = viewModel.isAdaptive
 
-        self.summaryLabel.text = viewModel.summary
+        self.summaryLabel.setTextWithHTMLString(viewModel.summary)
         self.summaryLabel.isHidden = viewModel.isEnrolled
         self.separatorView.isHidden = !viewModel.isEnrolled
         self.continueLearningButton.isHidden = !viewModel.isEnrolled


### PR DESCRIPTION
**YouTrack task**: [#APPS-3108](https://vyahhi.myjetbrains.com/youtrack/issue/APPS-3108)

**Description**:
- Fixes visible HTML tags in the summary label of `CourseWidgetView`.