### PR TITLE
Update dependencies 1.153

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 ruby "2.6.5"
 
-gem "fastlane", "2.168.0"
+gem "fastlane", "2.169.0"
 gem "cocoapods", "1.10.0"
 
 plugins_path = File.join(File.dirname(__FILE__), 'fastlane', 'Pluginfile')

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,7 +14,7 @@ GEM
       json (>= 1.5.1)
     atomos (0.1.3)
     aws-eventstream (1.1.0)
-    aws-partitions (1.399.0)
+    aws-partitions (1.402.0)
     aws-sdk-core (3.109.3)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.239.0)
@@ -23,7 +23,7 @@ GEM
     aws-sdk-kms (1.39.0)
       aws-sdk-core (~> 3, >= 3.109.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-s3 (1.85.0)
+    aws-sdk-s3 (1.86.0)
       aws-sdk-core (~> 3, >= 3.109.0)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.1)
@@ -94,7 +94,7 @@ GEM
     faraday_middleware (1.0.0)
       faraday (~> 1.0)
     fastimage (2.2.0)
-    fastlane (2.168.0)
+    fastlane (2.169.0)
       CFPropertyList (>= 2.3, < 4.0.0)
       addressable (>= 2.3, < 3.0.0)
       aws-sdk-s3 (~> 1.0)
@@ -240,7 +240,7 @@ PLATFORMS
 
 DEPENDENCIES
   cocoapods (= 1.10.0)
-  fastlane (= 2.168.0)
+  fastlane (= 2.169.0)
   fastlane-plugin-firebase_app_distribution
 
 RUBY VERSION

--- a/Podfile
+++ b/Podfile
@@ -65,7 +65,7 @@ def all_pods
     pod 'Charts', '3.6.0'
     pod 'EasyTipView', '2.0.4'
     pod 'ActionSheetPicker-3.0', '2.7.1'
-    pod 'Nuke', '9.1.3'
+    pod 'Nuke', '9.2.0'
     pod 'STRegex', '2.1.1'
     pod 'Tabman', '2.8.0'
     pod 'SwiftDate', '6.3.1'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -158,7 +158,7 @@ PODS:
   - nanopb/decode (2.30906.0)
   - nanopb/encode (2.30906.0)
   - Nimble (9.0.0)
-  - Nuke (9.1.3)
+  - Nuke (9.2.0)
   - Pageboy (3.5.1)
   - PanModal (1.2.7)
   - pop (1.0.12)
@@ -230,7 +230,7 @@ DEPENDENCIES:
   - lottie-ios (= 2.5.3)
   - Mockingjay (= 3.0.0-alpha.1)
   - Nimble (= 9.0.0)
-  - Nuke (= 9.1.3)
+  - Nuke (= 9.2.0)
   - PanModal (= 1.2.7)
   - Presentr (= 1.9)
   - PromiseKit (= 6.13.1)
@@ -375,7 +375,7 @@ SPEC CHECKSUMS:
   Mockingjay: 0f7c5aa49c7f1b95621cee3c79b557141f5a225c
   nanopb: 1bf24dd71191072e120b83dd02d08f3da0d65e53
   Nimble: 3b4ec3fd40f1dc178058e0981107721c615643d8
-  Nuke: ee78dff29ad68cfd70a292a7960952f72cc6af6a
+  Nuke: 1394e48b0940e01dd20f52ac56b121ab154e370d
   Pageboy: 288353d4cc848c24deec2f7542f325089247c136
   PanModal: 3e16ead1a907fb06f4df3f13492fd00149fa4974
   pop: d582054913807fd11fd50bfe6a539d91c7e1a55a
@@ -401,6 +401,6 @@ SPEC CHECKSUMS:
   VK-ios-sdk: 62a10b6571fbcda0657f455fedce7fedf55b4cd0
   YandexMobileMetrica: 7ba67267e1ef841f77d5db17a5091b8e9eba911f
 
-PODFILE CHECKSUM: 207240369f1278e6142c2dc8a17e8d0f8a8249f7
+PODFILE CHECKSUM: e994cefd1b4491d7f3be76407f6a76b19af9ccca
 
 COCOAPODS: 1.10.0

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,4 +1,4 @@
-fastlane_version "2.168.0"
+fastlane_version "2.169.0"
 
 default_platform :ios
 


### PR DESCRIPTION
Bumps:
- [Nuke](https://github.com/kean/Nuke) from 9.1.3 to 9.2.0
- [fastlane](https://github.com/fastlane/fastlane) from 2.168.0 to 2.169.0