### PR TITLE
Fix table quiz pan modal content size not fitting

### DIFF
--- a/Stepic/Sources/Modules/Quizzes/TableQuiz/TableQuizSelectColumns/TableQuizSelectColumnsViewController.swift
+++ b/Stepic/Sources/Modules/Quizzes/TableQuiz/TableQuizSelectColumns/TableQuizSelectColumnsViewController.swift
@@ -57,7 +57,7 @@ final class TableQuizSelectColumnsViewController: UIViewController {
 
         coordinator.animate(
             alongsideTransition: { _ in
-                self.additionalSafeAreaInsets = UIApplication.shared.delegate?.window??.safeAreaInsets ?? .zero
+                self.updateAdditionalSafeAreaInsets()
             },
             completion: nil
         )
@@ -69,6 +69,13 @@ final class TableQuizSelectColumnsViewController: UIViewController {
             : NSLocalizedString("SingleChoiceTableQuizPrompt", comment: "")
         self.tableQuizSelectColumnsView?.title = self.row.text
         self.tableQuizSelectColumnsView?.set(columns: self.columns, selectedColumnsIDs: self.selectedColumnsIDs)
+
+        self.updateAdditionalSafeAreaInsets()
+        self.panModalSetNeedsLayoutUpdate()
+    }
+
+    private func updateAdditionalSafeAreaInsets() {
+        self.additionalSafeAreaInsets = UIApplication.shared.delegate?.window??.safeAreaInsets ?? .zero
     }
 }
 
@@ -103,7 +110,7 @@ extension TableQuizSelectColumnsViewController: TableQuizSelectColumnsViewDelega
 }
 
 extension TableQuizSelectColumnsViewController: PanModalPresentable {
-    var panScrollable: UIScrollView? { nil }
+    var panScrollable: UIScrollView? { self.tableQuizSelectColumnsView?.panScrollable }
 
     var shortFormHeight: PanModalHeight {
         self.isShortFormEnabled

--- a/Stepic/Sources/Modules/Quizzes/TableQuiz/TableQuizSelectColumns/Views/TableQuizSelectColumnsColumnView.swift
+++ b/Stepic/Sources/Modules/Quizzes/TableQuiz/TableQuizSelectColumns/Views/TableQuizSelectColumnsColumnView.swift
@@ -19,7 +19,7 @@ extension TableQuizSelectColumnsColumnView {
 
         let contentViewMinHeight: CGFloat = 44
 
-        let backgroundColor = UIColor.stepikBackground
+        let backgroundColor = UIColor.clear
     }
 }
 

--- a/Stepic/Sources/Modules/Quizzes/TableQuiz/TableQuizSelectColumns/Views/TableQuizSelectColumnsHeaderView.swift
+++ b/Stepic/Sources/Modules/Quizzes/TableQuiz/TableQuizSelectColumns/Views/TableQuizSelectColumnsHeaderView.swift
@@ -16,7 +16,7 @@ extension TableQuizSelectColumnsHeaderView {
         let contentStackViewSpacing: CGFloat = 16
         let contentStackViewInsets = UIEdgeInsets(top: 16, left: 16, bottom: 16, right: 16)
 
-        let backgroundColor = UIColor.stepikBackground
+        let backgroundColor = UIColor.clear
     }
 }
 

--- a/Stepic/Sources/Modules/Quizzes/TableQuiz/TableQuizSelectColumns/Views/TableQuizSelectColumnsView.swift
+++ b/Stepic/Sources/Modules/Quizzes/TableQuiz/TableQuizSelectColumns/Views/TableQuizSelectColumnsView.swift
@@ -39,10 +39,9 @@ final class TableQuizSelectColumnsView: UIView {
         return stackView
     }()
 
-    private lazy var contentStackView: UIStackView = {
-        let stackView = UIStackView()
-        stackView.axis = .vertical
-        stackView.distribution = .fillProportionally
+    private lazy var scrollableContentStackView: ScrollableStackView = {
+        let stackView = ScrollableStackView(orientation: .vertical)
+        stackView.contentInsetAdjustmentBehavior = .never
         return stackView
     }()
 
@@ -61,12 +60,6 @@ final class TableQuizSelectColumnsView: UIView {
         }
     }
 
-    override var intrinsicContentSize: CGSize {
-        let contentStackViewIntrinsicContentSize = self.contentStackView
-            .systemLayoutSizeFitting(UIView.layoutFittingCompressedSize)
-        return CGSize(width: UIView.noIntrinsicMetric, height: contentStackViewIntrinsicContentSize.height)
-    }
-
     init(
         frame: CGRect = .zero,
         appearance: Appearance = Appearance()
@@ -82,11 +75,6 @@ final class TableQuizSelectColumnsView: UIView {
     @available(*, unavailable)
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
-    }
-
-    override func layoutSubviews() {
-        super.layoutSubviews()
-        self.invalidateIntrinsicContentSize()
     }
 
     func set(columns: [TableQuiz.Column], selectedColumnsIDs: Set<UniqueIdentifierType>) {
@@ -143,17 +131,20 @@ extension TableQuizSelectColumnsView: ProgrammaticallyInitializableViewProtocol 
     }
 
     func addSubviews() {
-        self.addSubview(self.contentStackView)
+        self.addSubview(self.scrollableContentStackView)
 
-        self.contentStackView.addArrangedSubview(self.headerView)
-        self.contentStackView.addArrangedSubview(self.columnsStackView)
+        self.scrollableContentStackView.addArrangedView(self.headerView)
+        self.scrollableContentStackView.addArrangedView(self.columnsStackView)
     }
 
     func makeConstraints() {
-        self.contentStackView.snp.makeConstraints { make in
-            make.top.equalToSuperview()
+        self.scrollableContentStackView.snp.makeConstraints { make in
+            make.top.bottom.equalToSuperview()
             make.leading.trailing.equalTo(self.safeAreaLayoutGuide)
-            make.bottom.lessThanOrEqualToSuperview()
         }
     }
+}
+
+extension TableQuizSelectColumnsView: PanModalScrollable {
+    var panScrollable: UIScrollView? { self.scrollableContentStackView.panScrollable }
 }

--- a/Stepic/Sources/Modules/Quizzes/TableQuiz/TableQuizSelectColumns/Views/TableQuizSelectColumnsView.swift
+++ b/Stepic/Sources/Modules/Quizzes/TableQuiz/TableQuizSelectColumns/Views/TableQuizSelectColumnsView.swift
@@ -39,11 +39,7 @@ final class TableQuizSelectColumnsView: UIView {
         return stackView
     }()
 
-    private lazy var scrollableContentStackView: ScrollableStackView = {
-        let stackView = ScrollableStackView(orientation: .vertical)
-        stackView.contentInsetAdjustmentBehavior = .never
-        return stackView
-    }()
+    private lazy var scrollableContentStackView = ScrollableStackView(orientation: .vertical)
 
     private var columns = [TableQuiz.Column]()
     private var selectedColumnsIDs = Set<UniqueIdentifierType>()

--- a/Stepic/Sources/Views/ScrollableStackView.swift
+++ b/Stepic/Sources/Views/ScrollableStackView.swift
@@ -302,3 +302,13 @@ extension ScrollableStackView: ProgrammaticallyInitializableViewProtocol {
         }
     }
 }
+
+// MARK: - PanModalScrollable -
+
+protocol PanModalScrollable: AnyObject {
+    var panScrollable: UIScrollView? { get }
+}
+
+extension ScrollableStackView: PanModalScrollable {
+    var panScrollable: UIScrollView? { self.scrollView }
+}


### PR DESCRIPTION
**YouTrack task**: [#APPS-3110](https://vyahhi.myjetbrains.com/youtrack/issue/APPS-3110)

**Description**:
- Uses `ScrollableStackView` instead of plain `StackView` as a content view.