### PR TITLE
Fix local notifications routing

### DIFF
--- a/Stepic/Legacy/Services/Notifications/NotificationsService.swift
+++ b/Stepic/Legacy/Services/Notifications/NotificationsService.swift
@@ -113,6 +113,7 @@ extension NotificationsService {
         self.reportReceivedNotificationWithType(self.extractNotificationType(from: userInfo))
 
         if #available(iOS 10.0, *) {
+            self.routeLocalNotification(with: userInfo)
         } else if self.isInForeground {
             guard let title = userInfo?[LocalNotificationsService.PayloadKey.title.rawValue] as? String,
                   let body = userInfo?[LocalNotificationsService.PayloadKey.body.rawValue] as? String else {


### PR DESCRIPTION
**YouTrack task**: [#APPS-3028](https://vyahhi.myjetbrains.com/youtrack/issue/APPS-3028)

**Description**:
- Fixes routing for local notifications on iOS 10 and above.