### PR TITLE
RemoteConfig value for search-results query parameters

### DIFF
--- a/Stepic/Legacy/Model/Network/Endpoints/SearchResultsAPI.swift
+++ b/Stepic/Legacy/Model/Network/Endpoints/SearchResultsAPI.swift
@@ -21,6 +21,7 @@ final class SearchResultsAPI: APIEndpoint {
         type: String?,
         language: ContentLanguage,
         page: Int?,
+        searchQueryParams: Parameters,
         filterQuery: CourseListFilterQuery? = nil,
         headers: HTTPHeaders = AuthInfo.shared.initialHTTPHeaders,
         success: @escaping ([SearchResult], Meta) -> Void,
@@ -29,12 +30,7 @@ final class SearchResultsAPI: APIEndpoint {
         var params: Parameters = [
             "query": query.lowercased(),
             "access_token": AuthInfo.shared.token?.accessToken ?? "",
-            "language": language.searchCoursesParameter ?? "",
-            "is_popular": "true",
-            "is_public": "true",
-            "readiness__gte": 0.7,
-            "has_logo": "true",
-            "is_idea_compatible": "false"
+            "language": language.searchCoursesParameter ?? ""
         ]
 
         if let page = page {
@@ -43,6 +39,8 @@ final class SearchResultsAPI: APIEndpoint {
         if let type = type {
             params["type"] = type
         }
+
+        params.merge(searchQueryParams) { (_, new) in new }
 
         if let filterQuery = filterQuery {
             filterQuery.dictValue.forEach { key, value in
@@ -78,6 +76,7 @@ final class SearchResultsAPI: APIEndpoint {
         query: String,
         language: ContentLanguage,
         page: Int,
+        searchQueryParams: Parameters = RemoteConfig.shared.searchResultsQueryParams,
         filterQuery: CourseListFilterQuery? = nil,
         headers: HTTPHeaders = AuthInfo.shared.initialHTTPHeaders
     ) -> Promise<([SearchResult], Meta)> {
@@ -87,6 +86,7 @@ final class SearchResultsAPI: APIEndpoint {
                 type: "course",
                 language: language,
                 page: page,
+                searchQueryParams: searchQueryParams,
                 filterQuery: filterQuery,
                 headers: headers,
                 success: { searchResults, meta in

--- a/Stepic/Legacy/Model/RemoteConfig/RemoteConfig.swift
+++ b/Stepic/Legacy/Model/RemoteConfig/RemoteConfig.swift
@@ -27,7 +27,8 @@ final class RemoteConfig {
         Key.newLessonAvailable.rawValue: NSNumber(value: true),
         Key.darkModeAvailable.rawValue: NSNumber(value: true),
         Key.arQuickLookAvailable.rawValue: NSNumber(value: false),
-        Key.isDisabledStepsSupported.rawValue: NSNumber(value: false)
+        Key.isDisabledStepsSupported.rawValue: NSNumber(value: false),
+        Key.searchResultsQueryParams.rawValue: NSDictionary(dictionary: ["is_popular": "true", "is_public": "true"])
     ]
 
     var showStreaksNotificationTrigger: ShowStreaksNotificationTrigger {
@@ -105,20 +106,30 @@ final class RemoteConfig {
             .boolValue
     }
 
+    var searchResultsQueryParams: JSONDictionary {
+        guard let configValue = FirebaseRemoteConfig.RemoteConfig.remoteConfig().configValue(
+            forKey: Key.searchResultsQueryParams.rawValue
+        ).jsonValue, let params = configValue as? JSONDictionary else {
+            return self.appDefaults[Key.searchResultsQueryParams.rawValue] as? JSONDictionary ?? [:]
+        }
+
+        return params
+    }
+
     init() {
-        self.loadDefaultValues()
-        self.fetchCloudValues()
+        self.setConfigDefaults()
+        self.fetchRemoteConfigData()
     }
 
     func setup() {}
 
     // MARK: Private API
 
-    private func loadDefaultValues() {
+    private func setConfigDefaults() {
         FirebaseRemoteConfig.RemoteConfig.remoteConfig().setDefaults(self.appDefaults)
     }
 
-    private func fetchCloudValues() {
+    private func fetchRemoteConfigData() {
         #if DEBUG
             self.activateDebugMode()
         #endif
@@ -165,5 +176,6 @@ final class RemoteConfig {
         case darkModeAvailable = "is_dark_mode_available_ios"
         case arQuickLookAvailable = "is_ar_quick_look_available_ios"
         case isDisabledStepsSupported = "is_disabled_steps_supported"
+        case searchResultsQueryParams = "search_query_params_ios"
     }
 }


### PR DESCRIPTION
**YouTrack task**: [#APPS-3155](https://vyahhi.myjetbrains.com/youtrack/issue/APPS-3155)

**Description**:
- Adds config value `RemoteConfig.searchResultsQueryParams`.
- Updates SearchResultsAPI query params.