### PR TITLE
Update dependencies 1.159

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -35,7 +35,7 @@ def all_pods
     pod 'Firebase/Crashlytics', '7.4.0'
     pod 'Firebase/RemoteConfig', '7.4.0'
 
-    pod 'YandexMobileMetrica/Dynamic', '3.14.0'
+    pod 'YandexMobileMetrica/Dynamic', '3.14.1'
     pod 'Amplitude-iOS', '4.9.3'
     pod 'Branch', '0.31.0'
         

--- a/Podfile
+++ b/Podfile
@@ -67,7 +67,7 @@ def all_pods
     pod 'ActionSheetPicker-3.0', '2.7.1'
     pod 'Nuke', '9.2.4'
     pod 'STRegex', '2.1.1'
-    pod 'Tabman', '2.8.0'
+    pod 'Tabman', '2.10.0'
     pod 'SwiftDate', '6.3.1'
 end
 

--- a/Podfile
+++ b/Podfile
@@ -10,7 +10,7 @@ def shared_pods
     pod 'Alamofire', '5.4.1'
     pod 'Atributika', '4.9.10'
     pod 'SwiftyJSON', '5.0.0'
-    pod 'SDWebImage', '5.10.2'
+    pod 'SDWebImage', '5.10.3'
     pod 'SVGKit', :git => 'https://github.com/SVGKit/SVGKit.git', :branch => '2.x'
     pod 'DeviceKit', '4.2.1'
     pod 'PromiseKit', '6.13.1'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -175,9 +175,9 @@ PODS:
   - PromisesObjC (1.2.12)
   - Quick (3.0.0)
   - Reveal-SDK (26)
-  - SDWebImage (5.10.2):
-    - SDWebImage/Core (= 5.10.2)
-  - SDWebImage/Core (5.10.2)
+  - SDWebImage (5.10.3):
+    - SDWebImage/Core (= 5.10.3)
+  - SDWebImage/Core (5.10.3)
   - SnapKit (5.0.1)
   - STRegex (2.1.1)
   - SVGKit (2.1.0):
@@ -236,7 +236,7 @@ DEPENDENCIES:
   - PromiseKit (= 6.13.1)
   - Quick (= 3.0.0)
   - Reveal-SDK
-  - SDWebImage (= 5.10.2)
+  - SDWebImage (= 5.10.3)
   - SnapKit (= 5.0.1)
   - STRegex (= 2.1.1)
   - SVGKit (from `https://github.com/SVGKit/SVGKit.git`, branch `2.x`)
@@ -384,7 +384,7 @@ SPEC CHECKSUMS:
   PromisesObjC: 3113f7f76903778cf4a0586bd1ab89329a0b7b97
   Quick: 6d9559f40647bc4d510103842ef2fdd882d753e2
   Reveal-SDK: 5f94f14aff3d5f2a49f246edcd266fa4472679e9
-  SDWebImage: b969dcfc02c40a5da71eac0b03b8f1a0c794a86f
+  SDWebImage: e378178472b735e84b007bfb55514c97948a0598
   SnapKit: 97b92857e3df3a0c71833cce143274bf6ef8e5eb
   STRegex: d49e88d0fe58538d3175fdd989bc1243b9be2a07
   SVGKit: 8a2fc74258bdb2abb54d3b65f3dd68b0277a9c4d
@@ -401,6 +401,6 @@ SPEC CHECKSUMS:
   VK-ios-sdk: 62a10b6571fbcda0657f455fedce7fedf55b4cd0
   YandexMobileMetrica: a2dd4fd2f01ae7ae6850d786c443cb41fbbbea78
 
-PODFILE CHECKSUM: fe02eb79da9660405e874e232d48a4e97719eedf
+PODFILE CHECKSUM: 0c101f8e79f2c65784eef355e471764fc04bf0db
 
 COCOAPODS: 1.10.1

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -159,7 +159,7 @@ PODS:
   - nanopb/encode (2.30907.0)
   - Nimble (9.0.0)
   - Nuke (9.2.4)
-  - Pageboy (3.5.1)
+  - Pageboy (3.6.2)
   - PanModal (1.2.7)
   - pop (1.0.12)
   - Presentr (1.9)
@@ -187,8 +187,8 @@ PODS:
   - SwiftLint (0.42.0)
   - SwiftyGif (5.3.0)
   - SwiftyJSON (5.0.0)
-  - Tabman (2.8.0):
-    - Pageboy (~> 3.5.0)
+  - Tabman (2.10.0):
+    - Pageboy (~> 3.6.0)
   - TSMessages (0.9.13):
     - HexColors (~> 2.3.0)
   - TTTAttributedLabel (2.0.0)
@@ -244,7 +244,7 @@ DEPENDENCIES:
   - SwiftDate (= 6.3.1)
   - SwiftLint (= 0.42.0)
   - SwiftyJSON (= 5.0.0)
-  - Tabman (= 2.8.0)
+  - Tabman (= 2.10.0)
   - TSMessages (from `https://github.com/KrauseFx/TSMessages.git`)
   - TTTAttributedLabel (= 2.0.0)
   - TUSafariActivity (= 1.0.4)
@@ -376,7 +376,7 @@ SPEC CHECKSUMS:
   nanopb: 59221d7f958fb711001e6a449489542d92ae113e
   Nimble: 3b4ec3fd40f1dc178058e0981107721c615643d8
   Nuke: 44439f7a92e665a4f927ecd73cb51f91d93b0e0c
-  Pageboy: 288353d4cc848c24deec2f7542f325089247c136
+  Pageboy: cf121b9dd48c63f3f281b2a9ec93d02e0f23879b
   PanModal: 3e16ead1a907fb06f4df3f13492fd00149fa4974
   pop: d582054913807fd11fd50bfe6a539d91c7e1a55a
   Presentr: 7078d7eb5d1661ebeaae60c9e42a1e534de1b993
@@ -393,7 +393,7 @@ SPEC CHECKSUMS:
   SwiftLint: 4fa9579c63416865179bc416f0a92d55f009600d
   SwiftyGif: e466e86c660d343357ab944a819a101c4127cb40
   SwiftyJSON: 36413e04c44ee145039d332b4f4e2d3e8d6c4db7
-  Tabman: f62ad94ee54a7d96e3fbab34f677d9ea4d38ece6
+  Tabman: d8d6ab0b483c7db375a71ac227d3ef791b56a049
   TSMessages: eb3cf27b6900684a21bad4fe9ea426e287b8c839
   TTTAttributedLabel: 8cffe8e127e4e82ff3af1e5386d4cd0ad000b656
   TUSafariActivity: afc55a00965377939107ce4fdc7f951f62454546
@@ -401,6 +401,6 @@ SPEC CHECKSUMS:
   VK-ios-sdk: 62a10b6571fbcda0657f455fedce7fedf55b4cd0
   YandexMobileMetrica: a2dd4fd2f01ae7ae6850d786c443cb41fbbbea78
 
-PODFILE CHECKSUM: abda023051e58ed2d33ec9c3cde188a60bd0f9ba
+PODFILE CHECKSUM: fe02eb79da9660405e874e232d48a4e97719eedf
 
 COCOAPODS: 1.10.1

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -195,11 +195,11 @@ PODS:
   - TUSafariActivity (1.0.4)
   - URITemplate (3.0.0)
   - VK-ios-sdk (1.5.1)
-  - YandexMobileMetrica/Dynamic (3.14.0):
-    - YandexMobileMetrica/Dynamic/Core (= 3.14.0)
-    - YandexMobileMetrica/Dynamic/Crashes (= 3.14.0)
-  - YandexMobileMetrica/Dynamic/Core (3.14.0)
-  - YandexMobileMetrica/Dynamic/Crashes (3.14.0):
+  - YandexMobileMetrica/Dynamic (3.14.1):
+    - YandexMobileMetrica/Dynamic/Core (= 3.14.1)
+    - YandexMobileMetrica/Dynamic/Crashes (= 3.14.1)
+  - YandexMobileMetrica/Dynamic/Core (3.14.1)
+  - YandexMobileMetrica/Dynamic/Crashes (3.14.1):
     - YandexMobileMetrica/Dynamic/Core
 
 DEPENDENCIES:
@@ -249,7 +249,7 @@ DEPENDENCIES:
   - TTTAttributedLabel (= 2.0.0)
   - TUSafariActivity (= 1.0.4)
   - VK-ios-sdk (= 1.5.1)
-  - YandexMobileMetrica/Dynamic (= 3.14.0)
+  - YandexMobileMetrica/Dynamic (= 3.14.1)
 
 SPEC REPOS:
   https://github.com/CocoaPods/Specs.git:
@@ -399,8 +399,8 @@ SPEC CHECKSUMS:
   TUSafariActivity: afc55a00965377939107ce4fdc7f951f62454546
   URITemplate: 58e0d47f967006c5d59888af5356c4a8ed3b197d
   VK-ios-sdk: 62a10b6571fbcda0657f455fedce7fedf55b4cd0
-  YandexMobileMetrica: a2dd4fd2f01ae7ae6850d786c443cb41fbbbea78
+  YandexMobileMetrica: 072fc59d216c8824d83d1d54bdc6e96d9cfcc59c
 
-PODFILE CHECKSUM: 0c101f8e79f2c65784eef355e471764fc04bf0db
+PODFILE CHECKSUM: b64372deed0bc946a9651b35549d6f42855d8036
 
 COCOAPODS: 1.10.1


### PR DESCRIPTION
Bumps:
- [Tabman](https://github.com/uias/Tabman) from 2.8.0 to 2.10.0
- [SDWebImage](https://github.com/SDWebImage/SDWebImage) from 5.10.2 to 5.10.3
- [YandexMobileMetrica](https://github.com/yandexmobile/metrica-sdk-ios) from 3.14.0 to 3.14.1