### PR TITLE
Fix LatexView clickable images script

### DIFF
--- a/Stepic/Legacy/Model/Constants/Scripts/Scripts.plist
+++ b/Stepic/Legacy/Model/Constants/Scripts/Scripts.plist
@@ -22,6 +22,10 @@
 	<string>&lt;script type=&quot;text/javascript&quot;&gt;
 $(document).ready(function() {
     $(&quot;img&quot;).each(function() {
+    	var parentTagName = $(this).parent().get(0).tagName;
+    	if (parentTagName.toLowerCase() == &quot;a&quot;) {
+    		return true;
+    	}
         var $this = $(this);
         var src = &quot;openimg://&quot; + $this.attr(&apos;src&apos;);
         $this.addClass(&apos;image&apos;);


### PR DESCRIPTION
**YouTrack task**: [#APPS-3164](https://vyahhi.myjetbrains.com/youtrack/issue/APPS-3164)

**Description**:
- Fixes `clickableImages` script by preventing nested <a> tags.