### PR TITLE
Update dependencies 1.165

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -41,7 +41,7 @@ def all_pods
   pod 'Firebase/RemoteConfig', '7.7.0'
 
   pod 'YandexMobileMetrica/Dynamic', '3.14.1'
-  pod 'Amplitude', '7.3.0'
+  pod 'Amplitude', '8.0.0'
   pod 'Branch', '1.39.0'
 
   pod 'BEMCheckBox', '1.4.1'

--- a/Podfile
+++ b/Podfile
@@ -42,7 +42,7 @@ def all_pods
 
   pod 'YandexMobileMetrica/Dynamic', '3.14.1'
   pod 'Amplitude', '7.3.0'
-  pod 'Branch', '1.38.0'
+  pod 'Branch', '1.39.0'
 
   pod 'BEMCheckBox', '1.4.1'
 

--- a/Podfile
+++ b/Podfile
@@ -34,11 +34,11 @@ def all_pods
   pod 'SnapKit', '5.0.1'
 
   # Firebase
-  pod 'Firebase/Core', '7.7.0'
-  pod 'Firebase/Messaging', '7.7.0'
-  pod 'Firebase/Analytics', '7.7.0'
-  pod 'Firebase/Crashlytics', '7.7.0'
-  pod 'Firebase/RemoteConfig', '7.7.0'
+  pod 'Firebase/Core', '7.8.0'
+  pod 'Firebase/Messaging', '7.8.0'
+  pod 'Firebase/Analytics', '7.8.0'
+  pod 'Firebase/Crashlytics', '7.8.0'
+  pod 'Firebase/RemoteConfig', '7.8.0'
 
   pod 'YandexMobileMetrica/Dynamic', '3.14.1'
   pod 'Amplitude', '8.0.0'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -11,7 +11,7 @@ PODS:
   - AppAuth/ExternalUserAgent (1.4.0)
   - Atributika (4.9.10)
   - BEMCheckBox (1.4.1)
-  - Branch (1.38.0)
+  - Branch (1.39.0)
   - Charts (3.6.0):
     - Charts/Core (= 3.6.0)
   - Charts/Core (3.6.0)
@@ -206,7 +206,7 @@ DEPENDENCIES:
   - Amplitude (= 7.3.0)
   - Atributika (= 4.9.10)
   - BEMCheckBox (= 1.4.1)
-  - Branch (= 1.38.0)
+  - Branch (= 1.39.0)
   - Charts (= 3.6.0)
   - CRToast (= 0.0.9)
   - DeviceKit (= 4.3.0)
@@ -336,7 +336,7 @@ SPEC CHECKSUMS:
   AppAuth: 31bcec809a638d7bd2f86ea8a52bd45f6e81e7c7
   Atributika: cf87f95f1d31d9cdb9af611a2b4e00672e9ae195
   BEMCheckBox: 5ba6e37ade3d3657b36caecc35c8b75c6c2b1a4e
-  Branch: 612f9d7022b19cb34a8574f0e89ca8f90c4edc88
+  Branch: 12142519e006ba9d563a280a28d6de216c82ba97
   Charts: b1e3a1f5a1c9ba5394438ca3b91bd8c9076310af
   CocoaLumberjack: e8955b9d337ac307103b0a34fd141c32f27e53c5
   CRToast: 5a78c22b921c5ed3487488af605bc403a9c92fed
@@ -395,6 +395,6 @@ SPEC CHECKSUMS:
   VK-ios-sdk: 5bcf00a2014a7323f98db9328b603d4f96635caa
   YandexMobileMetrica: 072fc59d216c8824d83d1d54bdc6e96d9cfcc59c
 
-PODFILE CHECKSUM: 911356f61e8b94acedc867b398f9825d9e888a55
+PODFILE CHECKSUM: 607ecf5a6a9f0748cdc28184b55a36a093f8ca1c
 
 COCOAPODS: 1.10.1

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -3,7 +3,7 @@ PODS:
   - Agrume (5.6.12):
     - SwiftyGif
   - Alamofire (5.4.1)
-  - Amplitude (7.3.0)
+  - Amplitude (8.0.0)
   - AppAuth (1.4.0):
     - AppAuth/Core (= 1.4.0)
     - AppAuth/ExternalUserAgent (= 1.4.0)
@@ -203,7 +203,7 @@ DEPENDENCIES:
   - ActionSheetPicker-3.0 (= 2.7.1)
   - Agrume (= 5.6.12)
   - Alamofire (= 5.4.1)
-  - Amplitude (= 7.3.0)
+  - Amplitude (= 8.0.0)
   - Atributika (= 4.9.10)
   - BEMCheckBox (= 1.4.1)
   - Branch (= 1.39.0)
@@ -332,7 +332,7 @@ SPEC CHECKSUMS:
   ActionSheetPicker-3.0: 36da254b97a09ff89679ecb8b8510bd3e5bdc773
   Agrume: d60f7ead4aad9720564148f7e9cbe0b225b1d814
   Alamofire: 2291f7d21ca607c491dd17642e5d40fdcda0e65c
-  Amplitude: 14cabfdfb5eec1ab7a54b3e4baba9ef56e824bc1
+  Amplitude: cbda1d180f47a8e45f78809d7d5f693670116776
   AppAuth: 31bcec809a638d7bd2f86ea8a52bd45f6e81e7c7
   Atributika: cf87f95f1d31d9cdb9af611a2b4e00672e9ae195
   BEMCheckBox: 5ba6e37ade3d3657b36caecc35c8b75c6c2b1a4e
@@ -395,6 +395,6 @@ SPEC CHECKSUMS:
   VK-ios-sdk: 5bcf00a2014a7323f98db9328b603d4f96635caa
   YandexMobileMetrica: 072fc59d216c8824d83d1d54bdc6e96d9cfcc59c
 
-PODFILE CHECKSUM: 607ecf5a6a9f0748cdc28184b55a36a093f8ca1c
+PODFILE CHECKSUM: f616f22779ed8441674476873d03aa2954223295
 
 COCOAPODS: 1.10.1

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -32,72 +32,72 @@ PODS:
     - FBSDKLoginKit/Login (= 8.2.0)
   - FBSDKLoginKit/Login (8.2.0):
     - FBSDKCoreKit (~> 8.2.0)
-  - Firebase/Analytics (7.7.0):
+  - Firebase/Analytics (7.8.0):
     - Firebase/Core
-  - Firebase/Core (7.7.0):
+  - Firebase/Core (7.8.0):
     - Firebase/CoreOnly
-    - FirebaseAnalytics (= 7.7.0)
-  - Firebase/CoreOnly (7.7.0):
-    - FirebaseCore (= 7.7.0)
-  - Firebase/Crashlytics (7.7.0):
+    - FirebaseAnalytics (= 7.8.0)
+  - Firebase/CoreOnly (7.8.0):
+    - FirebaseCore (= 7.8.0)
+  - Firebase/Crashlytics (7.8.0):
     - Firebase/CoreOnly
-    - FirebaseCrashlytics (~> 7.7.0)
-  - Firebase/Messaging (7.7.0):
+    - FirebaseCrashlytics (~> 7.8.0)
+  - Firebase/Messaging (7.8.0):
     - Firebase/CoreOnly
-    - FirebaseMessaging (~> 7.7.0)
-  - Firebase/RemoteConfig (7.7.0):
+    - FirebaseMessaging (~> 7.8.0)
+  - Firebase/RemoteConfig (7.8.0):
     - Firebase/CoreOnly
-    - FirebaseRemoteConfig (~> 7.7.0)
-  - FirebaseABTesting (7.7.0):
+    - FirebaseRemoteConfig (~> 7.8.0)
+  - FirebaseABTesting (7.8.0):
     - FirebaseCore (~> 7.0)
-  - FirebaseAnalytics (7.7.0):
+  - FirebaseAnalytics (7.8.0):
     - FirebaseCore (~> 7.0)
     - FirebaseInstallations (~> 7.0)
-    - GoogleAppMeasurement (= 7.7.0)
+    - GoogleAppMeasurement (= 7.8.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 7.0)
     - GoogleUtilities/MethodSwizzler (~> 7.0)
     - GoogleUtilities/Network (~> 7.0)
     - "GoogleUtilities/NSData+zlib (~> 7.0)"
     - nanopb (~> 2.30907.0)
-  - FirebaseCore (7.7.0):
+  - FirebaseCore (7.8.0):
     - FirebaseCoreDiagnostics (~> 7.4)
     - GoogleUtilities/Environment (~> 7.0)
     - GoogleUtilities/Logger (~> 7.0)
-  - FirebaseCoreDiagnostics (7.7.0):
+  - FirebaseCoreDiagnostics (7.8.0):
     - GoogleDataTransport (~> 8.0)
     - GoogleUtilities/Environment (~> 7.0)
     - GoogleUtilities/Logger (~> 7.0)
     - nanopb (~> 2.30907.0)
-  - FirebaseCrashlytics (7.7.0):
+  - FirebaseCrashlytics (7.8.0):
     - FirebaseCore (~> 7.0)
     - FirebaseInstallations (~> 7.0)
     - GoogleDataTransport (~> 8.0)
     - nanopb (~> 2.30907.0)
     - PromisesObjC (~> 1.2)
-  - FirebaseInstallations (7.7.0):
+  - FirebaseInstallations (7.8.0):
     - FirebaseCore (~> 7.0)
     - GoogleUtilities/Environment (~> 7.0)
     - GoogleUtilities/UserDefaults (~> 7.0)
     - PromisesObjC (~> 1.2)
-  - FirebaseInstanceID (7.7.0):
+  - FirebaseInstanceID (7.8.0):
     - FirebaseCore (~> 7.0)
     - FirebaseInstallations (~> 7.0)
     - GoogleUtilities/Environment (~> 7.0)
     - GoogleUtilities/UserDefaults (~> 7.0)
-  - FirebaseMessaging (7.7.0):
+  - FirebaseMessaging (7.8.0):
     - FirebaseCore (~> 7.0)
     - FirebaseInstanceID (~> 7.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 7.0)
     - GoogleUtilities/Environment (~> 7.0)
     - GoogleUtilities/Reachability (~> 7.0)
     - GoogleUtilities/UserDefaults (~> 7.0)
-  - FirebaseRemoteConfig (7.7.0):
+  - FirebaseRemoteConfig (7.8.0):
     - FirebaseABTesting (~> 7.0)
     - FirebaseCore (~> 7.0)
     - FirebaseInstallations (~> 7.0)
     - GoogleUtilities/Environment (~> 7.0)
     - "GoogleUtilities/NSData+zlib (~> 7.0)"
-  - GoogleAppMeasurement (7.7.0):
+  - GoogleAppMeasurement (7.8.0):
     - GoogleUtilities/AppDelegateSwizzler (~> 7.0)
     - GoogleUtilities/MethodSwizzler (~> 7.0)
     - GoogleUtilities/Network (~> 7.0)
@@ -214,11 +214,11 @@ DEPENDENCIES:
   - EasyTipView (= 2.1.0)
   - FBSDKCoreKit (= 8.2.0)
   - FBSDKLoginKit (= 8.2.0)
-  - Firebase/Analytics (= 7.7.0)
-  - Firebase/Core (= 7.7.0)
-  - Firebase/Crashlytics (= 7.7.0)
-  - Firebase/Messaging (= 7.7.0)
-  - Firebase/RemoteConfig (= 7.7.0)
+  - Firebase/Analytics (= 7.8.0)
+  - Firebase/Core (= 7.8.0)
+  - Firebase/Crashlytics (= 7.8.0)
+  - Firebase/Messaging (= 7.8.0)
+  - Firebase/RemoteConfig (= 7.8.0)
   - GoogleSignIn (= 5.0.2)
   - Highlightr (= 2.1.0)
   - IQKeyboardManagerSwift (= 6.5.6)
@@ -345,17 +345,17 @@ SPEC CHECKSUMS:
   EasyTipView: a92b6edc377b81c5ac18e9fd35d5ee78e9409488
   FBSDKCoreKit: 4afd6ff53d8133a433dbcda44451c9498f8c6ce4
   FBSDKLoginKit: 7181765f2524d7ebf82d9629066c8e6caafc99d0
-  Firebase: cd2ab85eec8170dc260186159f21072ecb679ad5
-  FirebaseABTesting: 96117eb86e2fa429520bbf5a3f02caef615f6576
-  FirebaseAnalytics: f3f8f75de34fe04141a69bb1c4bd7e24a80178e1
-  FirebaseCore: ac35d680a0bf32319a59966a1478e0741536b97b
-  FirebaseCoreDiagnostics: 179bf3831213451c8addd036aca7fcf5492ec154
-  FirebaseCrashlytics: 47af228115805e190b566db12c028263531b8ce0
-  FirebaseInstallations: 42c86e7b02ff75b7f27f85833bf5dcb5f38a9774
-  FirebaseInstanceID: cf940324a20ac14a27ad1e931d15ac9d335526db
-  FirebaseMessaging: ce33c2537fdda1d1a4bc82b2245e3c3bf9107684
-  FirebaseRemoteConfig: 44024544404d1195537bd883b60d596d95e129b7
-  GoogleAppMeasurement: 0c3b134b2c0a90c4c24833873894bfe0e42a0384
+  Firebase: 1e0d6610f21bdd131231525d7ee78f7f9e64e606
+  FirebaseABTesting: 44acbfc9db915bca8f111ebae342da6fd4f1cc55
+  FirebaseAnalytics: e70f7e0f1f178960a7d0b4ebec32e8c386245eda
+  FirebaseCore: 049029df3096e5c118917029be7da75ee16f3b1b
+  FirebaseCoreDiagnostics: 066f996579cf097bdad3d7dc9a918d6b9e129c50
+  FirebaseCrashlytics: d07e61d85aabc7d38a68f94ff99995f8557ea8d0
+  FirebaseInstallations: 7f7ed0e7e27fb51f57291e1876e2ddb1524126c1
+  FirebaseInstanceID: aaecc93b4528bbcafea12c477e26827719ca1183
+  FirebaseMessaging: 1d5cac3728c042d3d4700ecb56bbac893660a963
+  FirebaseRemoteConfig: 0d7a7e45c23bfaa1f299c768b3c357ae3a5bc9d5
+  GoogleAppMeasurement: dccff6095ea1cd8972a8b96d0ee38b9e6d67acbb
   GoogleDataTransport: 1024b1a4dfbd7a0e92cb20d7e0a6f1fb66b449a4
   GoogleSignIn: 7137d297ddc022a7e0aa4619c86d72c909fa7213
   GoogleUtilities: 31c5b01f978a70c6cff2afc6272b3f1921614b43
@@ -395,6 +395,6 @@ SPEC CHECKSUMS:
   VK-ios-sdk: 5bcf00a2014a7323f98db9328b603d4f96635caa
   YandexMobileMetrica: 072fc59d216c8824d83d1d54bdc6e96d9cfcc59c
 
-PODFILE CHECKSUM: f616f22779ed8441674476873d03aa2954223295
+PODFILE CHECKSUM: ac25680ae97cd3b47a2c7611a56f6aa389fd5022
 
 COCOAPODS: 1.10.1


### PR DESCRIPTION
Bumps:
- [Branch](https://github.com/BranchMetrics/ios-branch-deep-linking-attribution) from 1.38.0 to 1.39.0
- [Amplitude](https://github.com/amplitude/Amplitude-iOS) from 7.3.0 to 8.0.0
- [Firebase](https://github.com/firebase/firebase-ios-sdk) from 7.7.0 to 7.8.0