### PR TITLE
Hide Log Out in settings when current user is unauthorized

### DIFF
--- a/Stepic/Sources/Modules/Settings/SettingsDataFlow.swift
+++ b/Stepic/Sources/Modules/Settings/SettingsDataFlow.swift
@@ -188,6 +188,7 @@ enum Settings {
         let isAutoplayEnabled: Bool
         let isAdaptiveModeEnabled: Bool
         let isDarkModeAvailable: Bool
+        let isAuthorized: Bool
     }
 
     struct SettingDescription {

--- a/Stepic/Sources/Modules/Settings/SettingsInteractor.swift
+++ b/Stepic/Sources/Modules/Settings/SettingsInteractor.swift
@@ -48,8 +48,13 @@ final class SettingsInteractor: SettingsInteractorProtocol {
             shouldUseCellularDataForDownloads: self.provider.shouldUseCellularDataForDownloads,
             isAutoplayEnabled: self.provider.isAutoplayEnabled,
             isAdaptiveModeEnabled: self.provider.isAdaptiveModeEnabled,
-            isDarkModeAvailable: self.remoteConfig.isDarkModeAvailable
+            isDarkModeAvailable: self.remoteConfig.isDarkModeAvailable,
+            isAuthorized: self.isAuthorized
         )
+    }
+
+    private var isAuthorized: Bool {
+        !(self.userAccountService.currentUser?.isGuest ?? true) && self.userAccountService.isAuthorized
     }
 
     init(

--- a/Stepic/Sources/Modules/Settings/SettingsPresenter.swift
+++ b/Stepic/Sources/Modules/Settings/SettingsPresenter.swift
@@ -119,7 +119,8 @@ final class SettingsPresenter: SettingsPresenterProtocol {
             shouldUseCellularDataForDownloads: data.shouldUseCellularDataForDownloads,
             isAutoplayEnabled: data.isAutoplayEnabled,
             isAdaptiveModeEnabled: data.isAdaptiveModeEnabled,
-            isApplicationThemeSettingAvailable: data.isDarkModeAvailable
+            isApplicationThemeSettingAvailable: data.isDarkModeAvailable,
+            isAuthorized: data.isAuthorized
         )
     }
 }

--- a/Stepic/Sources/Modules/Settings/SettingsViewController.swift
+++ b/Stepic/Sources/Modules/Settings/SettingsViewController.swift
@@ -418,20 +418,6 @@ extension SettingsViewController: SettingsViewControllerProtocol {
             )
         )
 
-        // Log Out
-        let logOutCellViewModel = SettingsTableSectionViewModel.Cell(
-            uniqueIdentifier: Setting.logOut.rawValue,
-            type: .rightDetail(
-                options: .init(
-                    title: .init(
-                        text: Setting.logOut.cellTitle,
-                        appearance: .init(textColor: .stepikRed, textAlignment: .center)
-                    ),
-                    accessoryType: .none
-                )
-            )
-        )
-
         let learningSectionCellsViewModels = settingsViewModel.isApplicationThemeSettingAvailable
             ? [autoplayCellViewModel, adaptiveModeCellViewModel]
             : [
@@ -468,8 +454,7 @@ extension SettingsViewController: SettingsViewControllerProtocol {
                 header: .init(title: NSLocalizedString("SettingsHeaderTitleOther", comment: "")),
                 cells: [aboutCellViewModel],
                 footer: nil
-            ),
-            .init(header: nil, cells: [logOutCellViewModel], footer: nil)
+            )
         ]
 
         if settingsViewModel.isApplicationThemeSettingAvailable {
@@ -480,6 +465,23 @@ extension SettingsViewController: SettingsViewControllerProtocol {
             )
 
             sectionsViewModels.insert(appearanceSectionViewModel, at: 1)
+        }
+
+        if settingsViewModel.isAuthorized {
+            let logOutCellViewModel = SettingsTableSectionViewModel.Cell(
+                uniqueIdentifier: Setting.logOut.rawValue,
+                type: .rightDetail(
+                    options: .init(
+                        title: .init(
+                            text: Setting.logOut.cellTitle,
+                            appearance: .init(textColor: .stepikRed, textAlignment: .center)
+                        ),
+                        accessoryType: .none
+                    )
+                )
+            )
+
+            sectionsViewModels.append(.init(header: nil, cells: [logOutCellViewModel], footer: nil))
         }
 
         self.settingsView?.configure(viewModel: SettingsTableViewModel(sections: sectionsViewModels))

--- a/Stepic/Sources/Modules/Settings/SettingsViewModel.swift
+++ b/Stepic/Sources/Modules/Settings/SettingsViewModel.swift
@@ -10,4 +10,5 @@ struct SettingsViewModel {
     let isAutoplayEnabled: Bool
     let isAdaptiveModeEnabled: Bool
     let isApplicationThemeSettingAvailable: Bool
+    let isAuthorized: Bool
 }


### PR DESCRIPTION
**YouTrack task**: [#APPS-3260](https://vyahhi.myjetbrains.com/youtrack/issue/APPS-3260)

**Description**:
- Shows `logOut` cell in settings only when the current user is authorized.