### PR TITLE
Update dependencies 1.171

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -45,11 +45,11 @@ def all_pods
   pod 'SnapKit', '5.0.1'
 
   # Firebase
-  pod 'Firebase/Core', '7.10.0'
-  pod 'Firebase/Messaging', '7.10.0'
-  pod 'Firebase/Analytics', '7.10.0'
-  pod 'Firebase/Crashlytics', '7.10.0'
-  pod 'Firebase/RemoteConfig', '7.10.0'
+  pod 'Firebase/Core', '7.11.0'
+  pod 'Firebase/Messaging', '7.11.0'
+  pod 'Firebase/Analytics', '7.11.0'
+  pod 'Firebase/Crashlytics', '7.11.0'
+  pod 'Firebase/RemoteConfig', '7.11.0'
 
   pod 'YandexMobileMetrica/Dynamic', '3.15.1'
   pod 'Amplitude', '8.2.1'

--- a/Podfile
+++ b/Podfile
@@ -13,7 +13,7 @@ project 'Stepic',
         'Develop Release' => :release
 
 def shared_pods
-  pod 'Alamofire', '5.4.2'
+  pod 'Alamofire', '5.4.3'
   pod 'Atributika', '4.9.10'
   pod 'SwiftyJSON', '5.0.0'
   pod 'SDWebImage', '5.11.0'

--- a/Podfile
+++ b/Podfile
@@ -72,7 +72,7 @@ def all_pods
   pod 'PanModal', :git => 'https://github.com/ivan-magda/PanModal.git', :branch => 'remove-presenting-appearance-transitions'
 
   pod 'Agrume', '5.6.13'
-  pod 'Highlightr', '2.1.0'
+  pod 'Highlightr', :git => 'https://github.com/raspu/Highlightr.git', :tag => '2.1.2'
   pod 'TTTAttributedLabel', '2.0.0'
   pod 'lottie-ios', '3.2.1'
   pod 'Koloda', '5.0.1'

--- a/Podfile
+++ b/Podfile
@@ -51,7 +51,7 @@ def all_pods
   pod 'Firebase/Crashlytics', '7.10.0'
   pod 'Firebase/RemoteConfig', '7.10.0'
 
-  pod 'YandexMobileMetrica/Dynamic', '3.15.0'
+  pod 'YandexMobileMetrica/Dynamic', '3.15.1'
   pod 'Amplitude', '8.2.1'
   pod 'Branch', '1.39.2'
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -2,7 +2,7 @@ PODS:
   - ActionSheetPicker-3.0 (2.7.1)
   - Agrume (5.6.13):
     - SwiftyGif
-  - Alamofire (5.4.2)
+  - Alamofire (5.4.3)
   - Amplitude (8.2.1)
   - AppAuth (1.4.0):
     - AppAuth/Core (= 1.4.0)
@@ -219,7 +219,7 @@ PODS:
 DEPENDENCIES:
   - ActionSheetPicker-3.0 (= 2.7.1)
   - Agrume (= 5.6.13)
-  - Alamofire (= 5.4.2)
+  - Alamofire (= 5.4.3)
   - Amplitude (= 8.2.1)
   - Atributika (= 4.9.10)
   - BEMCheckBox (= 1.4.1)
@@ -358,7 +358,7 @@ CHECKOUT OPTIONS:
 SPEC CHECKSUMS:
   ActionSheetPicker-3.0: 36da254b97a09ff89679ecb8b8510bd3e5bdc773
   Agrume: 21b96a1138abc0f890211bfcb12f8b1e3464b4c1
-  Alamofire: bfbc4c2fe5909b1d94fb4ef2277c6b3727ef5dae
+  Alamofire: e447a2774a40c996748296fa2c55112fdbbc42f9
   Amplitude: e91463935daea43afc81afa535b3d4d23043b0f5
   AppAuth: 31bcec809a638d7bd2f86ea8a52bd45f6e81e7c7
   Atributika: cf87f95f1d31d9cdb9af611a2b4e00672e9ae195
@@ -422,6 +422,6 @@ SPEC CHECKSUMS:
   VK-ios-sdk: 5bcf00a2014a7323f98db9328b603d4f96635caa
   YandexMobileMetrica: fb4b3c20a0c0237b03b34cc07b6d575332f43097
 
-PODFILE CHECKSUM: 82d8e760ecf7d27224fd1f3170cb018bf93f4216
+PODFILE CHECKSUM: 34a6c6ff730d3bf09648f93ec8de18ced2204d7d
 
 COCOAPODS: 1.10.1

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -190,11 +190,11 @@ PODS:
   - TUSafariActivity (1.0.4)
   - URITemplate (3.0.0)
   - VK-ios-sdk (1.6.2)
-  - YandexMobileMetrica/Dynamic (3.15.0):
-    - YandexMobileMetrica/Dynamic/Core (= 3.15.0)
-    - YandexMobileMetrica/Dynamic/Crashes (= 3.15.0)
-  - YandexMobileMetrica/Dynamic/Core (3.15.0)
-  - YandexMobileMetrica/Dynamic/Crashes (3.15.0):
+  - YandexMobileMetrica/Dynamic (3.15.1):
+    - YandexMobileMetrica/Dynamic/Core (= 3.15.1)
+    - YandexMobileMetrica/Dynamic/Crashes (= 3.15.1)
+  - YandexMobileMetrica/Dynamic/Core (3.15.1)
+  - YandexMobileMetrica/Dynamic/Crashes (3.15.1):
     - YandexMobileMetrica/Dynamic/Core
 
 DEPENDENCIES:
@@ -243,7 +243,7 @@ DEPENDENCIES:
   - TTTAttributedLabel (= 2.0.0)
   - TUSafariActivity (= 1.0.4)
   - VK-ios-sdk (= 1.6.2)
-  - YandexMobileMetrica/Dynamic (= 3.15.0)
+  - YandexMobileMetrica/Dynamic (= 3.15.1)
 
 SPEC REPOS:
   https://github.com/CocoaPods/Specs.git:
@@ -401,8 +401,8 @@ SPEC CHECKSUMS:
   TUSafariActivity: afc55a00965377939107ce4fdc7f951f62454546
   URITemplate: 58e0d47f967006c5d59888af5356c4a8ed3b197d
   VK-ios-sdk: 5bcf00a2014a7323f98db9328b603d4f96635caa
-  YandexMobileMetrica: bf9b2bceb40811ab29c3d0f660ef13d381d8dd93
+  YandexMobileMetrica: fb4b3c20a0c0237b03b34cc07b6d575332f43097
 
-PODFILE CHECKSUM: 3bb9bc441fd56cfb8f0d5d519ae99d2e89bac500
+PODFILE CHECKSUM: 5871053716042cb4410771c99d99fe6156174cad
 
 COCOAPODS: 1.10.1

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -237,7 +237,7 @@ DEPENDENCIES:
   - Firebase/RemoteConfig (= 7.11.0)
   - FLEX (from `https://github.com/ivan-magda/FLEX.git`, branch `master`)
   - GoogleSignIn (= 5.0.2)
-  - Highlightr (= 2.1.0)
+  - Highlightr (from `https://github.com/raspu/Highlightr.git`, tag `2.1.2`)
   - IQKeyboardManagerSwift (= 6.5.6)
   - Kanna (= 5.2.2)
   - Koloda (= 5.0.1)
@@ -298,7 +298,6 @@ SPEC REPOS:
     - GTMAppAuth
     - GTMSessionFetcher
     - HexColors
-    - Highlightr
     - IQKeyboardManagerSwift
     - Kanna
     - Koloda
@@ -332,6 +331,9 @@ EXTERNAL SOURCES:
   FLEX:
     :branch: master
     :git: https://github.com/ivan-magda/FLEX.git
+  Highlightr:
+    :git: https://github.com/raspu/Highlightr.git
+    :tag: 2.1.2
   PanModal:
     :branch: remove-presenting-appearance-transitions
     :git: https://github.com/ivan-magda/PanModal.git
@@ -345,6 +347,9 @@ CHECKOUT OPTIONS:
   FLEX:
     :commit: 99338e8545f70c143c88e2564e8b604ad4b285ae
     :git: https://github.com/ivan-magda/FLEX.git
+  Highlightr:
+    :git: https://github.com/raspu/Highlightr.git
+    :tag: 2.1.2
   PanModal:
     :commit: 32fc8b5868b0254a2025c9c01b24c0e4b3fe537d
     :git: https://github.com/ivan-magda/PanModal.git
@@ -389,7 +394,7 @@ SPEC CHECKSUMS:
   GTMAppAuth: 5b53231ef6920f149ab84b2969cb0ab572da3077
   GTMSessionFetcher: b3503b20a988c4e20cc189aa798fd18220133f52
   HexColors: 6ad3947c3447a055a3aa8efa859def096351fe5f
-  Highlightr: 595f3e100737c8de41113385da8bd0b5b65212c6
+  Highlightr: 683f05d5223cade533a78528a35c9f06e4caddf8
   IQKeyboardManagerSwift: c7df9d2deb356c04522f5c4b7b6e4ce4d8ed94fe
   Kanna: 2c4eddaaa4bfb9a1ed19e53c0b3d42ef02838046
   Koloda: d07b9199a383abc5898b62aa945a599f5e7c0c4b
@@ -422,6 +427,6 @@ SPEC CHECKSUMS:
   VK-ios-sdk: 5bcf00a2014a7323f98db9328b603d4f96635caa
   YandexMobileMetrica: fb4b3c20a0c0237b03b34cc07b6d575332f43097
 
-PODFILE CHECKSUM: 34a6c6ff730d3bf09648f93ec8de18ced2204d7d
+PODFILE CHECKSUM: ec81cdf19dc5146ed521e3097ef3ceff23697e1e
 
 COCOAPODS: 1.10.1

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -31,73 +31,92 @@ PODS:
     - FBSDKLoginKit/Login (= 8.2.0)
   - FBSDKLoginKit/Login (8.2.0):
     - FBSDKCoreKit (~> 8.2.0)
-  - Firebase/Analytics (7.10.0):
+  - Firebase/Analytics (7.11.0):
     - Firebase/Core
-  - Firebase/Core (7.10.0):
+  - Firebase/Core (7.11.0):
     - Firebase/CoreOnly
-    - FirebaseAnalytics (~> 7.10.0)
-  - Firebase/CoreOnly (7.10.0):
-    - FirebaseCore (= 7.10.0)
-  - Firebase/Crashlytics (7.10.0):
+    - FirebaseAnalytics (~> 7.11.0)
+  - Firebase/CoreOnly (7.11.0):
+    - FirebaseCore (= 7.11.0)
+  - Firebase/Crashlytics (7.11.0):
     - Firebase/CoreOnly
-    - FirebaseCrashlytics (~> 7.10.0)
-  - Firebase/Messaging (7.10.0):
+    - FirebaseCrashlytics (~> 7.11.0)
+  - Firebase/Messaging (7.11.0):
     - Firebase/CoreOnly
-    - FirebaseMessaging (~> 7.10.0)
-  - Firebase/RemoteConfig (7.10.0):
+    - FirebaseMessaging (~> 7.11.0)
+  - Firebase/RemoteConfig (7.11.0):
     - Firebase/CoreOnly
-    - FirebaseRemoteConfig (~> 7.10.0)
-  - FirebaseABTesting (7.10.0):
+    - FirebaseRemoteConfig (~> 7.11.0)
+  - FirebaseABTesting (7.11.0):
     - FirebaseCore (~> 7.0)
-  - FirebaseAnalytics (7.10.0):
+  - FirebaseAnalytics (7.11.0):
+    - FirebaseAnalytics/AdIdSupport (= 7.11.0)
     - FirebaseCore (~> 7.0)
     - FirebaseInstallations (~> 7.0)
-    - GoogleAppMeasurement (= 7.10.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 7.0)
     - GoogleUtilities/MethodSwizzler (~> 7.0)
     - GoogleUtilities/Network (~> 7.0)
     - "GoogleUtilities/NSData+zlib (~> 7.0)"
     - nanopb (~> 2.30908.0)
-  - FirebaseCore (7.10.0):
+  - FirebaseAnalytics/AdIdSupport (7.11.0):
+    - FirebaseAnalytics/Base (= 7.11.0)
+    - FirebaseCore (~> 7.0)
+    - FirebaseInstallations (~> 7.0)
+    - GoogleAppMeasurement/AdIdSupport (= 7.11.0)
+    - GoogleUtilities/AppDelegateSwizzler (~> 7.0)
+    - GoogleUtilities/MethodSwizzler (~> 7.0)
+    - GoogleUtilities/Network (~> 7.0)
+    - "GoogleUtilities/NSData+zlib (~> 7.0)"
+    - nanopb (~> 2.30908.0)
+  - FirebaseAnalytics/Base (7.11.0):
+    - FirebaseCore (~> 7.0)
+    - FirebaseInstallations (~> 7.0)
+    - GoogleUtilities/AppDelegateSwizzler (~> 7.0)
+    - GoogleUtilities/MethodSwizzler (~> 7.0)
+    - GoogleUtilities/Network (~> 7.0)
+    - "GoogleUtilities/NSData+zlib (~> 7.0)"
+    - nanopb (~> 2.30908.0)
+  - FirebaseCore (7.11.0):
     - FirebaseCoreDiagnostics (~> 7.4)
     - GoogleUtilities/Environment (~> 7.0)
     - GoogleUtilities/Logger (~> 7.0)
-  - FirebaseCoreDiagnostics (7.10.0):
+  - FirebaseCoreDiagnostics (7.11.0):
     - GoogleDataTransport (~> 8.4)
     - GoogleUtilities/Environment (~> 7.0)
     - GoogleUtilities/Logger (~> 7.0)
     - nanopb (~> 2.30908.0)
-  - FirebaseCrashlytics (7.10.0):
+  - FirebaseCrashlytics (7.11.0):
     - FirebaseCore (~> 7.0)
     - FirebaseInstallations (~> 7.0)
     - GoogleDataTransport (~> 8.4)
     - nanopb (~> 2.30908.0)
     - PromisesObjC (~> 1.2)
-  - FirebaseInstallations (7.10.0):
+  - FirebaseInstallations (7.11.0):
     - FirebaseCore (~> 7.0)
     - GoogleUtilities/Environment (~> 7.0)
     - GoogleUtilities/UserDefaults (~> 7.0)
     - PromisesObjC (~> 1.2)
-  - FirebaseInstanceID (7.10.0):
+  - FirebaseInstanceID (7.11.0):
     - FirebaseCore (~> 7.0)
     - FirebaseInstallations (~> 7.0)
     - GoogleUtilities/Environment (~> 7.0)
     - GoogleUtilities/UserDefaults (~> 7.0)
-  - FirebaseMessaging (7.10.0):
+  - FirebaseMessaging (7.11.0):
     - FirebaseCore (~> 7.0)
+    - FirebaseInstallations (~> 7.0)
     - FirebaseInstanceID (~> 7.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 7.0)
     - GoogleUtilities/Environment (~> 7.0)
     - GoogleUtilities/Reachability (~> 7.0)
     - GoogleUtilities/UserDefaults (~> 7.0)
-  - FirebaseRemoteConfig (7.10.0):
+  - FirebaseRemoteConfig (7.11.0):
     - FirebaseABTesting (~> 7.0)
     - FirebaseCore (~> 7.0)
     - FirebaseInstallations (~> 7.0)
     - GoogleUtilities/Environment (~> 7.0)
     - "GoogleUtilities/NSData+zlib (~> 7.0)"
   - FLEX (4.4.1)
-  - GoogleAppMeasurement (7.10.0):
+  - GoogleAppMeasurement/AdIdSupport (7.11.0):
     - GoogleUtilities/AppDelegateSwizzler (~> 7.0)
     - GoogleUtilities/MethodSwizzler (~> 7.0)
     - GoogleUtilities/Network (~> 7.0)
@@ -211,11 +230,11 @@ DEPENDENCIES:
   - EasyTipView (= 2.1.0)
   - FBSDKCoreKit (= 8.2.0)
   - FBSDKLoginKit (= 8.2.0)
-  - Firebase/Analytics (= 7.10.0)
-  - Firebase/Core (= 7.10.0)
-  - Firebase/Crashlytics (= 7.10.0)
-  - Firebase/Messaging (= 7.10.0)
-  - Firebase/RemoteConfig (= 7.10.0)
+  - Firebase/Analytics (= 7.11.0)
+  - Firebase/Core (= 7.11.0)
+  - Firebase/Crashlytics (= 7.11.0)
+  - Firebase/Messaging (= 7.11.0)
+  - Firebase/RemoteConfig (= 7.11.0)
   - FLEX (from `https://github.com/ivan-magda/FLEX.git`, branch `master`)
   - GoogleSignIn (= 5.0.2)
   - Highlightr (= 2.1.0)
@@ -352,18 +371,18 @@ SPEC CHECKSUMS:
   EasyTipView: a92b6edc377b81c5ac18e9fd35d5ee78e9409488
   FBSDKCoreKit: 4afd6ff53d8133a433dbcda44451c9498f8c6ce4
   FBSDKLoginKit: 7181765f2524d7ebf82d9629066c8e6caafc99d0
-  Firebase: fffddd0bab8677d07376538365faa93ff3889b39
-  FirebaseABTesting: 457bc058cf6de8bcffc6fd9a2a4c933b24bfc264
-  FirebaseAnalytics: 4641d7ae4220174f6ca5626163ffc5de2e90391e
-  FirebaseCore: ec566d917b2195fc2610aeb148dae99f57a788f9
-  FirebaseCoreDiagnostics: 5662a3823ffcc0acbaa9a21ba5ed302fac634705
-  FirebaseCrashlytics: e7669d368a22d202f1d0c7546ffdfdff496e1a8c
-  FirebaseInstallations: bf2ec8dbf36ff4c91af6b9a003d15855757680c1
-  FirebaseInstanceID: 5ad92c898e1328b66e8dd58811964d6fe4d334c3
-  FirebaseMessaging: 76b3058cef7f339cf10db196e03bbbb2165fb5d7
-  FirebaseRemoteConfig: 2841e353accfe688150781deebeb245e3fe16c2f
+  Firebase: c121feb35e4126c0b355e3313fa9b487d47319fd
+  FirebaseABTesting: e66f1f80747792630d9b292966de206d5df9853b
+  FirebaseAnalytics: cd3bd84d722a24a8923918af8af8e5236f615d77
+  FirebaseCore: 907447d8917a4d3eb0cce2829c5a0ad21d90b432
+  FirebaseCoreDiagnostics: 68ad972f99206cef818230f3f3179d52ccfb7f8c
+  FirebaseCrashlytics: 272b675aa9d1e9bae1f9e1449fcc1f2cf6042806
+  FirebaseInstallations: a58d4f72ec5861840b84df489f2668d970df558a
+  FirebaseInstanceID: ad5135045a498d7775903efd39762d2cdfa1be27
+  FirebaseMessaging: 163435fb6db065e3b6228f1e577b10ed2cc506d2
+  FirebaseRemoteConfig: 0ea30de5fb0231df8c1bdcdf3b6c23bdc5066131
   FLEX: 75ca95cff4bd57592c6e75adee7651ace29f9c25
-  GoogleAppMeasurement: 1c863b1161fc3c8cf614a7460d1be6a7c262aab3
+  GoogleAppMeasurement: fd19169c3034975cb934e865e5667bfdce59df7f
   GoogleDataTransport: cd9db2180fcecd8da1b561aea31e3e56cf834aa7
   GoogleSignIn: 7137d297ddc022a7e0aa4619c86d72c909fa7213
   GoogleUtilities: e1d9ed4e544fc32a93e00e721400cbc3f377200d
@@ -403,6 +422,6 @@ SPEC CHECKSUMS:
   VK-ios-sdk: 5bcf00a2014a7323f98db9328b603d4f96635caa
   YandexMobileMetrica: fb4b3c20a0c0237b03b34cc07b6d575332f43097
 
-PODFILE CHECKSUM: 5871053716042cb4410771c99d99fe6156174cad
+PODFILE CHECKSUM: 82d8e760ecf7d27224fd1f3170cb018bf93f4216
 
 COCOAPODS: 1.10.1


### PR DESCRIPTION
Bumps:
- [YandexMobileMetrica](https://github.com/yandexmobile/metrica-sdk-ios) from 3.15.0 to 3.15.1
- [Firebase](https://github.com/firebase/firebase-ios-sdk) from 7.10.0 to 7.11.0
- [Alamofire](https://github.com/Alamofire/Alamofire) from 5.4.2 to 5.4.3
- [Highlightr](https://github.com/raspu/Highlightr) from 2.1.0 to 2.1.2