### PR TITLE
Fix video player no sound after comes from background at double fast rate

### DIFF
--- a/Stepic/Legacy/Controllers/VideoPlayer/StepikVideoPlayerViewController/StepikVideoPlayerViewController.swift
+++ b/Stepic/Legacy/Controllers/VideoPlayer/StepikVideoPlayerViewController/StepikVideoPlayerViewController.swift
@@ -1006,15 +1006,25 @@ extension StepikVideoPlayerViewController: PlayerDelegate {
         }
 
         let isPlayerFirstTimeReady = player.playbackState == .stopped || !self.isPlayerPassedReadyState
+
         let isPlayerReadyAfterVideoQualityChanged = player.playbackState == .paused
             && self.isPlayerPassedReadyState
             && !self.applicationDidComeFromBackground
+
+        let isPlayerReadyAfterDidComeFromBackgroundAtDoubleFastVideoRate = player.playbackState == .paused
+            && self.currentVideoRate == .doubleFast
+            && self.isPlayerPassedReadyState
+            && self.applicationDidComeFromBackground
 
         if self.applicationDidComeFromBackground {
             self.applicationDidComeFromBackground = false
         }
 
-        guard isPlayerFirstTimeReady || isPlayerReadyAfterVideoQualityChanged else {
+        let shouldPlayFromCurrentTime = isPlayerFirstTimeReady
+            || isPlayerReadyAfterVideoQualityChanged
+            || isPlayerReadyAfterDidComeFromBackgroundAtDoubleFastVideoRate
+
+        guard shouldPlayFromCurrentTime else {
             return
         }
 


### PR DESCRIPTION
**YouTrack task**: [#APPS-3277](https://vyahhi.myjetbrains.com/youtrack/issue/APPS-3277)

**Description**:
- Fixes video player no sound after comes from a background at a double fast rate.