### PR TITLE
Fix back button menus with empty titles

### DIFF
--- a/Stepic/Sources/Controllers/StyledNavigationController.swift
+++ b/Stepic/Sources/Controllers/StyledNavigationController.swift
@@ -161,12 +161,16 @@ class StyledNavigationController: UINavigationController {
             return
         }
 
-        parentViewController.navigationItem.backBarButtonItem = UIBarButtonItem(
-            title: "",
-            style: .plain,
-            target: nil,
-            action: nil
-        )
+        if #available(iOS 14.0, *) {
+            parentViewController.navigationItem.backButtonDisplayMode = .minimal
+        } else {
+            parentViewController.navigationItem.backBarButtonItem = UIBarButtonItem(
+                title: "",
+                style: .plain,
+                target: nil,
+                action: nil
+            )
+        }
     }
 
     /// Change color of navigation bar & status bar background

--- a/Stepic/Sources/Modules/Quizzes/CodeQuizFullscreen/CodeQuizFullscreenViewController.swift
+++ b/Stepic/Sources/Modules/Quizzes/CodeQuizFullscreen/CodeQuizFullscreenViewController.swift
@@ -132,7 +132,12 @@ final class CodeQuizFullscreenViewController: TabmanViewController {
             Appearance.navigationBarAppearance.shadowViewAlpha,
             sender: self
         )
-        self.navigationItem.backBarButtonItem = UIBarButtonItem(title: "", style: .plain, target: nil, action: nil)
+
+        if #available(iOS 14.0, *) {
+            self.navigationItem.backButtonDisplayMode = .minimal
+        } else {
+            self.navigationItem.backBarButtonItem = UIBarButtonItem(title: "", style: .plain, target: nil, action: nil)
+        }
     }
 
     override func viewWillDisappear(_ animated: Bool) {

--- a/Stepic/Sources/Modules/Settings/SettingsViewController.swift
+++ b/Stepic/Sources/Modules/Settings/SettingsViewController.swift
@@ -84,7 +84,12 @@ final class SettingsViewController: UIViewController {
     private func setupNavigationItem() {
         self.title = NSLocalizedString("SettingsTitle", comment: "")
         self.navigationItem.rightBarButtonItem = self.closeBarButtonItem
-        self.navigationItem.backBarButtonItem = UIBarButtonItem(title: "", style: .plain, target: nil, action: nil)
+
+        if #available(iOS 14.0, *) {
+            self.navigationItem.backButtonDisplayMode = .minimal
+        } else {
+            self.navigationItem.backBarButtonItem = UIBarButtonItem(title: "", style: .plain, target: nil, action: nil)
+        }
     }
 
     private func updateNavigationBarAppearance() {


### PR DESCRIPTION
**YouTrack task**: [#APPS-3318](https://vyahhi.myjetbrains.com/youtrack/issue/APPS-3318)

**Description**:
- On iOS 14 uses `UINavigationItem.BackButtonDisplayMode.minimal` to show the back button indicator instead of the title.