### PR TITLE
Fix course revenue header invalid content offset on expand content

### DIFF
--- a/Stepic/Sources/Modules/CourseRevenueSubmodules/CourseRevenueTabPurchases/Views/CourseRevenueTabPurchasesView.swift
+++ b/Stepic/Sources/Modules/CourseRevenueSubmodules/CourseRevenueTabPurchases/Views/CourseRevenueTabPurchasesView.swift
@@ -176,6 +176,12 @@ extension CourseRevenueTabPurchasesView: ScrollablePageViewProtocol {
         set {
             self.tableView.contentInset = newValue
             self.placeholderViewTopConstraint?.update(offset: newValue.top)
+
+            // Manually update contentOffset if needed APPS-3384
+            let newContentOffset = CGPoint(x: 0, y: -newValue.top)
+            if self.contentOffset != newContentOffset {
+                self.contentOffset = newContentOffset
+            }
         }
     }
 


### PR DESCRIPTION
**YouTrack task**: [#APPS-3384](https://vyahhi.myjetbrains.com/youtrack/issue/APPS-3384)

**Description**:
- Fixes course revenue header view offset on expanding content action.