### PR TITLE
Fix streak notifications manager not checking notification permission status

### DIFF
--- a/Stepic/Legacy/Controllers/RegistrationSignIn/AuthNavigationViewController.swift
+++ b/Stepic/Legacy/Controllers/RegistrationSignIn/AuthNavigationViewController.swift
@@ -9,7 +9,7 @@
 import UIKit
 
 final class AuthNavigationViewController: UINavigationController {
-    private let streaksAlertPresentationManager = StreaksAlertPresentationManager(source: .login)
+    private static let streaksAlertPresentationManager = StreaksAlertPresentationManager(source: .login)
     private let notificationSuggestionManager = NotificationSuggestionManager()
     private let userActivitiesAPI = UserActivitiesAPI()
 
@@ -21,7 +21,7 @@ final class AuthNavigationViewController: UINavigationController {
 
     weak var source: UIViewController? {
         didSet {
-            streaksAlertPresentationManager.controller = source
+            Self.streaksAlertPresentationManager.controller = source
         }
     }
     var success: (() -> Void)?
@@ -31,7 +31,7 @@ final class AuthNavigationViewController: UINavigationController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        streaksAlertPresentationManager.controller = source
+        Self.streaksAlertPresentationManager.controller = source
         navigationBar.shadowImage = UIImage()
         navigationBar.setBackgroundImage(UIImage(), for: .default)
     }
@@ -47,7 +47,7 @@ final class AuthNavigationViewController: UINavigationController {
                 after: .login
             )
             if canShowAlert && userActivity.didSolveThisWeek {
-                self.streaksAlertPresentationManager.suggestStreak(
+                Self.streaksAlertPresentationManager.suggestStreak(
                     streak: userActivity.currentStreak
                 )
             }

--- a/Stepic/Legacy/Model/Managers/StreaksAlertPresentationManager.swift
+++ b/Stepic/Legacy/Model/Managers/StreaksAlertPresentationManager.swift
@@ -22,7 +22,7 @@ final class StreaksAlertPresentationManager {
     }()
 
     private let streakTimePickerPresenter: Presentr = {
-        let streakTimePickerPresenter = Presentr(presentationType: .popup)
+        let streakTimePickerPresenter = Presentr(presentationType: .bottomHalf)
         return streakTimePickerPresenter
     }()
 
@@ -61,14 +61,18 @@ final class StreaksAlertPresentationManager {
         let source = self.source.analyticsSource
         presenter.onPositiveCallback = { [weak self] in
             PreferencesContainer.notifications.allowStreaksNotifications = true
+            NotificationCenter.default.post(
+                name: .streaksAlertPresentationManagerDidChangeStreakNotifications,
+                object: nil
+            )
 
             StepikAnalytics.shared.send(
                 .streaksSuggestionSucceeded(index: NotificationSuggestionManager().streakAlertShownCnt)
             )
             NotificationAlertsAnalytics(source: source).reportCustomAlertInteractionResult(.yes)
 
-            // When we are suggesting streak with the `Source` of .login type - `self` will be deallocated at this point.
-            // In this case we need to register for remote notifications.
+            assert(self != nil)
+
             if let strongSelf = self {
                 strongSelf.notifyPressed()
             } else {
@@ -101,7 +105,12 @@ final class StreaksAlertPresentationManager {
         }
     }
 
-    private func didChooseTime() {}
+    private func didChooseTime() {
+        NotificationCenter.default.post(
+            name: .streaksAlertPresentationManagerDidChangeStreakNotifications,
+            object: PreferencesContainer.notifications.streaksNotificationStartHourUTC
+        )
+    }
 
     private func selectStreakNotificationTime() {
         guard let controller = controller else {
@@ -144,7 +153,6 @@ final class StreaksAlertPresentationManager {
             case .denied:
                 self?.showSettingsAlert()
             }
-            return
         }
     }
 
@@ -204,4 +212,9 @@ final class StreaksAlertPresentationManager {
             }
         }
     }
+}
+
+extension Foundation.Notification.Name {
+    static let streaksAlertPresentationManagerDidChangeStreakNotifications = Foundation.Notification
+        .Name("streaksAlertPresentationManagerDidChangeStreakNotifications")
 }

--- a/Stepic/Legacy/Model/Managers/StreaksAlertPresentationManager.swift
+++ b/Stepic/Legacy/Model/Managers/StreaksAlertPresentationManager.swift
@@ -22,7 +22,7 @@ final class StreaksAlertPresentationManager {
     }()
 
     private let streakTimePickerPresenter: Presentr = {
-        let streakTimePickerPresenter = Presentr(presentationType: .bottomHalf)
+        let streakTimePickerPresenter = Presentr(presentationType: .popup)
         return streakTimePickerPresenter
     }()
 

--- a/Stepic/Sources/Modules/Quizzes/BaseQuiz/BaseQuizViewController.swift
+++ b/Stepic/Sources/Modules/Quizzes/BaseQuiz/BaseQuizViewController.swift
@@ -13,6 +13,8 @@ final class BaseQuizViewController: UIViewController, ControllerWithStepikPlaceh
 
     lazy var baseQuizView = self.view as? BaseQuizView
 
+    private lazy var streaksAlertPresentationManager = StreaksAlertPresentationManager(source: .submission)
+
     private var quizAssembly: QuizAssembly
 
     private var childQuizModuleInput: QuizInputProtocol? { self.quizAssembly.moduleInput }
@@ -151,9 +153,8 @@ extension BaseQuizViewController: BaseQuizViewControllerProtocol {
     }
 
     func displayStreakAlert(viewModel: BaseQuiz.StreakAlertPresentation.ViewModel) {
-        let streaksAlertPresentationManager = StreaksAlertPresentationManager(source: .submission)
-        streaksAlertPresentationManager.controller = self
-        streaksAlertPresentationManager.suggestStreak(streak: viewModel.streak)
+        self.streaksAlertPresentationManager.controller = self
+        self.streaksAlertPresentationManager.suggestStreak(streak: viewModel.streak)
     }
 }
 


### PR DESCRIPTION
**YouTrack task**: [#APPS-3404](https://vyahhi.myjetbrains.com/youtrack/issue/APPS-3404)

**Description**:
- Fixes `StreaksAlertPresentationManager` not checking current notification permission status on enabling streaks notifications.