### PR TITLE
Fix <details> content not visible

### DIFF
--- a/Stepic/Sources/Frameworks/ContentProcessor/Processing/ContentProcessingRule.swift
+++ b/Stepic/Sources/Frameworks/ContentProcessor/Processing/ContentProcessingRule.swift
@@ -164,3 +164,10 @@ final class ReplaceModelViewerWithARImageRule: BaseHTMLExtractionRule {
         return content
     }
 }
+
+/// Makes the contents of the <details> element visible and prevents toggle behavior.
+final class AlwaysOpenedDetailsDisclosureBoxRule: BaseHTMLExtractionRule {
+    override func process(content: String) -> String {
+        content.replacingOccurrences(of: "<details>", with: "<details open onclick=\"return false\">")
+    }
+}

--- a/Stepic/Sources/Frameworks/ContentProcessor/Processing/ContentProcessor.swift
+++ b/Stepic/Sources/Frameworks/ContentProcessor/Processing/ContentProcessor.swift
@@ -22,7 +22,8 @@ final class ContentProcessor: ContentProcessorProtocol {
     static let defaultRules: [ContentProcessingRule] = [
         FixRelativeProtocolURLsRule(),
         AddStepikSiteForRelativeURLsRule(extractorType: HTMLExtractor.self),
-        RemoveImageFixedHeightRule(extractorType: HTMLExtractor.self)
+        RemoveImageFixedHeightRule(extractorType: HTMLExtractor.self),
+        AlwaysOpenedDetailsDisclosureBoxRule(extractorType: HTMLExtractor.self)
     ]
 
     private let rules: [ContentProcessingRule]


### PR DESCRIPTION
**YouTrack task**: [#APPS-3424](https://vyahhi.myjetbrains.com/youtrack/issue/APPS-3424)

**Description**:
- Makes the contents of the `<details>` tag visible and prevents toggle behavior.