### PR TITLE
Update dependencies 1.191

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -30,9 +30,11 @@ only_rules:
   - deployment_target
   - discarded_notification_center_observer
   - discouraged_direct_init
+  - discouraged_none_name
   - discouraged_object_literal
   - duplicate_enum_cases
   - duplicate_imports
+  - duplicated_key_in_dictionary_literal
   - dynamic_inline
   - empty_collection_literal
   - empty_count
@@ -214,6 +216,9 @@ discarded_notification_center_observer:
 discouraged_direct_init:
   severity: error
 
+discouraged_none_name:
+  severity: warning
+
 discouraged_object_literal:
   severity: error
 
@@ -221,6 +226,9 @@ duplicate_enum_cases:
   severity: error
 
 duplicate_imports:
+  severity: error
+
+duplicated_key_in_dictionary_literal:
   severity: error
 
 dynamic_inline:

--- a/Podfile
+++ b/Podfile
@@ -43,11 +43,11 @@ def all_pods
   pod 'SnapKit', '5.0.1'
 
   # Firebase
-  pod 'Firebase/Core', '8.6.0'
-  pod 'Firebase/Messaging', '8.6.0'
-  pod 'Firebase/Analytics', '8.6.0'
-  pod 'Firebase/Crashlytics', '8.6.0'
-  pod 'Firebase/RemoteConfig', '8.6.0'
+  pod 'Firebase/Core', '8.7.0'
+  pod 'Firebase/Messaging', '8.7.0'
+  pod 'Firebase/Analytics', '8.7.0'
+  pod 'Firebase/Crashlytics', '8.7.0'
+  pod 'Firebase/RemoteConfig', '8.7.0'
 
   pod 'YandexMobileMetrica/Dynamic', '3.15.1'
   pod 'Amplitude', '8.3.0'

--- a/Podfile
+++ b/Podfile
@@ -50,7 +50,7 @@ def all_pods
   pod 'Firebase/RemoteConfig', '8.7.0'
 
   pod 'YandexMobileMetrica/Dynamic', '3.15.1'
-  pod 'Amplitude', '8.3.0'
+  pod 'Amplitude', '8.3.1'
   pod 'Branch', '1.39.3'
 
   pod 'BEMCheckBox', '1.4.1'

--- a/Podfile
+++ b/Podfile
@@ -85,7 +85,7 @@ end
 
 def testing_pods
   pod 'Quick', '4.0.0'
-  pod 'Nimble', '9.2.0'
+  pod 'Nimble', '9.2.1'
   pod 'Mockingjay', '3.0.0-alpha.1'
 end
 

--- a/Podfile
+++ b/Podfile
@@ -20,7 +20,7 @@ def shared_pods
   pod 'SVGKit', :git => 'https://github.com/SVGKit/SVGKit.git', :branch => '2.x'
   pod 'DeviceKit', '4.5.0'
   pod 'PromiseKit', '6.15.3'
-  pod 'SwiftLint', '0.43.1'
+  pod 'SwiftLint', '0.44.0'
 
   if ENV['FASTLANE_BETA_PROFILE'] == 'true'
     pod 'FLEX',

--- a/Podfile
+++ b/Podfile
@@ -18,7 +18,7 @@ def shared_pods
   pod 'SwiftyJSON', '5.0.0'
   pod 'SDWebImage', '5.11.0'
   pod 'SVGKit', :git => 'https://github.com/SVGKit/SVGKit.git', :branch => '2.x'
-  pod 'DeviceKit', '4.4.0'
+  pod 'DeviceKit', '4.5.0'
   pod 'PromiseKit', '6.15.3'
   pod 'SwiftLint', '0.43.1'
 

--- a/Podfile
+++ b/Podfile
@@ -49,7 +49,7 @@ def all_pods
   pod 'Firebase/Crashlytics', '8.7.0'
   pod 'Firebase/RemoteConfig', '8.7.0'
 
-  pod 'YandexMobileMetrica/Dynamic', '3.15.1'
+  pod 'YandexMobileMetrica/Dynamic', '3.17.0'
   pod 'Amplitude', '8.3.1'
   pod 'Branch', '1.39.3'
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -201,11 +201,11 @@ PODS:
   - TUSafariActivity (1.0.4)
   - URITemplate (3.0.0)
   - VK-ios-sdk (1.6.2)
-  - YandexMobileMetrica/Dynamic (3.15.1):
-    - YandexMobileMetrica/Dynamic/Core (= 3.15.1)
-    - YandexMobileMetrica/Dynamic/Crashes (= 3.15.1)
-  - YandexMobileMetrica/Dynamic/Core (3.15.1)
-  - YandexMobileMetrica/Dynamic/Crashes (3.15.1):
+  - YandexMobileMetrica/Dynamic (3.17.0):
+    - YandexMobileMetrica/Dynamic/Core (= 3.17.0)
+    - YandexMobileMetrica/Dynamic/Crashes (= 3.17.0)
+  - YandexMobileMetrica/Dynamic/Core (3.17.0)
+  - YandexMobileMetrica/Dynamic/Crashes (3.17.0):
     - YandexMobileMetrica/Dynamic/Core
 
 DEPENDENCIES:
@@ -253,7 +253,7 @@ DEPENDENCIES:
   - TTTAttributedLabel (= 2.0.0)
   - TUSafariActivity (= 1.0.4)
   - VK-ios-sdk (= 1.6.2)
-  - YandexMobileMetrica/Dynamic (= 3.15.1)
+  - YandexMobileMetrica/Dynamic (= 3.17.0)
 
 SPEC REPOS:
   https://github.com/CocoaPods/Specs.git:
@@ -411,8 +411,8 @@ SPEC CHECKSUMS:
   TUSafariActivity: afc55a00965377939107ce4fdc7f951f62454546
   URITemplate: 58e0d47f967006c5d59888af5356c4a8ed3b197d
   VK-ios-sdk: 5bcf00a2014a7323f98db9328b603d4f96635caa
-  YandexMobileMetrica: fb4b3c20a0c0237b03b34cc07b6d575332f43097
+  YandexMobileMetrica: 9e713c16bb6aca0ba63b84c8d7b8b86d32f4ecc4
 
-PODFILE CHECKSUM: 5e56c08aaff44c25bad9b4c603b230c19c8f9aa7
+PODFILE CHECKSUM: 55ed750956baf820114531709f1e0c7623cd1fe4
 
 COCOAPODS: 1.11.2

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -192,7 +192,7 @@ PODS:
     - CocoaLumberjack (~> 3.0)
   - SVProgressHUD (2.2.5)
   - SwiftDate (6.3.1)
-  - SwiftLint (0.43.1)
+  - SwiftLint (0.44.0)
   - SwiftyGif (5.4.0)
   - SwiftyJSON (5.0.0)
   - Tabman (2.10.0):
@@ -247,7 +247,7 @@ DEPENDENCIES:
   - SVGKit (from `https://github.com/SVGKit/SVGKit.git`, branch `2.x`)
   - SVProgressHUD (= 2.2.5)
   - SwiftDate (= 6.3.1)
-  - SwiftLint (= 0.43.1)
+  - SwiftLint (= 0.44.0)
   - SwiftyJSON (= 5.0.0)
   - Tabman (= 2.10.0)
   - TTTAttributedLabel (= 2.0.0)
@@ -403,7 +403,7 @@ SPEC CHECKSUMS:
   SVGKit: 8a2fc74258bdb2abb54d3b65f3dd68b0277a9c4d
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
   SwiftDate: 72d28954e8e1c6c1c0f917ccc8005e4f83c7d4b2
-  SwiftLint: 99f82d07b837b942dd563c668de129a03fc3fb52
+  SwiftLint: e96c0a8c770c7ebbc4d36c55baf9096bb65c4584
   SwiftyGif: 5d4af95df24caf1c570dbbcb32a3b8a0763bc6d7
   SwiftyJSON: 36413e04c44ee145039d332b4f4e2d3e8d6c4db7
   Tabman: d8d6ab0b483c7db375a71ac227d3ef791b56a049
@@ -413,6 +413,6 @@ SPEC CHECKSUMS:
   VK-ios-sdk: 5bcf00a2014a7323f98db9328b603d4f96635caa
   YandexMobileMetrica: fb4b3c20a0c0237b03b34cc07b6d575332f43097
 
-PODFILE CHECKSUM: e357018f7138c314a01b9218c3d75b979f657e3c
+PODFILE CHECKSUM: 4c658b152a4d562b37dd4446e778e05b17245134
 
 COCOAPODS: 1.11.2

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -18,7 +18,7 @@ PODS:
   - CocoaLumberjack (3.7.2):
     - CocoaLumberjack/Core (= 3.7.2)
   - CocoaLumberjack/Core (3.7.2)
-  - DeviceKit (4.4.0)
+  - DeviceKit (4.5.0)
   - DownloadButton (0.1.0)
   - EasyTipView (2.1.0)
   - FBSDKCoreKit (8.2.0):
@@ -217,7 +217,7 @@ DEPENDENCIES:
   - BEMCheckBox (= 1.4.1)
   - Branch (= 1.39.3)
   - Charts (= 3.6.0)
-  - DeviceKit (= 4.4.0)
+  - DeviceKit (= 4.5.0)
   - DownloadButton (= 0.1.0)
   - EasyTipView (= 2.1.0)
   - FBSDKCoreKit (= 8.2.0)
@@ -360,7 +360,7 @@ SPEC CHECKSUMS:
   Branch: 13df8e1a6985745a03389146df1eeda723645a97
   Charts: b1e3a1f5a1c9ba5394438ca3b91bd8c9076310af
   CocoaLumberjack: b7e05132ff94f6ae4dfa9d5bce9141893a21d9da
-  DeviceKit: 2c5d7485a2fa10b65c0091b2952d30843a6ba06d
+  DeviceKit: b68cded46afdaefc5d2253d631d441ba7049a7fe
   DownloadButton: 49a21a89e0d7d1b42d9134f79aaa40e727cd57c3
   EasyTipView: a92b6edc377b81c5ac18e9fd35d5ee78e9409488
   FBSDKCoreKit: 4afd6ff53d8133a433dbcda44451c9498f8c6ce4
@@ -413,6 +413,6 @@ SPEC CHECKSUMS:
   VK-ios-sdk: 5bcf00a2014a7323f98db9328b603d4f96635caa
   YandexMobileMetrica: fb4b3c20a0c0237b03b34cc07b6d575332f43097
 
-PODFILE CHECKSUM: d0de1a76d431a90bc012d23be042bea3c5284d8a
+PODFILE CHECKSUM: e357018f7138c314a01b9218c3d75b979f657e3c
 
 COCOAPODS: 1.11.2

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -3,7 +3,7 @@ PODS:
   - Agrume (5.6.13):
     - SwiftyGif
   - Alamofire (5.4.3)
-  - Amplitude (8.3.0)
+  - Amplitude (8.3.1)
   - AppAuth (1.4.0):
     - AppAuth/Core (= 1.4.0)
     - AppAuth/ExternalUserAgent (= 1.4.0)
@@ -212,7 +212,7 @@ DEPENDENCIES:
   - ActionSheetPicker-3.0 (= 2.7.1)
   - Agrume (= 5.6.13)
   - Alamofire (= 5.4.3)
-  - Amplitude (= 8.3.0)
+  - Amplitude (= 8.3.1)
   - Atributika (= 4.10.1)
   - BEMCheckBox (= 1.4.1)
   - Branch (= 1.39.3)
@@ -353,7 +353,7 @@ SPEC CHECKSUMS:
   ActionSheetPicker-3.0: 36da254b97a09ff89679ecb8b8510bd3e5bdc773
   Agrume: 21b96a1138abc0f890211bfcb12f8b1e3464b4c1
   Alamofire: e447a2774a40c996748296fa2c55112fdbbc42f9
-  Amplitude: 5627b4574e36d789a75c1656ba39b3278edf1ade
+  Amplitude: c25a44ad72b84e684fcf67c478c1fb5c95e286a3
   AppAuth: 31bcec809a638d7bd2f86ea8a52bd45f6e81e7c7
   Atributika: 47e778507cfb3cd2c996278b0285221a62e97d71
   BEMCheckBox: 5ba6e37ade3d3657b36caecc35c8b75c6c2b1a4e
@@ -413,6 +413,6 @@ SPEC CHECKSUMS:
   VK-ios-sdk: 5bcf00a2014a7323f98db9328b603d4f96635caa
   YandexMobileMetrica: fb4b3c20a0c0237b03b34cc07b6d575332f43097
 
-PODFILE CHECKSUM: a0a8c0be069dacc598c8ead23ec3af1dee45e7ac
+PODFILE CHECKSUM: 5e56c08aaff44c25bad9b4c603b230c19c8f9aa7
 
 COCOAPODS: 1.11.2

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -166,7 +166,7 @@ PODS:
     - nanopb/encode (= 2.30908.0)
   - nanopb/decode (2.30908.0)
   - nanopb/encode (2.30908.0)
-  - Nimble (9.2.0)
+  - Nimble (9.2.1)
   - Nuke (9.5.0)
   - Pageboy (3.6.2)
   - PanModal (1.2.7)
@@ -235,7 +235,7 @@ DEPENDENCIES:
   - Koloda (= 5.0.1)
   - lottie-ios (= 3.2.3)
   - Mockingjay (= 3.0.0-alpha.1)
-  - Nimble (= 9.2.0)
+  - Nimble (= 9.2.1)
   - Nuke (= 9.5.0)
   - PanModal (from `https://github.com/ivan-magda/PanModal.git`, branch `remove-presenting-appearance-transitions`)
   - Presentr (from `https://github.com/ivan-magda/Presentr.git`, tag `v1.9.1`)
@@ -388,7 +388,7 @@ SPEC CHECKSUMS:
   lottie-ios: c058aeafa76daa4cf64d773554bccc8385d0150e
   Mockingjay: 0f7c5aa49c7f1b95621cee3c79b557141f5a225c
   nanopb: a0ba3315591a9ae0a16a309ee504766e90db0c96
-  Nimble: 4f4a345c80b503b3ea13606a4f98405974ee4d0b
+  Nimble: e7e615c0335ee4bf5b0d786685451e62746117d5
   Nuke: 6f400a4ea957e09149ec335a3c6acdcc814d89e4
   Pageboy: cf121b9dd48c63f3f281b2a9ec93d02e0f23879b
   PanModal: 3e16ead1a907fb06f4df3f13492fd00149fa4974
@@ -413,6 +413,6 @@ SPEC CHECKSUMS:
   VK-ios-sdk: 5bcf00a2014a7323f98db9328b603d4f96635caa
   YandexMobileMetrica: fb4b3c20a0c0237b03b34cc07b6d575332f43097
 
-PODFILE CHECKSUM: 506e75d172f8c6d47d13a2b5355e6c64549fcad6
+PODFILE CHECKSUM: a0a8c0be069dacc598c8ead23ec3af1dee45e7ac
 
 COCOAPODS: 1.11.2

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -31,26 +31,26 @@ PODS:
     - FBSDKLoginKit/Login (= 8.2.0)
   - FBSDKLoginKit/Login (8.2.0):
     - FBSDKCoreKit (~> 8.2.0)
-  - Firebase/Analytics (8.6.0):
+  - Firebase/Analytics (8.7.0):
     - Firebase/Core
-  - Firebase/Core (8.6.0):
+  - Firebase/Core (8.7.0):
     - Firebase/CoreOnly
-    - FirebaseAnalytics (~> 8.6.0)
-  - Firebase/CoreOnly (8.6.0):
-    - FirebaseCore (= 8.6.0)
-  - Firebase/Crashlytics (8.6.0):
+    - FirebaseAnalytics (~> 8.7.0)
+  - Firebase/CoreOnly (8.7.0):
+    - FirebaseCore (= 8.7.0)
+  - Firebase/Crashlytics (8.7.0):
     - Firebase/CoreOnly
-    - FirebaseCrashlytics (~> 8.6.0)
-  - Firebase/Messaging (8.6.0):
+    - FirebaseCrashlytics (~> 8.7.0)
+  - Firebase/Messaging (8.7.0):
     - Firebase/CoreOnly
-    - FirebaseMessaging (~> 8.6.0)
-  - Firebase/RemoteConfig (8.6.0):
+    - FirebaseMessaging (~> 8.7.0)
+  - Firebase/RemoteConfig (8.7.0):
     - Firebase/CoreOnly
-    - FirebaseRemoteConfig (~> 8.6.0)
-  - FirebaseABTesting (8.6.0):
+    - FirebaseRemoteConfig (~> 8.7.0)
+  - FirebaseABTesting (8.7.0):
     - FirebaseCore (~> 8.0)
-  - FirebaseAnalytics (8.6.0):
-    - FirebaseAnalytics/AdIdSupport (= 8.6.0)
+  - FirebaseAnalytics (8.7.0):
+    - FirebaseAnalytics/AdIdSupport (= 8.7.0)
     - FirebaseCore (~> 8.0)
     - FirebaseInstallations (~> 8.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 7.4)
@@ -58,37 +58,37 @@ PODS:
     - GoogleUtilities/Network (~> 7.4)
     - "GoogleUtilities/NSData+zlib (~> 7.4)"
     - nanopb (~> 2.30908.0)
-  - FirebaseAnalytics/AdIdSupport (8.6.0):
+  - FirebaseAnalytics/AdIdSupport (8.7.0):
     - FirebaseCore (~> 8.0)
     - FirebaseInstallations (~> 8.0)
-    - GoogleAppMeasurement (= 8.6.0)
+    - GoogleAppMeasurement (= 8.7.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 7.4)
     - GoogleUtilities/MethodSwizzler (~> 7.4)
     - GoogleUtilities/Network (~> 7.4)
     - "GoogleUtilities/NSData+zlib (~> 7.4)"
     - nanopb (~> 2.30908.0)
-  - FirebaseCore (8.6.0):
+  - FirebaseCore (8.7.0):
     - FirebaseCoreDiagnostics (~> 8.0)
     - GoogleUtilities/Environment (~> 7.4)
     - GoogleUtilities/Logger (~> 7.4)
-  - FirebaseCoreDiagnostics (8.6.0):
+  - FirebaseCoreDiagnostics (8.7.0):
     - GoogleDataTransport (~> 9.0)
     - GoogleUtilities/Environment (~> 7.4)
     - GoogleUtilities/Logger (~> 7.4)
     - nanopb (~> 2.30908.0)
-  - FirebaseCrashlytics (8.6.0):
+  - FirebaseCrashlytics (8.7.0):
     - FirebaseCore (~> 8.0)
     - FirebaseInstallations (~> 8.0)
     - GoogleDataTransport (~> 9.0)
     - GoogleUtilities/Environment (~> 7.4)
     - nanopb (~> 2.30908.0)
     - PromisesObjC (< 3.0, >= 1.2)
-  - FirebaseInstallations (8.6.0):
+  - FirebaseInstallations (8.7.0):
     - FirebaseCore (~> 8.0)
     - GoogleUtilities/Environment (~> 7.4)
     - GoogleUtilities/UserDefaults (~> 7.4)
     - PromisesObjC (< 3.0, >= 1.2)
-  - FirebaseMessaging (8.6.0):
+  - FirebaseMessaging (8.7.0):
     - FirebaseCore (~> 8.0)
     - FirebaseInstallations (~> 8.0)
     - GoogleDataTransport (~> 9.0)
@@ -97,21 +97,21 @@ PODS:
     - GoogleUtilities/Reachability (~> 7.4)
     - GoogleUtilities/UserDefaults (~> 7.4)
     - nanopb (~> 2.30908.0)
-  - FirebaseRemoteConfig (8.6.0):
+  - FirebaseRemoteConfig (8.7.0):
     - FirebaseABTesting (~> 8.0)
     - FirebaseCore (~> 8.0)
     - FirebaseInstallations (~> 8.0)
     - GoogleUtilities/Environment (~> 7.4)
     - "GoogleUtilities/NSData+zlib (~> 7.4)"
   - FLEX (4.4.1)
-  - GoogleAppMeasurement (8.6.0):
-    - GoogleAppMeasurement/AdIdSupport (= 8.6.0)
+  - GoogleAppMeasurement (8.7.0):
+    - GoogleAppMeasurement/AdIdSupport (= 8.7.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 7.4)
     - GoogleUtilities/MethodSwizzler (~> 7.4)
     - GoogleUtilities/Network (~> 7.4)
     - "GoogleUtilities/NSData+zlib (~> 7.4)"
     - nanopb (~> 2.30908.0)
-  - GoogleAppMeasurement/AdIdSupport (8.6.0):
+  - GoogleAppMeasurement/AdIdSupport (8.7.0):
     - GoogleUtilities/AppDelegateSwizzler (~> 7.4)
     - GoogleUtilities/MethodSwizzler (~> 7.4)
     - GoogleUtilities/Network (~> 7.4)
@@ -125,24 +125,24 @@ PODS:
     - AppAuth (~> 1.2)
     - GTMAppAuth (~> 1.0)
     - GTMSessionFetcher/Core (~> 1.1)
-  - GoogleUtilities/AppDelegateSwizzler (7.5.1):
+  - GoogleUtilities/AppDelegateSwizzler (7.5.2):
     - GoogleUtilities/Environment
     - GoogleUtilities/Logger
     - GoogleUtilities/Network
-  - GoogleUtilities/Environment (7.5.1):
+  - GoogleUtilities/Environment (7.5.2):
     - PromisesObjC (< 3.0, >= 1.2)
-  - GoogleUtilities/Logger (7.5.1):
+  - GoogleUtilities/Logger (7.5.2):
     - GoogleUtilities/Environment
-  - GoogleUtilities/MethodSwizzler (7.5.1):
+  - GoogleUtilities/MethodSwizzler (7.5.2):
     - GoogleUtilities/Logger
-  - GoogleUtilities/Network (7.5.1):
+  - GoogleUtilities/Network (7.5.2):
     - GoogleUtilities/Logger
     - "GoogleUtilities/NSData+zlib"
     - GoogleUtilities/Reachability
-  - "GoogleUtilities/NSData+zlib (7.5.1)"
-  - GoogleUtilities/Reachability (7.5.1):
+  - "GoogleUtilities/NSData+zlib (7.5.2)"
+  - GoogleUtilities/Reachability (7.5.2):
     - GoogleUtilities/Logger
-  - GoogleUtilities/UserDefaults (7.5.1):
+  - GoogleUtilities/UserDefaults (7.5.2):
     - GoogleUtilities/Logger
   - GTMAppAuth (1.2.2):
     - AppAuth/Core (~> 1.4)
@@ -222,11 +222,11 @@ DEPENDENCIES:
   - EasyTipView (= 2.1.0)
   - FBSDKCoreKit (= 8.2.0)
   - FBSDKLoginKit (= 8.2.0)
-  - Firebase/Analytics (= 8.6.0)
-  - Firebase/Core (= 8.6.0)
-  - Firebase/Crashlytics (= 8.6.0)
-  - Firebase/Messaging (= 8.6.0)
-  - Firebase/RemoteConfig (= 8.6.0)
+  - Firebase/Analytics (= 8.7.0)
+  - Firebase/Core (= 8.7.0)
+  - Firebase/Crashlytics (= 8.7.0)
+  - Firebase/Messaging (= 8.7.0)
+  - Firebase/RemoteConfig (= 8.7.0)
   - FLEX (from `https://github.com/ivan-magda/FLEX.git`, branch `master`)
   - GoogleSignIn (= 5.0.2)
   - Highlightr (from `https://github.com/ivan-magda/Highlightr.git`, tag `v2.1.3`)
@@ -365,20 +365,20 @@ SPEC CHECKSUMS:
   EasyTipView: a92b6edc377b81c5ac18e9fd35d5ee78e9409488
   FBSDKCoreKit: 4afd6ff53d8133a433dbcda44451c9498f8c6ce4
   FBSDKLoginKit: 7181765f2524d7ebf82d9629066c8e6caafc99d0
-  Firebase: 21ac9f28b09a8bdfc005f34c984fca84e7e8786d
-  FirebaseABTesting: c3e48ebf5e7e5c674c5a131c68e941d7921d83dc
-  FirebaseAnalytics: 8f32ae54ad42754f503354782575c4ddfc1425c3
-  FirebaseCore: 620b677f70f5470a8e59cb77f3ddc666f6f09785
-  FirebaseCoreDiagnostics: 3721920bde3a9a6d5aa093c1d25e9d3e47f694af
-  FirebaseCrashlytics: 58f8ecea7c799c61c50e8111d2e438424a8a1d2e
-  FirebaseInstallations: 0ede6ffcd215b8f93c19d9b06c1c54e2d4107e98
-  FirebaseMessaging: ce0a5ee974f7bfe83b6cc5acce88c2d969e37c41
-  FirebaseRemoteConfig: 9ee4672d4eacf646256e26cfac61021b3a390ea4
+  Firebase: bc9325d5ee2041524bac78a5213d0e530c651309
+  FirebaseABTesting: 5a72ea0e88422f9e223614cb4016cafffb2af8d1
+  FirebaseAnalytics: 52768800c2add1d84b751420cb4caaf8195f2c41
+  FirebaseCore: f4804c1d3f4bbbefc88904d15653038f2c99ddf7
+  FirebaseCoreDiagnostics: b63732f581a1c6a453ec7241f9ab60b3a5bd3450
+  FirebaseCrashlytics: 6fac03d1eef054833b71c929c93ab95c12989728
+  FirebaseInstallations: ede6fb72bb6337914e5888b399271259d0c4910c
+  FirebaseMessaging: 93227dd71d7888e200baef65043f81acb2b6596e
+  FirebaseRemoteConfig: 34300dd83055c06e2768d0932dd8fb2c1575745f
   FLEX: 75ca95cff4bd57592c6e75adee7651ace29f9c25
-  GoogleAppMeasurement: 2c0c6e2a7ab3fe730ade6379f732bdefb46f50b0
+  GoogleAppMeasurement: 2be61ce546ad074dbe4dd545f222ac6033bb1d9e
   GoogleDataTransport: 85fd18ff3019bb85d3f2c551d04c481dedf71fc9
   GoogleSignIn: 7137d297ddc022a7e0aa4619c86d72c909fa7213
-  GoogleUtilities: 3df19e3c24f7bbc291d8b5809aa6b0d41e642437
+  GoogleUtilities: 8de2a97a17e15b6b98e38e8770e2d129a57c0040
   GTMAppAuth: ad5c2b70b9a8689e1a04033c9369c4915bfcbe89
   GTMSessionFetcher: b3503b20a988c4e20cc189aa798fd18220133f52
   Highlightr: 9ff3790aef1a6c17a0181fa9f5b04f3f94def75a
@@ -413,6 +413,6 @@ SPEC CHECKSUMS:
   VK-ios-sdk: 5bcf00a2014a7323f98db9328b603d4f96635caa
   YandexMobileMetrica: fb4b3c20a0c0237b03b34cc07b6d575332f43097
 
-PODFILE CHECKSUM: 4c658b152a4d562b37dd4446e778e05b17245134
+PODFILE CHECKSUM: 506e75d172f8c6d47d13a2b5355e6c64549fcad6
 
 COCOAPODS: 1.11.2

--- a/Stepic.xcodeproj/project.pbxproj
+++ b/Stepic.xcodeproj/project.pbxproj
@@ -10402,8 +10402,6 @@
 				"${BUILT_PRODUCTS_DIR}/TUSafariActivity/TUSafariActivity.framework",
 				"${BUILT_PRODUCTS_DIR}/Tabman/Tabman.framework",
 				"${BUILT_PRODUCTS_DIR}/VK-ios-sdk/VK_ios_sdk.framework",
-				"${PODS_ROOT}/YandexMobileMetrica/ios/dynamic/YandexMobileMetrica.framework",
-				"${PODS_ROOT}/YandexMobileMetrica/ios/dynamic/YandexMobileMetricaCrashes.framework",
 				"${BUILT_PRODUCTS_DIR}/lottie-ios/Lottie.framework",
 				"${BUILT_PRODUCTS_DIR}/nanopb/nanopb.framework",
 				"${BUILT_PRODUCTS_DIR}/pop/pop.framework",
@@ -10411,6 +10409,8 @@
 				"${BUILT_PRODUCTS_DIR}/Nimble/Nimble.framework",
 				"${BUILT_PRODUCTS_DIR}/Quick/Quick.framework",
 				"${BUILT_PRODUCTS_DIR}/URITemplate/URITemplate.framework",
+				"${PODS_XCFRAMEWORKS_BUILD_DIR}/YandexMobileMetrica/Dynamic/Core/YandexMobileMetrica.framework/YandexMobileMetrica",
+				"${PODS_XCFRAMEWORKS_BUILD_DIR}/YandexMobileMetrica/Dynamic/Crashes/YandexMobileMetricaCrashes.framework/YandexMobileMetricaCrashes",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
@@ -10463,8 +10463,6 @@
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/TUSafariActivity.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Tabman.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/VK_ios_sdk.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/YandexMobileMetrica.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/YandexMobileMetricaCrashes.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Lottie.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/nanopb.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/pop.framework",
@@ -10472,6 +10470,8 @@
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Nimble.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Quick.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/URITemplate.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/YandexMobileMetrica.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/YandexMobileMetricaCrashes.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -10534,11 +10534,11 @@
 				"${BUILT_PRODUCTS_DIR}/TUSafariActivity/TUSafariActivity.framework",
 				"${BUILT_PRODUCTS_DIR}/Tabman/Tabman.framework",
 				"${BUILT_PRODUCTS_DIR}/VK-ios-sdk/VK_ios_sdk.framework",
-				"${PODS_ROOT}/YandexMobileMetrica/ios/dynamic/YandexMobileMetrica.framework",
-				"${PODS_ROOT}/YandexMobileMetrica/ios/dynamic/YandexMobileMetricaCrashes.framework",
 				"${BUILT_PRODUCTS_DIR}/lottie-ios/Lottie.framework",
 				"${BUILT_PRODUCTS_DIR}/nanopb/nanopb.framework",
 				"${BUILT_PRODUCTS_DIR}/pop/pop.framework",
+				"${PODS_XCFRAMEWORKS_BUILD_DIR}/YandexMobileMetrica/Dynamic/Core/YandexMobileMetrica.framework/YandexMobileMetrica",
+				"${PODS_XCFRAMEWORKS_BUILD_DIR}/YandexMobileMetrica/Dynamic/Crashes/YandexMobileMetricaCrashes.framework/YandexMobileMetricaCrashes",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
@@ -10591,11 +10591,11 @@
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/TUSafariActivity.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Tabman.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/VK_ios_sdk.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/YandexMobileMetrica.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/YandexMobileMetricaCrashes.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Lottie.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/nanopb.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/pop.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/YandexMobileMetrica.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/YandexMobileMetricaCrashes.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/Stepic/Sources/Frameworks/ContentProcessor/View/ProcessedContentView.swift
+++ b/Stepic/Sources/Frameworks/ContentProcessor/View/ProcessedContentView.swift
@@ -100,7 +100,7 @@ final class ProcessedContentView: UIView {
     private var didSetupTextView = false
     private var didSetupWebView = false
 
-    var processedContent: ProcessedContent? = nil {
+    var processedContent: ProcessedContent? {
         didSet {
             if oldValue == self.processedContent {
                 return

--- a/Stepic/Sources/Modules/Discussions/Views/Cells/Discussion/DiscussionsTableViewCell.swift
+++ b/Stepic/Sources/Modules/Discussions/Views/Cells/Discussion/DiscussionsTableViewCell.swift
@@ -234,7 +234,7 @@ final class DiscussionsTableViewCell: UITableViewCell, Reusable {
     private func updateSeparator(newStyle style: ViewModel.SeparatorStyle) {
         self.separatorStyle = style
         self.separatorHeightConstraint?.update(offset: style.height)
-        self.separatorView.isHidden = style == .none
+        self.separatorView.isHidden = style == .empty
         self.separatorView.backgroundColor = style.color
     }
 
@@ -263,7 +263,7 @@ final class DiscussionsTableViewCell: UITableViewCell, Reusable {
         enum SeparatorStyle {
             case small
             case large
-            case none
+            case empty
 
             var height: CGFloat {
                 switch self {
@@ -271,7 +271,7 @@ final class DiscussionsTableViewCell: UITableViewCell, Reusable {
                     return 1
                 case .large:
                     return 4
-                case .none:
+                case .empty:
                     return 0
                 }
             }
@@ -288,7 +288,7 @@ final class DiscussionsTableViewCell: UITableViewCell, Reusable {
                         light: UIColor.black.withAlphaComponent(0.04),
                         dark: .stepikSeparator
                     )
-                case .none:
+                case .empty:
                     return .clear
                 }
             }

--- a/Stepic/Sources/Modules/Discussions/Views/TableViewDataSource/DiscussionsTableViewDataSource.swift
+++ b/Stepic/Sources/Modules/Discussions/Views/TableViewDataSource/DiscussionsTableViewDataSource.swift
@@ -173,7 +173,7 @@ extension DiscussionsTableViewDataSource: UITableViewDataSource {
         let separatorStyle: DiscussionsTableViewCell.ViewModel.SeparatorStyle = {
             if indexPath.row == tableView.numberOfRows(inSection: indexPath.section) - 1 {
                 if discussionViewModel.repliesLeftToLoadCount > 0 {
-                    return .none
+                    return .empty
                 } else if indexPath.section == tableView.numberOfSections - 1 {
                     return .small
                 }


### PR DESCRIPTION
Bumps:
- [DeviceKit](https://github.com/devicekit/DeviceKit) from 4.4.0 to 4.5.0
- [SwiftLint](https://github.com/realm/SwiftLint) from 0.43.1 to 0.44.0
- [Firebase](https://github.com/firebase/firebase-ios-sdk) from 8.6.0 to 8.7.0
- [Nimble](https://github.com/Quick/Nimble) from 9.2.0 to 9.2.1
- [Amplitude](https://github.com/amplitude/Amplitude-iOS) from 8.3.0 to 8.3.1
- [YandexMobileMetrica](https://github.com/yandexmobile/metrica-sdk-ios) from 3.15.1 to 3.17.0