### PR TITLE
Fix lesson navigation unavailable when presented from course search

### DIFF
--- a/Stepic/Legacy/Model/Entities/SearchResult/SearchResult.swift
+++ b/Stepic/Legacy/Model/Entities/SearchResult/SearchResult.swift
@@ -44,6 +44,7 @@ extension SearchResult {
             courseTitle: self.courseTitle,
             courseCoverURL: self.courseCover,
             sectionPosition: self.lesson?.unit?.section?.position,
+            unitID: self.lesson?.unit?.id,
             unitPosition: self.lesson?.unit?.position,
             unitProgress: unitProgress,
             lessonID: self.lessonID,

--- a/Stepic/Legacy/Model/PlainObjects/SearchResult/SearchResultPlainObject.swift
+++ b/Stepic/Legacy/Model/PlainObjects/SearchResult/SearchResultPlainObject.swift
@@ -17,6 +17,7 @@ struct SearchResultPlainObject {
 
     var sectionPosition: Int?
 
+    var unitID: Int?
     var unitPosition: Int?
     var unitProgress: ProgressPlainObject?
 

--- a/Stepic/Sources/Modules/CourseSearch/CourseSearchDataFlow.swift
+++ b/Stepic/Sources/Modules/CourseSearch/CourseSearchDataFlow.swift
@@ -139,11 +139,13 @@ enum CourseSearch {
     /// Show lesson
     enum LessonPresentation {
         struct Response {
+            let unitID: Unit.IdType?
             let lessonID: Lesson.IdType
             let stepID: Step.IdType?
         }
 
         struct ViewModel {
+            let unitID: Unit.IdType?
             let lessonID: Lesson.IdType
             let stepID: Step.IdType?
         }

--- a/Stepic/Sources/Modules/CourseSearch/CourseSearchInteractor.swift
+++ b/Stepic/Sources/Modules/CourseSearch/CourseSearchInteractor.swift
@@ -227,10 +227,12 @@ final class CourseSearchInteractor: CourseSearchInteractorProtocol {
             )
         )
 
+        let unitID = targetSearchResult.unitID
+
         if targetSearchResult.isLesson {
-            self.presenter.presentLesson(response: .init(lessonID: lessonID, stepID: nil))
+            self.presenter.presentLesson(response: .init(unitID: unitID, lessonID: lessonID, stepID: nil))
         } else if let stepID = targetSearchResult.stepID {
-            self.presenter.presentLesson(response: .init(lessonID: lessonID, stepID: stepID))
+            self.presenter.presentLesson(response: .init(unitID: unitID, lessonID: lessonID, stepID: stepID))
         }
     }
 

--- a/Stepic/Sources/Modules/CourseSearch/CourseSearchPresenter.swift
+++ b/Stepic/Sources/Modules/CourseSearch/CourseSearchPresenter.swift
@@ -109,7 +109,9 @@ final class CourseSearchPresenter: CourseSearchPresenterProtocol {
     }
 
     func presentLesson(response: CourseSearch.LessonPresentation.Response) {
-        self.viewController?.displayLesson(viewModel: .init(lessonID: response.lessonID, stepID: response.stepID))
+        self.viewController?.displayLesson(
+            viewModel: .init(unitID: response.unitID, lessonID: response.lessonID, stepID: response.stepID)
+        )
     }
 
     func presentLoadingState(response: CourseSearch.LoadingStatePresentation.Response) {

--- a/Stepic/Sources/Modules/CourseSearch/CourseSearchViewController.swift
+++ b/Stepic/Sources/Modules/CourseSearch/CourseSearchViewController.swift
@@ -215,6 +215,12 @@ extension CourseSearchViewController: CourseSearchViewControllerProtocol {
     }
 
     func displayLesson(viewModel: CourseSearch.LessonPresentation.ViewModel) {
+        let initialContext: LessonDataFlow.Context = {
+            if let unitID = viewModel.unitID {
+                return .unit(id: unitID)
+            }
+            return .lesson(id: viewModel.lessonID)
+        }()
         let startStep: LessonDataFlow.StartStep = {
             if let stepID = viewModel.stepID {
                 return .id(stepID)
@@ -223,7 +229,7 @@ extension CourseSearchViewController: CourseSearchViewControllerProtocol {
         }()
 
         let assembly = LessonAssembly(
-            initialContext: .lesson(id: viewModel.lessonID),
+            initialContext: initialContext,
             startStep: startStep,
             moduleOutput: nil
         )


### PR DESCRIPTION
**YouTrack task**: [#APPS-3472](https://vyahhi.myjetbrains.com/youtrack/issue/APPS-3472)

**Description**:
- Fixes lesson navigation unavailable when presented from course search by updating `initialContext`.