### PR TITLE
Update dependencies 1.201

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -43,11 +43,11 @@ def all_pods
   pod 'SnapKit', '5.0.1'
 
   # Firebase
-  pod 'Firebase/Core', '8.8.0'
-  pod 'Firebase/Messaging', '8.8.0'
-  pod 'Firebase/Analytics', '8.8.0'
-  pod 'Firebase/Crashlytics', '8.8.0'
-  pod 'Firebase/RemoteConfig', '8.8.0'
+  pod 'Firebase/Core', '8.9.1'
+  pod 'Firebase/Messaging', '8.9.1'
+  pod 'Firebase/Analytics', '8.9.1'
+  pod 'Firebase/Crashlytics', '8.9.1'
+  pod 'Firebase/RemoteConfig', '8.9.1'
 
   pod 'YandexMobileMetrica/Dynamic', '3.17.0'
   pod 'Amplitude', '8.5.0'

--- a/Podfile
+++ b/Podfile
@@ -18,7 +18,7 @@ def shared_pods
   pod 'SwiftyJSON', '5.0.0'
   pod 'SDWebImage', '5.12.1'
   pod 'SVGKit', :git => 'https://github.com/SVGKit/SVGKit.git', :branch => '2.x'
-  pod 'DeviceKit', '4.5.1'
+  pod 'DeviceKit', '4.5.2'
   pod 'PromiseKit', '6.15.3'
   pod 'SwiftLint', '0.45.0'
 

--- a/Podfile
+++ b/Podfile
@@ -51,7 +51,7 @@ def all_pods
 
   pod 'YandexMobileMetrica/Dynamic', '3.17.0'
   pod 'Amplitude', '8.5.0'
-  pod 'Branch', '1.40.1'
+  pod 'Branch', '1.40.2'
 
   pod 'BEMCheckBox', '1.4.1'
 

--- a/Podfile
+++ b/Podfile
@@ -19,7 +19,7 @@ def shared_pods
   pod 'SDWebImage', '5.12.1'
   pod 'SVGKit', :git => 'https://github.com/SVGKit/SVGKit.git', :branch => '2.x'
   pod 'DeviceKit', '4.5.2'
-  pod 'PromiseKit', '6.15.3'
+  pod 'PromiseKit', :git => 'https://github.com/mxcl/PromiseKit.git', :tag => '6.16.2'
   pod 'SwiftLint', '0.45.0'
 
   if ENV['FASTLANE_BETA_PROFILE'] == 'true'

--- a/Podfile
+++ b/Podfile
@@ -50,7 +50,7 @@ def all_pods
   pod 'Firebase/RemoteConfig', '8.8.0'
 
   pod 'YandexMobileMetrica/Dynamic', '3.17.0'
-  pod 'Amplitude', '8.4.0'
+  pod 'Amplitude', '8.5.0'
   pod 'Branch', '1.40.1'
 
   pod 'BEMCheckBox', '1.4.1'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -11,7 +11,7 @@ PODS:
   - AppAuth/ExternalUserAgent (1.4.0)
   - Atributika (4.10.1)
   - BEMCheckBox (1.4.1)
-  - Branch (1.40.1)
+  - Branch (1.40.2)
   - Charts (3.6.0):
     - Charts/Core (= 3.6.0)
   - Charts/Core (3.6.0)
@@ -222,7 +222,7 @@ DEPENDENCIES:
   - Amplitude (= 8.5.0)
   - Atributika (= 4.10.1)
   - BEMCheckBox (= 1.4.1)
-  - Branch (= 1.40.1)
+  - Branch (= 1.40.2)
   - Charts (= 3.6.0)
   - DeviceKit (= 4.5.2)
   - DownloadButton (= 0.1.0)
@@ -374,7 +374,7 @@ SPEC CHECKSUMS:
   AppAuth: 31bcec809a638d7bd2f86ea8a52bd45f6e81e7c7
   Atributika: 47e778507cfb3cd2c996278b0285221a62e97d71
   BEMCheckBox: 5ba6e37ade3d3657b36caecc35c8b75c6c2b1a4e
-  Branch: e9cf368f79b6da7537fd1866b81037aec32ceb5b
+  Branch: c1b244bf1170b0ea5c5eefa897648de8d14ff0d2
   Charts: b1e3a1f5a1c9ba5394438ca3b91bd8c9076310af
   CocoaLumberjack: b7e05132ff94f6ae4dfa9d5bce9141893a21d9da
   DeviceKit: c622fc19f795f3e0b4d75d6d11b26604338cdab3
@@ -430,6 +430,6 @@ SPEC CHECKSUMS:
   VK-ios-sdk: 5bcf00a2014a7323f98db9328b603d4f96635caa
   YandexMobileMetrica: 9e713c16bb6aca0ba63b84c8d7b8b86d32f4ecc4
 
-PODFILE CHECKSUM: 093845ccc113e0353be828c404769590c55360bb
+PODFILE CHECKSUM: 91c5501d3a27c4d1d80ff880978ef3b8111e3b6d
 
 COCOAPODS: 1.11.2

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -18,7 +18,7 @@ PODS:
   - CocoaLumberjack (3.7.2):
     - CocoaLumberjack/Core (= 3.7.2)
   - CocoaLumberjack/Core (3.7.2)
-  - DeviceKit (4.5.1)
+  - DeviceKit (4.5.2)
   - DownloadButton (0.1.0)
   - EasyTipView (2.1.0)
   - FBSDKCoreKit (8.2.0):
@@ -224,7 +224,7 @@ DEPENDENCIES:
   - BEMCheckBox (= 1.4.1)
   - Branch (= 1.40.1)
   - Charts (= 3.6.0)
-  - DeviceKit (= 4.5.1)
+  - DeviceKit (= 4.5.2)
   - DownloadButton (= 0.1.0)
   - EasyTipView (= 2.1.0)
   - FBSDKCoreKit (= 8.2.0)
@@ -372,7 +372,7 @@ SPEC CHECKSUMS:
   Branch: e9cf368f79b6da7537fd1866b81037aec32ceb5b
   Charts: b1e3a1f5a1c9ba5394438ca3b91bd8c9076310af
   CocoaLumberjack: b7e05132ff94f6ae4dfa9d5bce9141893a21d9da
-  DeviceKit: 8664c09f619f53e48000b41ee3bb7573158a333b
+  DeviceKit: c622fc19f795f3e0b4d75d6d11b26604338cdab3
   DownloadButton: 49a21a89e0d7d1b42d9134f79aaa40e727cd57c3
   EasyTipView: a92b6edc377b81c5ac18e9fd35d5ee78e9409488
   FBSDKCoreKit: 4afd6ff53d8133a433dbcda44451c9498f8c6ce4
@@ -425,6 +425,6 @@ SPEC CHECKSUMS:
   VK-ios-sdk: 5bcf00a2014a7323f98db9328b603d4f96635caa
   YandexMobileMetrica: 9e713c16bb6aca0ba63b84c8d7b8b86d32f4ecc4
 
-PODFILE CHECKSUM: 5f0b0f4f3880254f033560044ac649d45562c5c9
+PODFILE CHECKSUM: bc5e3608914c1a5fdf846205bf74371b11d56463
 
 COCOAPODS: 1.11.2

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -31,98 +31,98 @@ PODS:
     - FBSDKLoginKit/Login (= 8.2.0)
   - FBSDKLoginKit/Login (8.2.0):
     - FBSDKCoreKit (~> 8.2.0)
-  - Firebase/Analytics (8.8.0):
+  - Firebase/Analytics (8.9.1):
     - Firebase/Core
-  - Firebase/Core (8.8.0):
+  - Firebase/Core (8.9.1):
     - Firebase/CoreOnly
-    - FirebaseAnalytics (~> 8.8.0)
-  - Firebase/CoreOnly (8.8.0):
-    - FirebaseCore (= 8.8.0)
-  - Firebase/Crashlytics (8.8.0):
+    - FirebaseAnalytics (~> 8.9.1)
+  - Firebase/CoreOnly (8.9.1):
+    - FirebaseCore (= 8.9.1)
+  - Firebase/Crashlytics (8.9.1):
     - Firebase/CoreOnly
-    - FirebaseCrashlytics (~> 8.8.0)
-  - Firebase/Messaging (8.8.0):
+    - FirebaseCrashlytics (~> 8.9.0)
+  - Firebase/Messaging (8.9.1):
     - Firebase/CoreOnly
-    - FirebaseMessaging (~> 8.8.0)
-  - Firebase/RemoteConfig (8.8.0):
+    - FirebaseMessaging (~> 8.9.0)
+  - Firebase/RemoteConfig (8.9.1):
     - Firebase/CoreOnly
-    - FirebaseRemoteConfig (~> 8.8.0)
-  - FirebaseABTesting (8.8.0):
+    - FirebaseRemoteConfig (~> 8.9.0)
+  - FirebaseABTesting (8.9.0):
     - FirebaseCore (~> 8.0)
-  - FirebaseAnalytics (8.8.0):
-    - FirebaseAnalytics/AdIdSupport (= 8.8.0)
-    - FirebaseCore (~> 8.0)
-    - FirebaseInstallations (~> 8.0)
-    - GoogleUtilities/AppDelegateSwizzler (~> 7.4)
-    - GoogleUtilities/MethodSwizzler (~> 7.4)
-    - GoogleUtilities/Network (~> 7.4)
-    - "GoogleUtilities/NSData+zlib (~> 7.4)"
-    - nanopb (~> 2.30908.0)
-  - FirebaseAnalytics/AdIdSupport (8.8.0):
+  - FirebaseAnalytics (8.9.1):
+    - FirebaseAnalytics/AdIdSupport (= 8.9.1)
     - FirebaseCore (~> 8.0)
     - FirebaseInstallations (~> 8.0)
-    - GoogleAppMeasurement (= 8.8.0)
-    - GoogleUtilities/AppDelegateSwizzler (~> 7.4)
-    - GoogleUtilities/MethodSwizzler (~> 7.4)
-    - GoogleUtilities/Network (~> 7.4)
-    - "GoogleUtilities/NSData+zlib (~> 7.4)"
+    - GoogleUtilities/AppDelegateSwizzler (~> 7.6)
+    - GoogleUtilities/MethodSwizzler (~> 7.6)
+    - GoogleUtilities/Network (~> 7.6)
+    - "GoogleUtilities/NSData+zlib (~> 7.6)"
     - nanopb (~> 2.30908.0)
-  - FirebaseCore (8.8.0):
+  - FirebaseAnalytics/AdIdSupport (8.9.1):
+    - FirebaseCore (~> 8.0)
+    - FirebaseInstallations (~> 8.0)
+    - GoogleAppMeasurement (= 8.9.1)
+    - GoogleUtilities/AppDelegateSwizzler (~> 7.6)
+    - GoogleUtilities/MethodSwizzler (~> 7.6)
+    - GoogleUtilities/Network (~> 7.6)
+    - "GoogleUtilities/NSData+zlib (~> 7.6)"
+    - nanopb (~> 2.30908.0)
+  - FirebaseCore (8.9.1):
     - FirebaseCoreDiagnostics (~> 8.0)
-    - GoogleUtilities/Environment (~> 7.4)
-    - GoogleUtilities/Logger (~> 7.4)
-  - FirebaseCoreDiagnostics (8.8.0):
-    - GoogleDataTransport (~> 9.0)
-    - GoogleUtilities/Environment (~> 7.4)
-    - GoogleUtilities/Logger (~> 7.4)
+    - GoogleUtilities/Environment (~> 7.6)
+    - GoogleUtilities/Logger (~> 7.6)
+  - FirebaseCoreDiagnostics (8.9.0):
+    - GoogleDataTransport (~> 9.1)
+    - GoogleUtilities/Environment (~> 7.6)
+    - GoogleUtilities/Logger (~> 7.6)
     - nanopb (~> 2.30908.0)
-  - FirebaseCrashlytics (8.8.0):
+  - FirebaseCrashlytics (8.9.0):
     - FirebaseCore (~> 8.0)
     - FirebaseInstallations (~> 8.0)
-    - GoogleDataTransport (~> 9.0)
-    - GoogleUtilities/Environment (~> 7.4)
+    - GoogleDataTransport (~> 9.1)
+    - GoogleUtilities/Environment (~> 7.6)
     - nanopb (~> 2.30908.0)
     - PromisesObjC (< 3.0, >= 1.2)
-  - FirebaseInstallations (8.8.0):
+  - FirebaseInstallations (8.9.0):
     - FirebaseCore (~> 8.0)
-    - GoogleUtilities/Environment (~> 7.4)
-    - GoogleUtilities/UserDefaults (~> 7.4)
+    - GoogleUtilities/Environment (~> 7.6)
+    - GoogleUtilities/UserDefaults (~> 7.6)
     - PromisesObjC (< 3.0, >= 1.2)
-  - FirebaseMessaging (8.8.0):
+  - FirebaseMessaging (8.9.0):
     - FirebaseCore (~> 8.0)
     - FirebaseInstallations (~> 8.0)
-    - GoogleDataTransport (~> 9.0)
-    - GoogleUtilities/AppDelegateSwizzler (~> 7.4)
-    - GoogleUtilities/Environment (~> 7.4)
-    - GoogleUtilities/Reachability (~> 7.4)
-    - GoogleUtilities/UserDefaults (~> 7.4)
+    - GoogleDataTransport (~> 9.1)
+    - GoogleUtilities/AppDelegateSwizzler (~> 7.6)
+    - GoogleUtilities/Environment (~> 7.6)
+    - GoogleUtilities/Reachability (~> 7.6)
+    - GoogleUtilities/UserDefaults (~> 7.6)
     - nanopb (~> 2.30908.0)
-  - FirebaseRemoteConfig (8.8.0):
+  - FirebaseRemoteConfig (8.9.0):
     - FirebaseABTesting (~> 8.0)
     - FirebaseCore (~> 8.0)
     - FirebaseInstallations (~> 8.0)
-    - GoogleUtilities/Environment (~> 7.4)
-    - "GoogleUtilities/NSData+zlib (~> 7.4)"
+    - GoogleUtilities/Environment (~> 7.6)
+    - "GoogleUtilities/NSData+zlib (~> 7.6)"
   - FLEX (4.4.1)
-  - GoogleAppMeasurement (8.8.0):
-    - GoogleAppMeasurement/AdIdSupport (= 8.8.0)
-    - GoogleUtilities/AppDelegateSwizzler (~> 7.4)
-    - GoogleUtilities/MethodSwizzler (~> 7.4)
-    - GoogleUtilities/Network (~> 7.4)
-    - "GoogleUtilities/NSData+zlib (~> 7.4)"
+  - GoogleAppMeasurement (8.9.1):
+    - GoogleAppMeasurement/AdIdSupport (= 8.9.1)
+    - GoogleUtilities/AppDelegateSwizzler (~> 7.6)
+    - GoogleUtilities/MethodSwizzler (~> 7.6)
+    - GoogleUtilities/Network (~> 7.6)
+    - "GoogleUtilities/NSData+zlib (~> 7.6)"
     - nanopb (~> 2.30908.0)
-  - GoogleAppMeasurement/AdIdSupport (8.8.0):
-    - GoogleAppMeasurement/WithoutAdIdSupport (= 8.8.0)
-    - GoogleUtilities/AppDelegateSwizzler (~> 7.4)
-    - GoogleUtilities/MethodSwizzler (~> 7.4)
-    - GoogleUtilities/Network (~> 7.4)
-    - "GoogleUtilities/NSData+zlib (~> 7.4)"
+  - GoogleAppMeasurement/AdIdSupport (8.9.1):
+    - GoogleAppMeasurement/WithoutAdIdSupport (= 8.9.1)
+    - GoogleUtilities/AppDelegateSwizzler (~> 7.6)
+    - GoogleUtilities/MethodSwizzler (~> 7.6)
+    - GoogleUtilities/Network (~> 7.6)
+    - "GoogleUtilities/NSData+zlib (~> 7.6)"
     - nanopb (~> 2.30908.0)
-  - GoogleAppMeasurement/WithoutAdIdSupport (8.8.0):
-    - GoogleUtilities/AppDelegateSwizzler (~> 7.4)
-    - GoogleUtilities/MethodSwizzler (~> 7.4)
-    - GoogleUtilities/Network (~> 7.4)
-    - "GoogleUtilities/NSData+zlib (~> 7.4)"
+  - GoogleAppMeasurement/WithoutAdIdSupport (8.9.1):
+    - GoogleUtilities/AppDelegateSwizzler (~> 7.6)
+    - GoogleUtilities/MethodSwizzler (~> 7.6)
+    - GoogleUtilities/Network (~> 7.6)
+    - "GoogleUtilities/NSData+zlib (~> 7.6)"
     - nanopb (~> 2.30908.0)
   - GoogleDataTransport (9.1.2):
     - GoogleUtilities/Environment (~> 7.2)
@@ -132,24 +132,24 @@ PODS:
     - AppAuth (~> 1.2)
     - GTMAppAuth (~> 1.0)
     - GTMSessionFetcher/Core (~> 1.1)
-  - GoogleUtilities/AppDelegateSwizzler (7.5.2):
+  - GoogleUtilities/AppDelegateSwizzler (7.6.0):
     - GoogleUtilities/Environment
     - GoogleUtilities/Logger
     - GoogleUtilities/Network
-  - GoogleUtilities/Environment (7.5.2):
+  - GoogleUtilities/Environment (7.6.0):
     - PromisesObjC (< 3.0, >= 1.2)
-  - GoogleUtilities/Logger (7.5.2):
+  - GoogleUtilities/Logger (7.6.0):
     - GoogleUtilities/Environment
-  - GoogleUtilities/MethodSwizzler (7.5.2):
+  - GoogleUtilities/MethodSwizzler (7.6.0):
     - GoogleUtilities/Logger
-  - GoogleUtilities/Network (7.5.2):
+  - GoogleUtilities/Network (7.6.0):
     - GoogleUtilities/Logger
     - "GoogleUtilities/NSData+zlib"
     - GoogleUtilities/Reachability
-  - "GoogleUtilities/NSData+zlib (7.5.2)"
-  - GoogleUtilities/Reachability (7.5.2):
+  - "GoogleUtilities/NSData+zlib (7.6.0)"
+  - GoogleUtilities/Reachability (7.6.0):
     - GoogleUtilities/Logger
-  - GoogleUtilities/UserDefaults (7.5.2):
+  - GoogleUtilities/UserDefaults (7.6.0):
     - GoogleUtilities/Logger
   - GTMAppAuth (1.2.2):
     - AppAuth/Core (~> 1.4)
@@ -229,11 +229,11 @@ DEPENDENCIES:
   - EasyTipView (= 2.1.0)
   - FBSDKCoreKit (= 8.2.0)
   - FBSDKLoginKit (= 8.2.0)
-  - Firebase/Analytics (= 8.8.0)
-  - Firebase/Core (= 8.8.0)
-  - Firebase/Crashlytics (= 8.8.0)
-  - Firebase/Messaging (= 8.8.0)
-  - Firebase/RemoteConfig (= 8.8.0)
+  - Firebase/Analytics (= 8.9.1)
+  - Firebase/Core (= 8.9.1)
+  - Firebase/Crashlytics (= 8.9.1)
+  - Firebase/Messaging (= 8.9.1)
+  - Firebase/RemoteConfig (= 8.9.1)
   - FLEX (from `https://github.com/ivan-magda/FLEX.git`, branch `master`)
   - GoogleSignIn (= 5.0.2)
   - Highlightr (from `https://github.com/ivan-magda/Highlightr.git`, tag `v2.1.3`)
@@ -382,20 +382,20 @@ SPEC CHECKSUMS:
   EasyTipView: a92b6edc377b81c5ac18e9fd35d5ee78e9409488
   FBSDKCoreKit: 4afd6ff53d8133a433dbcda44451c9498f8c6ce4
   FBSDKLoginKit: 7181765f2524d7ebf82d9629066c8e6caafc99d0
-  Firebase: 629510f1a9ddb235f3a7c5c8ceb23ba887f0f814
-  FirebaseABTesting: 981336dd14d84787e33466e4247f77ec2343f8d9
-  FirebaseAnalytics: 5506ea8b867d8423485a84b4cd612d279f7b0b8a
-  FirebaseCore: 98b29e3828f0a53651c363937a7f7d92a19f1ba2
-  FirebaseCoreDiagnostics: fe77f42da6329d6d83d21fd9d621a6b704413bfc
-  FirebaseCrashlytics: 3660c045c8e45cc4276110562a0ef44cf43c8157
-  FirebaseInstallations: 2563cb18a723ef9c6ef18318a49519b75dce613c
-  FirebaseMessaging: 419b5c9d84f294a753c6501d8cfb9ced1ce37304
-  FirebaseRemoteConfig: f6365883d7950d784ee97bcdbbf1e442d4fa6119
+  Firebase: fb5114cd2bf96e2ff7bcb01d0d9a156cf5fd2f07
+  FirebaseABTesting: 9de50b34bf9eb4a07d4edb7af82c14152fd905aa
+  FirebaseAnalytics: 4ab446ce08a3fe52e8a4303dd997cf26276bf968
+  FirebaseCore: c5aab092d9c4b8efea894946166b04c9d9ef0e68
+  FirebaseCoreDiagnostics: 5daa63f1c1409d981a2d5007daa100b36eac6a34
+  FirebaseCrashlytics: 40efbd81157dae307ec95612fa1328347284d2c2
+  FirebaseInstallations: caa7c8e0d3e2345b8829d2fa9ca1b4dfbf2fcc85
+  FirebaseMessaging: 82c4a48638f53f7b184f3cc9f6cd2cbe533ab316
+  FirebaseRemoteConfig: a75c1bd44ebd3ed4ad3fa1ff09414a8b133be405
   FLEX: 75ca95cff4bd57592c6e75adee7651ace29f9c25
-  GoogleAppMeasurement: 5ba1164e3c844ba84272555e916d0a6d3d977e91
+  GoogleAppMeasurement: 837649ad3987936c232f6717c5680216f6243d24
   GoogleDataTransport: 629c20a4d363167143f30ea78320d5a7eb8bd940
   GoogleSignIn: 7137d297ddc022a7e0aa4619c86d72c909fa7213
-  GoogleUtilities: 8de2a97a17e15b6b98e38e8770e2d129a57c0040
+  GoogleUtilities: 684ee790a24f73ebb2d1d966e9711c203f2a4237
   GTMAppAuth: ad5c2b70b9a8689e1a04033c9369c4915bfcbe89
   GTMSessionFetcher: 43748f93435c2aa068b1cbe39655aaf600652e91
   Highlightr: 9fbc57afd1921d274d5df911caabf91eaf25f0f3
@@ -430,6 +430,6 @@ SPEC CHECKSUMS:
   VK-ios-sdk: 5bcf00a2014a7323f98db9328b603d4f96635caa
   YandexMobileMetrica: 9e713c16bb6aca0ba63b84c8d7b8b86d32f4ecc4
 
-PODFILE CHECKSUM: 4a7940410b99b687e14b15e943d40da565d4d061
+PODFILE CHECKSUM: 093845ccc113e0353be828c404769590c55360bb
 
 COCOAPODS: 1.11.2

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -3,7 +3,7 @@ PODS:
   - Agrume (5.6.13):
     - SwiftyGif
   - Alamofire (5.4.4)
-  - Amplitude (8.4.0)
+  - Amplitude (8.5.0)
   - AppAuth (1.4.0):
     - AppAuth/Core (= 1.4.0)
     - AppAuth/ExternalUserAgent (= 1.4.0)
@@ -219,7 +219,7 @@ DEPENDENCIES:
   - ActionSheetPicker-3.0 (= 2.7.1)
   - Agrume (= 5.6.13)
   - Alamofire (= 5.4.4)
-  - Amplitude (= 8.4.0)
+  - Amplitude (= 8.5.0)
   - Atributika (= 4.10.1)
   - BEMCheckBox (= 1.4.1)
   - Branch (= 1.40.1)
@@ -365,7 +365,7 @@ SPEC CHECKSUMS:
   ActionSheetPicker-3.0: 36da254b97a09ff89679ecb8b8510bd3e5bdc773
   Agrume: 21b96a1138abc0f890211bfcb12f8b1e3464b4c1
   Alamofire: f3b09a368f1582ab751b3fff5460276e0d2cf5c9
-  Amplitude: d0e5cf12748455c3b95cd9375e4293c4bb95a6a4
+  Amplitude: ef9ed339ddd33c9183edf63fa4bbaa86cf873321
   AppAuth: 31bcec809a638d7bd2f86ea8a52bd45f6e81e7c7
   Atributika: 47e778507cfb3cd2c996278b0285221a62e97d71
   BEMCheckBox: 5ba6e37ade3d3657b36caecc35c8b75c6c2b1a4e
@@ -425,6 +425,6 @@ SPEC CHECKSUMS:
   VK-ios-sdk: 5bcf00a2014a7323f98db9328b603d4f96635caa
   YandexMobileMetrica: 9e713c16bb6aca0ba63b84c8d7b8b86d32f4ecc4
 
-PODFILE CHECKSUM: b3710e5ece056cbc0e2aa1c1bf1d7a9dcae8cdae
+PODFILE CHECKSUM: 5f0b0f4f3880254f033560044ac649d45562c5c9
 
 COCOAPODS: 1.11.2

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -179,14 +179,14 @@ PODS:
   - PanModal (1.2.7)
   - pop (1.0.12)
   - Presentr (1.9)
-  - PromiseKit (6.15.3):
-    - PromiseKit/CorePromise (= 6.15.3)
-    - PromiseKit/Foundation (= 6.15.3)
-    - PromiseKit/UIKit (= 6.15.3)
-  - PromiseKit/CorePromise (6.15.3)
-  - PromiseKit/Foundation (6.15.3):
+  - PromiseKit (6.16.1):
+    - PromiseKit/CorePromise (= 6.16.1)
+    - PromiseKit/Foundation (= 6.16.1)
+    - PromiseKit/UIKit (= 6.16.1)
+  - PromiseKit/CorePromise (6.16.1)
+  - PromiseKit/Foundation (6.16.1):
     - PromiseKit/CorePromise
-  - PromiseKit/UIKit (6.15.3):
+  - PromiseKit/UIKit (6.16.1):
     - PromiseKit/CorePromise
   - PromisesObjC (2.0.0)
   - Quick (4.0.0)
@@ -246,7 +246,7 @@ DEPENDENCIES:
   - Nuke (= 9.5.0)
   - PanModal (from `https://github.com/ivan-magda/PanModal.git`, branch `remove-presenting-appearance-transitions`)
   - Presentr (from `https://github.com/ivan-magda/Presentr.git`, tag `v1.9.1`)
-  - PromiseKit (= 6.15.3)
+  - PromiseKit (from `https://github.com/mxcl/PromiseKit.git`, tag `6.16.2`)
   - Quick (= 4.0.0)
   - SDWebImage (= 5.12.1)
   - SnapKit (= 5.0.1)
@@ -303,7 +303,6 @@ SPEC REPOS:
     - Nuke
     - Pageboy
     - pop
-    - PromiseKit
     - PromisesObjC
     - Quick
     - SDWebImage
@@ -337,6 +336,9 @@ EXTERNAL SOURCES:
   Presentr:
     :git: https://github.com/ivan-magda/Presentr.git
     :tag: v1.9.1
+  PromiseKit:
+    :git: https://github.com/mxcl/PromiseKit.git
+    :tag: 6.16.2
   SVGKit:
     :branch: 2.x
     :git: https://github.com/SVGKit/SVGKit.git
@@ -357,6 +359,9 @@ CHECKOUT OPTIONS:
   Presentr:
     :git: https://github.com/ivan-magda/Presentr.git
     :tag: v1.9.1
+  PromiseKit:
+    :git: https://github.com/mxcl/PromiseKit.git
+    :tag: 6.16.2
   SVGKit:
     :commit: c40671b9a264f8f71831c4e0452736debfae2164
     :git: https://github.com/SVGKit/SVGKit.git
@@ -406,7 +411,7 @@ SPEC CHECKSUMS:
   PanModal: 3e16ead1a907fb06f4df3f13492fd00149fa4974
   pop: d582054913807fd11fd50bfe6a539d91c7e1a55a
   Presentr: 931d50e158060ea88fbf8f3dd202b17e0bb53eb0
-  PromiseKit: 3b2b6995e51a954c46dbc550ce3da44fbfb563c5
+  PromiseKit: ad27b174e5d8587cf799888f5e738f88e17055d8
   PromisesObjC: 68159ce6952d93e17b2dfe273b8c40907db5ba58
   Quick: 6473349e43b9271a8d43839d9ba1c442ed1b7ac4
   SDWebImage: 4dc3e42d9ec0c1028b960a33ac6b637bb432207b
@@ -425,6 +430,6 @@ SPEC CHECKSUMS:
   VK-ios-sdk: 5bcf00a2014a7323f98db9328b603d4f96635caa
   YandexMobileMetrica: 9e713c16bb6aca0ba63b84c8d7b8b86d32f4ecc4
 
-PODFILE CHECKSUM: bc5e3608914c1a5fdf846205bf74371b11d56463
+PODFILE CHECKSUM: 4a7940410b99b687e14b15e943d40da565d4d061
 
 COCOAPODS: 1.11.2


### PR DESCRIPTION
Bumps:
- [Amplitude](https://github.com/amplitude/Amplitude-iOS) from 8.4.0 to 8.5.0
- [DeviceKit](https://github.com/devicekit/DeviceKit) from 4.5.1 to 4.5.2
- [PromiseKit](https://github.com/mxcl/PromiseKit) from 6.15.3 to 6.16.2
- [Firebase](https://github.com/firebase/firebase-ios-sdk) from 8.8.0 to 8.9.1
- [Branch](https://github.com/BranchMetrics/ios-branch-deep-linking-attribution) from 1.40.1 to 1.40.2