### PR TITLE
Update dependencies 1.206

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -20,7 +20,7 @@ def shared_pods
   pod 'SVGKit', :git => 'https://github.com/SVGKit/SVGKit.git', :branch => '2.x'
   pod 'DeviceKit', '4.5.2'
   pod 'PromiseKit', :git => 'https://github.com/mxcl/PromiseKit.git', :tag => '6.16.2'
-  pod 'SwiftLint', '0.45.0'
+  pod 'SwiftLint', '0.45.1'
 
   if ENV['FASTLANE_BETA_PROFILE'] == 'true'
     pod 'FLEX',

--- a/Podfile
+++ b/Podfile
@@ -16,7 +16,7 @@ def shared_pods
   pod 'Alamofire', '5.4.4'
   pod 'Atributika', '4.10.1'
   pod 'SwiftyJSON', '5.0.0'
-  pod 'SDWebImage', '5.12.1'
+  pod 'SDWebImage', '5.12.2'
   pod 'SVGKit', :git => 'https://github.com/SVGKit/SVGKit.git', :branch => '2.x'
   pod 'DeviceKit', '4.5.2'
   pod 'PromiseKit', :git => 'https://github.com/mxcl/PromiseKit.git', :tag => '6.16.2'

--- a/Podfile
+++ b/Podfile
@@ -77,7 +77,7 @@ def all_pods
   pod 'Charts', '3.6.0'
   pod 'EasyTipView', '2.1.0'
   pod 'ActionSheetPicker-3.0', '2.7.1'
-  pod 'Nuke', '9.5.0'
+  pod 'Nuke', '10.6.1'
   pod 'STRegex', '2.1.1'
   pod 'Tabman', '2.10.0'
   pod 'SwiftDate', '6.3.1'

--- a/Podfile
+++ b/Podfile
@@ -43,11 +43,11 @@ def all_pods
   pod 'SnapKit', '5.0.1'
 
   # Firebase
-  pod 'Firebase/Core', '8.9.1'
-  pod 'Firebase/Messaging', '8.9.1'
-  pod 'Firebase/Analytics', '8.9.1'
-  pod 'Firebase/Crashlytics', '8.9.1'
-  pod 'Firebase/RemoteConfig', '8.9.1'
+  pod 'Firebase/Core', '8.10.0'
+  pod 'Firebase/Messaging', '8.10.0'
+  pod 'Firebase/Analytics', '8.10.0'
+  pod 'Firebase/Crashlytics', '8.10.0'
+  pod 'Firebase/RemoteConfig', '8.10.0'
 
   pod 'YandexMobileMetrica/Dynamic', '3.17.0'
   pod 'Amplitude', '8.7.1'

--- a/Podfile
+++ b/Podfile
@@ -64,7 +64,7 @@ def all_pods
   pod 'VK-ios-sdk', '1.6.2'
   pod 'FBSDKCoreKit', '8.2.0'
   pod 'FBSDKLoginKit', '8.2.0'
-  pod 'GoogleSignIn', '5.0.2'
+  pod 'GoogleSignIn', '6.1.0'
 
   pod 'Presentr', :git => 'https://github.com/ivan-magda/Presentr.git', :tag => 'v1.9.1'
   pod 'PanModal', :git => 'https://github.com/ivan-magda/PanModal.git', :branch => 'remove-presenting-appearance-transitions'

--- a/Podfile
+++ b/Podfile
@@ -72,7 +72,7 @@ def all_pods
   pod 'Agrume', '5.6.13'
   pod 'Highlightr', :git => 'https://github.com/ivan-magda/Highlightr.git', :tag => 'v2.1.3'
   pod 'TTTAttributedLabel', '2.0.0'
-  pod 'lottie-ios', '3.2.3'
+  pod 'lottie-ios', '3.3.0'
   pod 'Koloda', '5.0.1'
   pod 'Charts', '3.6.0'
   pod 'EasyTipView', '2.1.0'

--- a/Podfile
+++ b/Podfile
@@ -50,7 +50,7 @@ def all_pods
   pod 'Firebase/RemoteConfig', '8.9.1'
 
   pod 'YandexMobileMetrica/Dynamic', '3.17.0'
-  pod 'Amplitude', '8.5.0'
+  pod 'Amplitude', '8.7.1'
   pod 'Branch', '1.40.2'
 
   pod 'BEMCheckBox', '1.4.1'

--- a/Podfile
+++ b/Podfile
@@ -13,7 +13,7 @@ project 'Stepic',
         'Develop Release' => :release
 
 def shared_pods
-  pod 'Alamofire', '5.4.4'
+  pod 'Alamofire', '5.5.0'
   pod 'Atributika', '4.10.1'
   pod 'SwiftyJSON', '5.0.0'
   pod 'SDWebImage', '5.12.2'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -199,7 +199,7 @@ PODS:
     - CocoaLumberjack (~> 3.0)
   - SVProgressHUD (2.2.5)
   - SwiftDate (6.3.1)
-  - SwiftLint (0.45.0)
+  - SwiftLint (0.45.1)
   - SwiftyGif (5.4.0)
   - SwiftyJSON (5.0.0)
   - Tabman (2.10.0):
@@ -254,7 +254,7 @@ DEPENDENCIES:
   - SVGKit (from `https://github.com/SVGKit/SVGKit.git`, branch `2.x`)
   - SVProgressHUD (= 2.2.5)
   - SwiftDate (= 6.3.1)
-  - SwiftLint (= 0.45.0)
+  - SwiftLint (= 0.45.1)
   - SwiftyJSON (= 5.0.0)
   - Tabman (= 2.10.0)
   - TTTAttributedLabel (= 2.0.0)
@@ -420,7 +420,7 @@ SPEC CHECKSUMS:
   SVGKit: 8a2fc74258bdb2abb54d3b65f3dd68b0277a9c4d
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
   SwiftDate: 72d28954e8e1c6c1c0f917ccc8005e4f83c7d4b2
-  SwiftLint: e5c7f1fba68eccfc51509d5b2ce1699f5502e0c7
+  SwiftLint: 06ac37e4d38c7068e0935bb30cda95f093bec761
   SwiftyGif: 5d4af95df24caf1c570dbbcb32a3b8a0763bc6d7
   SwiftyJSON: 36413e04c44ee145039d332b4f4e2d3e8d6c4db7
   Tabman: d8d6ab0b483c7db375a71ac227d3ef791b56a049
@@ -430,6 +430,6 @@ SPEC CHECKSUMS:
   VK-ios-sdk: 5bcf00a2014a7323f98db9328b603d4f96635caa
   YandexMobileMetrica: 9e713c16bb6aca0ba63b84c8d7b8b86d32f4ecc4
 
-PODFILE CHECKSUM: d090778f877db1cd8189486ae6c09540718cd74d
+PODFILE CHECKSUM: d51c5eda751b737dd114fd295ab09fd1b7306085
 
 COCOAPODS: 1.11.2

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -3,7 +3,7 @@ PODS:
   - Agrume (5.6.13):
     - SwiftyGif
   - Alamofire (5.4.4)
-  - Amplitude (8.5.0)
+  - Amplitude (8.7.1)
   - AppAuth (1.4.0):
     - AppAuth/Core (= 1.4.0)
     - AppAuth/ExternalUserAgent (= 1.4.0)
@@ -219,7 +219,7 @@ DEPENDENCIES:
   - ActionSheetPicker-3.0 (= 2.7.1)
   - Agrume (= 5.6.13)
   - Alamofire (= 5.4.4)
-  - Amplitude (= 8.5.0)
+  - Amplitude (= 8.7.1)
   - Atributika (= 4.10.1)
   - BEMCheckBox (= 1.4.1)
   - Branch (= 1.40.2)
@@ -370,7 +370,7 @@ SPEC CHECKSUMS:
   ActionSheetPicker-3.0: 36da254b97a09ff89679ecb8b8510bd3e5bdc773
   Agrume: 21b96a1138abc0f890211bfcb12f8b1e3464b4c1
   Alamofire: f3b09a368f1582ab751b3fff5460276e0d2cf5c9
-  Amplitude: ef9ed339ddd33c9183edf63fa4bbaa86cf873321
+  Amplitude: 834c7332dfb9640a751e21c13efb22a07c0c12d4
   AppAuth: 31bcec809a638d7bd2f86ea8a52bd45f6e81e7c7
   Atributika: 47e778507cfb3cd2c996278b0285221a62e97d71
   BEMCheckBox: 5ba6e37ade3d3657b36caecc35c8b75c6c2b1a4e
@@ -430,6 +430,6 @@ SPEC CHECKSUMS:
   VK-ios-sdk: 5bcf00a2014a7323f98db9328b603d4f96635caa
   YandexMobileMetrica: 9e713c16bb6aca0ba63b84c8d7b8b86d32f4ecc4
 
-PODFILE CHECKSUM: 9a233838a4b2d2a920487bfc9b1d3da1fe1caba0
+PODFILE CHECKSUM: db582784a46b9c0076f6b88e25ff97a287f80b6a
 
 COCOAPODS: 1.11.2

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -2,7 +2,7 @@ PODS:
   - ActionSheetPicker-3.0 (2.7.1)
   - Agrume (5.6.13):
     - SwiftyGif
-  - Alamofire (5.4.4)
+  - Alamofire (5.5.0)
   - Amplitude (8.7.1)
   - AppAuth (1.4.0):
     - AppAuth/Core (= 1.4.0)
@@ -218,7 +218,7 @@ PODS:
 DEPENDENCIES:
   - ActionSheetPicker-3.0 (= 2.7.1)
   - Agrume (= 5.6.13)
-  - Alamofire (= 5.4.4)
+  - Alamofire (= 5.5.0)
   - Amplitude (= 8.7.1)
   - Atributika (= 4.10.1)
   - BEMCheckBox (= 1.4.1)
@@ -369,7 +369,7 @@ CHECKOUT OPTIONS:
 SPEC CHECKSUMS:
   ActionSheetPicker-3.0: 36da254b97a09ff89679ecb8b8510bd3e5bdc773
   Agrume: 21b96a1138abc0f890211bfcb12f8b1e3464b4c1
-  Alamofire: f3b09a368f1582ab751b3fff5460276e0d2cf5c9
+  Alamofire: 1c4fb5369c3fe93d2857c780d8bbe09f06f97e7c
   Amplitude: 834c7332dfb9640a751e21c13efb22a07c0c12d4
   AppAuth: 31bcec809a638d7bd2f86ea8a52bd45f6e81e7c7
   Atributika: 47e778507cfb3cd2c996278b0285221a62e97d71
@@ -430,6 +430,6 @@ SPEC CHECKSUMS:
   VK-ios-sdk: 5bcf00a2014a7323f98db9328b603d4f96635caa
   YandexMobileMetrica: 9e713c16bb6aca0ba63b84c8d7b8b86d32f4ecc4
 
-PODFILE CHECKSUM: b7973afbb8d7f7aca0a44f96d586e81eea31e526
+PODFILE CHECKSUM: 4d5baf64cfc3f103cc16a51042a60fa1da61c9ee
 
 COCOAPODS: 1.11.2

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -174,7 +174,7 @@ PODS:
   - nanopb/decode (2.30908.0)
   - nanopb/encode (2.30908.0)
   - Nimble (9.2.1)
-  - Nuke (9.5.0)
+  - Nuke (10.6.1)
   - Pageboy (3.6.2)
   - PanModal (1.2.7)
   - pop (1.0.12)
@@ -243,7 +243,7 @@ DEPENDENCIES:
   - lottie-ios (= 3.3.0)
   - Mockingjay (from `https://github.com/kylef/Mockingjay.git`, branch `master`)
   - Nimble (= 9.2.1)
-  - Nuke (= 9.5.0)
+  - Nuke (= 10.6.1)
   - PanModal (from `https://github.com/ivan-magda/PanModal.git`, branch `remove-presenting-appearance-transitions`)
   - Presentr (from `https://github.com/ivan-magda/Presentr.git`, tag `v1.9.1`)
   - PromiseKit (from `https://github.com/mxcl/PromiseKit.git`, tag `6.16.2`)
@@ -406,7 +406,7 @@ SPEC CHECKSUMS:
   Mockingjay: 97656c6f59879923976a0a52ef09da45756cca82
   nanopb: a0ba3315591a9ae0a16a309ee504766e90db0c96
   Nimble: e7e615c0335ee4bf5b0d786685451e62746117d5
-  Nuke: 6f400a4ea957e09149ec335a3c6acdcc814d89e4
+  Nuke: 3ca210aee6d90756605c5125cbe40569fd9c06f7
   Pageboy: cf121b9dd48c63f3f281b2a9ec93d02e0f23879b
   PanModal: 3e16ead1a907fb06f4df3f13492fd00149fa4974
   pop: d582054913807fd11fd50bfe6a539d91c7e1a55a
@@ -430,6 +430,6 @@ SPEC CHECKSUMS:
   VK-ios-sdk: 5bcf00a2014a7323f98db9328b603d4f96635caa
   YandexMobileMetrica: 9e713c16bb6aca0ba63b84c8d7b8b86d32f4ecc4
 
-PODFILE CHECKSUM: 4d5baf64cfc3f103cc16a51042a60fa1da61c9ee
+PODFILE CHECKSUM: c0a26901d2f12efd4fa7e051662134bf196dd97c
 
 COCOAPODS: 1.11.2

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -128,8 +128,8 @@ PODS:
     - GoogleUtilities/Environment (~> 7.2)
     - nanopb (~> 2.30908.0)
     - PromisesObjC (< 3.0, >= 1.2)
-  - GoogleSignIn (5.0.2):
-    - AppAuth (~> 1.2)
+  - GoogleSignIn (6.1.0):
+    - AppAuth (~> 1.4)
     - GTMAppAuth (~> 1.0)
     - GTMSessionFetcher/Core (~> 1.1)
   - GoogleUtilities/AppDelegateSwizzler (7.6.0):
@@ -235,7 +235,7 @@ DEPENDENCIES:
   - Firebase/Messaging (= 8.9.1)
   - Firebase/RemoteConfig (= 8.9.1)
   - FLEX (from `https://github.com/ivan-magda/FLEX.git`, branch `master`)
-  - GoogleSignIn (= 5.0.2)
+  - GoogleSignIn (= 6.1.0)
   - Highlightr (from `https://github.com/ivan-magda/Highlightr.git`, tag `v2.1.3`)
   - IQKeyboardManagerSwift (= 6.5.6)
   - Kanna (= 5.2.7)
@@ -394,7 +394,7 @@ SPEC CHECKSUMS:
   FLEX: 75ca95cff4bd57592c6e75adee7651ace29f9c25
   GoogleAppMeasurement: 837649ad3987936c232f6717c5680216f6243d24
   GoogleDataTransport: 629c20a4d363167143f30ea78320d5a7eb8bd940
-  GoogleSignIn: 7137d297ddc022a7e0aa4619c86d72c909fa7213
+  GoogleSignIn: c90b5bec45e780f54c6a8e1e3c182a86e3dda69d
   GoogleUtilities: 684ee790a24f73ebb2d1d966e9711c203f2a4237
   GTMAppAuth: ad5c2b70b9a8689e1a04033c9369c4915bfcbe89
   GTMSessionFetcher: 43748f93435c2aa068b1cbe39655aaf600652e91
@@ -430,6 +430,6 @@ SPEC CHECKSUMS:
   VK-ios-sdk: 5bcf00a2014a7323f98db9328b603d4f96635caa
   YandexMobileMetrica: 9e713c16bb6aca0ba63b84c8d7b8b86d32f4ecc4
 
-PODFILE CHECKSUM: db582784a46b9c0076f6b88e25ff97a287f80b6a
+PODFILE CHECKSUM: 16d32a3617329674b829c1bc88cbd652b87070ac
 
 COCOAPODS: 1.11.2

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -31,26 +31,26 @@ PODS:
     - FBSDKLoginKit/Login (= 8.2.0)
   - FBSDKLoginKit/Login (8.2.0):
     - FBSDKCoreKit (~> 8.2.0)
-  - Firebase/Analytics (8.9.1):
+  - Firebase/Analytics (8.10.0):
     - Firebase/Core
-  - Firebase/Core (8.9.1):
+  - Firebase/Core (8.10.0):
     - Firebase/CoreOnly
-    - FirebaseAnalytics (~> 8.9.1)
-  - Firebase/CoreOnly (8.9.1):
-    - FirebaseCore (= 8.9.1)
-  - Firebase/Crashlytics (8.9.1):
+    - FirebaseAnalytics (~> 8.10.0)
+  - Firebase/CoreOnly (8.10.0):
+    - FirebaseCore (= 8.10.0)
+  - Firebase/Crashlytics (8.10.0):
     - Firebase/CoreOnly
-    - FirebaseCrashlytics (~> 8.9.0)
-  - Firebase/Messaging (8.9.1):
+    - FirebaseCrashlytics (~> 8.10.0)
+  - Firebase/Messaging (8.10.0):
     - Firebase/CoreOnly
-    - FirebaseMessaging (~> 8.9.0)
-  - Firebase/RemoteConfig (8.9.1):
+    - FirebaseMessaging (~> 8.10.0)
+  - Firebase/RemoteConfig (8.10.0):
     - Firebase/CoreOnly
-    - FirebaseRemoteConfig (~> 8.9.0)
-  - FirebaseABTesting (8.9.0):
+    - FirebaseRemoteConfig (~> 8.10.0)
+  - FirebaseABTesting (8.10.0):
     - FirebaseCore (~> 8.0)
-  - FirebaseAnalytics (8.9.1):
-    - FirebaseAnalytics/AdIdSupport (= 8.9.1)
+  - FirebaseAnalytics (8.10.0):
+    - FirebaseAnalytics/AdIdSupport (= 8.10.0)
     - FirebaseCore (~> 8.0)
     - FirebaseInstallations (~> 8.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 7.6)
@@ -58,37 +58,37 @@ PODS:
     - GoogleUtilities/Network (~> 7.6)
     - "GoogleUtilities/NSData+zlib (~> 7.6)"
     - nanopb (~> 2.30908.0)
-  - FirebaseAnalytics/AdIdSupport (8.9.1):
+  - FirebaseAnalytics/AdIdSupport (8.10.0):
     - FirebaseCore (~> 8.0)
     - FirebaseInstallations (~> 8.0)
-    - GoogleAppMeasurement (= 8.9.1)
+    - GoogleAppMeasurement (= 8.10.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 7.6)
     - GoogleUtilities/MethodSwizzler (~> 7.6)
     - GoogleUtilities/Network (~> 7.6)
     - "GoogleUtilities/NSData+zlib (~> 7.6)"
     - nanopb (~> 2.30908.0)
-  - FirebaseCore (8.9.1):
+  - FirebaseCore (8.10.0):
     - FirebaseCoreDiagnostics (~> 8.0)
     - GoogleUtilities/Environment (~> 7.6)
     - GoogleUtilities/Logger (~> 7.6)
-  - FirebaseCoreDiagnostics (8.9.0):
+  - FirebaseCoreDiagnostics (8.10.0):
     - GoogleDataTransport (~> 9.1)
     - GoogleUtilities/Environment (~> 7.6)
     - GoogleUtilities/Logger (~> 7.6)
     - nanopb (~> 2.30908.0)
-  - FirebaseCrashlytics (8.9.0):
+  - FirebaseCrashlytics (8.10.0):
     - FirebaseCore (~> 8.0)
     - FirebaseInstallations (~> 8.0)
     - GoogleDataTransport (~> 9.1)
     - GoogleUtilities/Environment (~> 7.6)
     - nanopb (~> 2.30908.0)
     - PromisesObjC (< 3.0, >= 1.2)
-  - FirebaseInstallations (8.9.0):
+  - FirebaseInstallations (8.10.0):
     - FirebaseCore (~> 8.0)
     - GoogleUtilities/Environment (~> 7.6)
     - GoogleUtilities/UserDefaults (~> 7.6)
     - PromisesObjC (< 3.0, >= 1.2)
-  - FirebaseMessaging (8.9.0):
+  - FirebaseMessaging (8.10.0):
     - FirebaseCore (~> 8.0)
     - FirebaseInstallations (~> 8.0)
     - GoogleDataTransport (~> 9.1)
@@ -97,28 +97,28 @@ PODS:
     - GoogleUtilities/Reachability (~> 7.6)
     - GoogleUtilities/UserDefaults (~> 7.6)
     - nanopb (~> 2.30908.0)
-  - FirebaseRemoteConfig (8.9.0):
+  - FirebaseRemoteConfig (8.10.0):
     - FirebaseABTesting (~> 8.0)
     - FirebaseCore (~> 8.0)
     - FirebaseInstallations (~> 8.0)
     - GoogleUtilities/Environment (~> 7.6)
     - "GoogleUtilities/NSData+zlib (~> 7.6)"
   - FLEX (4.4.1)
-  - GoogleAppMeasurement (8.9.1):
-    - GoogleAppMeasurement/AdIdSupport (= 8.9.1)
+  - GoogleAppMeasurement (8.10.0):
+    - GoogleAppMeasurement/AdIdSupport (= 8.10.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 7.6)
     - GoogleUtilities/MethodSwizzler (~> 7.6)
     - GoogleUtilities/Network (~> 7.6)
     - "GoogleUtilities/NSData+zlib (~> 7.6)"
     - nanopb (~> 2.30908.0)
-  - GoogleAppMeasurement/AdIdSupport (8.9.1):
-    - GoogleAppMeasurement/WithoutAdIdSupport (= 8.9.1)
+  - GoogleAppMeasurement/AdIdSupport (8.10.0):
+    - GoogleAppMeasurement/WithoutAdIdSupport (= 8.10.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 7.6)
     - GoogleUtilities/MethodSwizzler (~> 7.6)
     - GoogleUtilities/Network (~> 7.6)
     - "GoogleUtilities/NSData+zlib (~> 7.6)"
     - nanopb (~> 2.30908.0)
-  - GoogleAppMeasurement/WithoutAdIdSupport (8.9.1):
+  - GoogleAppMeasurement/WithoutAdIdSupport (8.10.0):
     - GoogleUtilities/AppDelegateSwizzler (~> 7.6)
     - GoogleUtilities/MethodSwizzler (~> 7.6)
     - GoogleUtilities/Network (~> 7.6)
@@ -132,24 +132,24 @@ PODS:
     - AppAuth (~> 1.4)
     - GTMAppAuth (~> 1.0)
     - GTMSessionFetcher/Core (~> 1.1)
-  - GoogleUtilities/AppDelegateSwizzler (7.6.0):
+  - GoogleUtilities/AppDelegateSwizzler (7.7.0):
     - GoogleUtilities/Environment
     - GoogleUtilities/Logger
     - GoogleUtilities/Network
-  - GoogleUtilities/Environment (7.6.0):
+  - GoogleUtilities/Environment (7.7.0):
     - PromisesObjC (< 3.0, >= 1.2)
-  - GoogleUtilities/Logger (7.6.0):
+  - GoogleUtilities/Logger (7.7.0):
     - GoogleUtilities/Environment
-  - GoogleUtilities/MethodSwizzler (7.6.0):
+  - GoogleUtilities/MethodSwizzler (7.7.0):
     - GoogleUtilities/Logger
-  - GoogleUtilities/Network (7.6.0):
+  - GoogleUtilities/Network (7.7.0):
     - GoogleUtilities/Logger
     - "GoogleUtilities/NSData+zlib"
     - GoogleUtilities/Reachability
-  - "GoogleUtilities/NSData+zlib (7.6.0)"
-  - GoogleUtilities/Reachability (7.6.0):
+  - "GoogleUtilities/NSData+zlib (7.7.0)"
+  - GoogleUtilities/Reachability (7.7.0):
     - GoogleUtilities/Logger
-  - GoogleUtilities/UserDefaults (7.6.0):
+  - GoogleUtilities/UserDefaults (7.7.0):
     - GoogleUtilities/Logger
   - GTMAppAuth (1.2.2):
     - AppAuth/Core (~> 1.4)
@@ -229,11 +229,11 @@ DEPENDENCIES:
   - EasyTipView (= 2.1.0)
   - FBSDKCoreKit (= 8.2.0)
   - FBSDKLoginKit (= 8.2.0)
-  - Firebase/Analytics (= 8.9.1)
-  - Firebase/Core (= 8.9.1)
-  - Firebase/Crashlytics (= 8.9.1)
-  - Firebase/Messaging (= 8.9.1)
-  - Firebase/RemoteConfig (= 8.9.1)
+  - Firebase/Analytics (= 8.10.0)
+  - Firebase/Core (= 8.10.0)
+  - Firebase/Crashlytics (= 8.10.0)
+  - Firebase/Messaging (= 8.10.0)
+  - Firebase/RemoteConfig (= 8.10.0)
   - FLEX (from `https://github.com/ivan-magda/FLEX.git`, branch `master`)
   - GoogleSignIn (= 6.1.0)
   - Highlightr (from `https://github.com/ivan-magda/Highlightr.git`, tag `v2.1.3`)
@@ -382,20 +382,20 @@ SPEC CHECKSUMS:
   EasyTipView: a92b6edc377b81c5ac18e9fd35d5ee78e9409488
   FBSDKCoreKit: 4afd6ff53d8133a433dbcda44451c9498f8c6ce4
   FBSDKLoginKit: 7181765f2524d7ebf82d9629066c8e6caafc99d0
-  Firebase: fb5114cd2bf96e2ff7bcb01d0d9a156cf5fd2f07
-  FirebaseABTesting: 9de50b34bf9eb4a07d4edb7af82c14152fd905aa
-  FirebaseAnalytics: 4ab446ce08a3fe52e8a4303dd997cf26276bf968
-  FirebaseCore: c5aab092d9c4b8efea894946166b04c9d9ef0e68
-  FirebaseCoreDiagnostics: 5daa63f1c1409d981a2d5007daa100b36eac6a34
-  FirebaseCrashlytics: 40efbd81157dae307ec95612fa1328347284d2c2
-  FirebaseInstallations: caa7c8e0d3e2345b8829d2fa9ca1b4dfbf2fcc85
-  FirebaseMessaging: 82c4a48638f53f7b184f3cc9f6cd2cbe533ab316
-  FirebaseRemoteConfig: a75c1bd44ebd3ed4ad3fa1ff09414a8b133be405
+  Firebase: 44213362f1dcc52555b935dc925ed35ac55f1b20
+  FirebaseABTesting: fc7255f7e96d3cf7a1131fd68636c47e312cef76
+  FirebaseAnalytics: 319c9b3b1bdd400d60e2f415dff0c5f6959e6760
+  FirebaseCore: 04186597c095da37d90ff9fd3e53bc61a1ff2440
+  FirebaseCoreDiagnostics: 56fb7216d87e0e6ec2feddefa9d8a392fe8b2c18
+  FirebaseCrashlytics: 3b7f17cdf5bf1ae6ad5956696a6c26edeb39cca7
+  FirebaseInstallations: 830327b45345ffc859eaa9c17bcd5ae893fd5425
+  FirebaseMessaging: b0aeba17332ee1ee610662b4d1e02a86db82f08f
+  FirebaseRemoteConfig: 84d3397887d95587f0ee7a0a3989b2756dc2bbf9
   FLEX: 75ca95cff4bd57592c6e75adee7651ace29f9c25
-  GoogleAppMeasurement: 837649ad3987936c232f6717c5680216f6243d24
+  GoogleAppMeasurement: a3311dbcf3ea651e5a070fe8559b57c174ada081
   GoogleDataTransport: 629c20a4d363167143f30ea78320d5a7eb8bd940
   GoogleSignIn: c90b5bec45e780f54c6a8e1e3c182a86e3dda69d
-  GoogleUtilities: 684ee790a24f73ebb2d1d966e9711c203f2a4237
+  GoogleUtilities: e0913149f6b0625b553d70dae12b49fc62914fd1
   GTMAppAuth: ad5c2b70b9a8689e1a04033c9369c4915bfcbe89
   GTMSessionFetcher: 43748f93435c2aa068b1cbe39655aaf600652e91
   Highlightr: 9fbc57afd1921d274d5df911caabf91eaf25f0f3
@@ -430,6 +430,6 @@ SPEC CHECKSUMS:
   VK-ios-sdk: 5bcf00a2014a7323f98db9328b603d4f96635caa
   YandexMobileMetrica: 9e713c16bb6aca0ba63b84c8d7b8b86d32f4ecc4
 
-PODFILE CHECKSUM: c0a26901d2f12efd4fa7e051662134bf196dd97c
+PODFILE CHECKSUM: d090778f877db1cd8189486ae6c09540718cd74d
 
 COCOAPODS: 1.11.2

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -15,9 +15,9 @@ PODS:
   - Charts (3.6.0):
     - Charts/Core (= 3.6.0)
   - Charts/Core (3.6.0)
-  - CocoaLumberjack (3.7.2):
-    - CocoaLumberjack/Core (= 3.7.2)
-  - CocoaLumberjack/Core (3.7.2)
+  - CocoaLumberjack (3.7.4):
+    - CocoaLumberjack/Core (= 3.7.4)
+  - CocoaLumberjack/Core (3.7.4)
   - DeviceKit (4.5.2)
   - DownloadButton (0.1.0)
   - EasyTipView (2.1.0)
@@ -200,7 +200,7 @@ PODS:
   - SVProgressHUD (2.2.5)
   - SwiftDate (6.3.1)
   - SwiftLint (0.45.1)
-  - SwiftyGif (5.4.0)
+  - SwiftyGif (5.4.2)
   - SwiftyJSON (5.0.0)
   - Tabman (2.10.0):
     - Pageboy (~> 3.6.0)
@@ -376,7 +376,7 @@ SPEC CHECKSUMS:
   BEMCheckBox: 5ba6e37ade3d3657b36caecc35c8b75c6c2b1a4e
   Branch: c1b244bf1170b0ea5c5eefa897648de8d14ff0d2
   Charts: b1e3a1f5a1c9ba5394438ca3b91bd8c9076310af
-  CocoaLumberjack: b7e05132ff94f6ae4dfa9d5bce9141893a21d9da
+  CocoaLumberjack: 543c79c114dadc3b1aba95641d8738b06b05b646
   DeviceKit: c622fc19f795f3e0b4d75d6d11b26604338cdab3
   DownloadButton: 49a21a89e0d7d1b42d9134f79aaa40e727cd57c3
   EasyTipView: a92b6edc377b81c5ac18e9fd35d5ee78e9409488
@@ -421,7 +421,7 @@ SPEC CHECKSUMS:
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
   SwiftDate: 72d28954e8e1c6c1c0f917ccc8005e4f83c7d4b2
   SwiftLint: 06ac37e4d38c7068e0935bb30cda95f093bec761
-  SwiftyGif: 5d4af95df24caf1c570dbbcb32a3b8a0763bc6d7
+  SwiftyGif: dec758a9dd3d278e5a855dbf279bf062c923c387
   SwiftyJSON: 36413e04c44ee145039d332b4f4e2d3e8d6c4db7
   Tabman: d8d6ab0b483c7db375a71ac227d3ef791b56a049
   TTTAttributedLabel: 8cffe8e127e4e82ff3af1e5386d4cd0ad000b656

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -190,9 +190,9 @@ PODS:
     - PromiseKit/CorePromise
   - PromisesObjC (2.0.0)
   - Quick (4.0.0)
-  - SDWebImage (5.12.1):
-    - SDWebImage/Core (= 5.12.1)
-  - SDWebImage/Core (5.12.1)
+  - SDWebImage (5.12.2):
+    - SDWebImage/Core (= 5.12.2)
+  - SDWebImage/Core (5.12.2)
   - SnapKit (5.0.1)
   - STRegex (2.1.1)
   - SVGKit (2.1.0):
@@ -248,7 +248,7 @@ DEPENDENCIES:
   - Presentr (from `https://github.com/ivan-magda/Presentr.git`, tag `v1.9.1`)
   - PromiseKit (from `https://github.com/mxcl/PromiseKit.git`, tag `6.16.2`)
   - Quick (= 4.0.0)
-  - SDWebImage (= 5.12.1)
+  - SDWebImage (= 5.12.2)
   - SnapKit (= 5.0.1)
   - STRegex (= 2.1.1)
   - SVGKit (from `https://github.com/SVGKit/SVGKit.git`, branch `2.x`)
@@ -414,7 +414,7 @@ SPEC CHECKSUMS:
   PromiseKit: ad27b174e5d8587cf799888f5e738f88e17055d8
   PromisesObjC: 68159ce6952d93e17b2dfe273b8c40907db5ba58
   Quick: 6473349e43b9271a8d43839d9ba1c442ed1b7ac4
-  SDWebImage: 4dc3e42d9ec0c1028b960a33ac6b637bb432207b
+  SDWebImage: 240e5c12b592fb1268c1d03b8c90d90e8c2ffe82
   SnapKit: 97b92857e3df3a0c71833cce143274bf6ef8e5eb
   STRegex: d49e88d0fe58538d3175fdd989bc1243b9be2a07
   SVGKit: 8a2fc74258bdb2abb54d3b65f3dd68b0277a9c4d
@@ -430,6 +430,6 @@ SPEC CHECKSUMS:
   VK-ios-sdk: 5bcf00a2014a7323f98db9328b603d4f96635caa
   YandexMobileMetrica: 9e713c16bb6aca0ba63b84c8d7b8b86d32f4ecc4
 
-PODFILE CHECKSUM: 91c5501d3a27c4d1d80ff880978ef3b8111e3b6d
+PODFILE CHECKSUM: 9a233838a4b2d2a920487bfc9b1d3da1fe1caba0
 
 COCOAPODS: 1.11.2

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -160,7 +160,7 @@ PODS:
   - Kanna (5.2.7)
   - Koloda (5.0.1):
     - pop (~> 1.0)
-  - lottie-ios (3.2.3)
+  - lottie-ios (3.3.0)
   - Mockingjay (3.0.0-alpha.1):
     - Mockingjay/Core (= 3.0.0-alpha.1)
     - Mockingjay/XCTest (= 3.0.0-alpha.1)
@@ -240,7 +240,7 @@ DEPENDENCIES:
   - IQKeyboardManagerSwift (= 6.5.6)
   - Kanna (= 5.2.7)
   - Koloda (= 5.0.1)
-  - lottie-ios (= 3.2.3)
+  - lottie-ios (= 3.3.0)
   - Mockingjay (from `https://github.com/kylef/Mockingjay.git`, branch `master`)
   - Nimble (= 9.2.1)
   - Nuke (= 9.5.0)
@@ -402,7 +402,7 @@ SPEC CHECKSUMS:
   IQKeyboardManagerSwift: c7df9d2deb356c04522f5c4b7b6e4ce4d8ed94fe
   Kanna: 01cfbddc127f5ff0963692f285fcbc8a9d62d234
   Koloda: d07b9199a383abc5898b62aa945a599f5e7c0c4b
-  lottie-ios: c058aeafa76daa4cf64d773554bccc8385d0150e
+  lottie-ios: 6ac74dcc09904798f59b18cb3075c089d76be9ae
   Mockingjay: 97656c6f59879923976a0a52ef09da45756cca82
   nanopb: a0ba3315591a9ae0a16a309ee504766e90db0c96
   Nimble: e7e615c0335ee4bf5b0d786685451e62746117d5
@@ -430,6 +430,6 @@ SPEC CHECKSUMS:
   VK-ios-sdk: 5bcf00a2014a7323f98db9328b603d4f96635caa
   YandexMobileMetrica: 9e713c16bb6aca0ba63b84c8d7b8b86d32f4ecc4
 
-PODFILE CHECKSUM: 16d32a3617329674b829c1bc88cbd652b87070ac
+PODFILE CHECKSUM: b7973afbb8d7f7aca0a44f96d586e81eea31e526
 
 COCOAPODS: 1.11.2

--- a/Stepic.xcodeproj/project.pbxproj
+++ b/Stepic.xcodeproj/project.pbxproj
@@ -10242,7 +10242,6 @@
 				085D5CD61D007F2100092060 /* Frameworks */,
 				085D5CD71D007F2100092060 /* Resources */,
 				C79C1B724717A179569871E5 /* [CP] Embed Pods Frameworks */,
-				6280D7646D0AACF80BFE3C4F /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -10282,7 +10281,6 @@
 				086538401EB02716003A8415 /* Embed App Extensions */,
 				D25EB23E484464AD999FE2C5 /* [CP] Embed Pods Frameworks */,
 				08343B1A1BF5EC7F00370FC1 /* FirebaseCrashlytics Script */,
-				BD6CCF7C920494D46494C55D /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -10692,42 +10690,6 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		6280D7646D0AACF80BFE3C4F /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-StepicTests/Pods-StepicTests-resources.sh",
-				"${PODS_ROOT}/GoogleSignIn/Resources/GoogleSignIn.bundle",
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/GoogleSignIn.bundle",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-StepicTests/Pods-StepicTests-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		BD6CCF7C920494D46494C55D /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Stepic/Pods-Stepic-resources.sh",
-				"${PODS_ROOT}/GoogleSignIn/Resources/GoogleSignIn.bundle",
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/GoogleSignIn.bundle",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Stepic/Pods-Stepic-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
 		C79C1B724717A179569871E5 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -10761,6 +10723,7 @@
 				"${BUILT_PRODUCTS_DIR}/GTMAppAuth/GTMAppAuth.framework",
 				"${BUILT_PRODUCTS_DIR}/GTMSessionFetcher/GTMSessionFetcher.framework",
 				"${BUILT_PRODUCTS_DIR}/GoogleDataTransport/GoogleDataTransport.framework",
+				"${BUILT_PRODUCTS_DIR}/GoogleSignIn/GoogleSignIn.framework",
 				"${BUILT_PRODUCTS_DIR}/GoogleUtilities/GoogleUtilities.framework",
 				"${BUILT_PRODUCTS_DIR}/Highlightr/Highlightr.framework",
 				"${BUILT_PRODUCTS_DIR}/IQKeyboardManagerSwift/IQKeyboardManagerSwift.framework",
@@ -10822,6 +10785,7 @@
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GTMAppAuth.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GTMSessionFetcher.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GoogleDataTransport.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GoogleSignIn.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GoogleUtilities.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Highlightr.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/IQKeyboardManagerSwift.framework",
@@ -10893,6 +10857,7 @@
 				"${BUILT_PRODUCTS_DIR}/GTMAppAuth/GTMAppAuth.framework",
 				"${BUILT_PRODUCTS_DIR}/GTMSessionFetcher/GTMSessionFetcher.framework",
 				"${BUILT_PRODUCTS_DIR}/GoogleDataTransport/GoogleDataTransport.framework",
+				"${BUILT_PRODUCTS_DIR}/GoogleSignIn/GoogleSignIn.framework",
 				"${BUILT_PRODUCTS_DIR}/GoogleUtilities/GoogleUtilities.framework",
 				"${BUILT_PRODUCTS_DIR}/Highlightr/Highlightr.framework",
 				"${BUILT_PRODUCTS_DIR}/IQKeyboardManagerSwift/IQKeyboardManagerSwift.framework",
@@ -10950,6 +10915,7 @@
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GTMAppAuth.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GTMSessionFetcher.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GoogleDataTransport.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GoogleSignIn.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GoogleUtilities.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Highlightr.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/IQKeyboardManagerSwift.framework",

--- a/Stepic/Legacy/AppDelegate.swift
+++ b/Stepic/Legacy/AppDelegate.swift
@@ -306,7 +306,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         if ApplicationDelegate.shared.application(app, open: url, options: options) {
             return true
         }
-        if GIDSignIn.sharedInstance().handle(url) {
+        if GIDSignIn.sharedInstance.handle(url) {
             return true
         }
         if url.scheme == "vk\(StepikApplicationsInfo.SocialInfo.AppIds.vk)"

--- a/Stepic/Legacy/Model/Network/SocialSDKProviders/GoogleIDSocialSDKProvider.swift
+++ b/Stepic/Legacy/Model/Network/SocialSDKProviders/GoogleIDSocialSDKProvider.swift
@@ -13,16 +13,13 @@ final class GoogleIDSocialSDKProvider: NSObject, SocialSDKProvider {
 
     let name = "google"
 
-    private var sdkInstance: GIDSignIn
-
-    private var successHandler: ((SocialSDKCredential) -> Void)?
-    private var errorHandler: ((SocialSDKError) -> Void)?
+    private let sdkInstance: GIDSignIn
+    private let signInConfig: GIDConfiguration
 
     override private init() {
-        self.sdkInstance = GIDSignIn.sharedInstance()
+        self.sdkInstance = GIDSignIn.sharedInstance
+        self.signInConfig = GIDConfiguration.init(clientID: StepikApplicationsInfo.SocialInfo.AppIds.google)
         super.init()
-        self.sdkInstance.clientID = StepikApplicationsInfo.SocialInfo.AppIds.google
-        self.sdkInstance.delegate = self
     }
 
     func getAccessInfo() -> Promise<SocialSDKCredential> {
@@ -42,35 +39,35 @@ final class GoogleIDSocialSDKProvider: NSObject, SocialSDKProvider {
         success successHandler: @escaping (SocialSDKCredential) -> Void,
         error errorHandler: @escaping (SocialSDKError) -> Void
     ) {
-        self.successHandler = successHandler
-        self.errorHandler = errorHandler
-
-        self.sdkInstance.presentingViewController = self.delegate?.googleSignInPresentingViewController
+        guard let presentingViewController = self.delegate?.googleSignInPresentingViewController else {
+            return errorHandler(.connectionError)
+        }
 
         if self.sdkInstance.hasPreviousSignIn() {
             self.sdkInstance.signOut()
         }
 
-        self.sdkInstance.signIn()
-    }
-}
-
-extension GoogleIDSocialSDKProvider: GIDSignInDelegate {
-    func sign(_ signIn: GIDSignIn!, didSignInFor user: GIDGoogleUser!, withError error: Error!) {
-        if let error = error {
-            print("GoogleIDSocialSDKProvider :: error=\(error.localizedDescription)")
-            self.errorHandler?(SocialSDKError.connectionError)
-        } else if let authentication = user.authentication,
-                  let accessToken = authentication.accessToken {
-            var email: String?
-            if let profile = user.profile,
-               let profileEmail = profile.email {
-                email = profileEmail
+        self.sdkInstance.signIn(with: self.signInConfig, presenting: presentingViewController) { user, error in
+            if let error = error {
+                print("GoogleIDSocialSDKProvider :: error = \(error.localizedDescription)")
+                errorHandler(.connectionError)
+            } else if let user = user {
+                let email = user.profile?.email
+                user.authentication.do { authentication, error in
+                    if let error = error {
+                        print("GoogleIDSocialSDKProvider :: error = \(error.localizedDescription)")
+                        errorHandler(.connectionError)
+                    } else if let authentication = authentication {
+                        successHandler(SocialSDKCredential(token: authentication.accessToken, email: email))
+                    } else {
+                        print("GoogleIDSocialSDKProvider :: error missing accessToken")
+                        errorHandler(.accessDenied)
+                    }
+                }
+            } else {
+                print("GoogleIDSocialSDKProvider :: error missing accessToken")
+                errorHandler(.accessDenied)
             }
-            self.successHandler?(SocialSDKCredential(token: accessToken, email: email))
-        } else {
-            print("GoogleIDSocialSDKProvider :: error missing accessToken")
-            self.errorHandler?(SocialSDKError.accessDenied)
         }
     }
 }

--- a/Stepic/Legacy/Model/Network/SocialSDKProviders/GoogleIDSocialSDKProvider.swift
+++ b/Stepic/Legacy/Model/Network/SocialSDKProviders/GoogleIDSocialSDKProvider.swift
@@ -18,7 +18,7 @@ final class GoogleIDSocialSDKProvider: NSObject, SocialSDKProvider {
 
     override private init() {
         self.sdkInstance = GIDSignIn.sharedInstance
-        self.signInConfig = GIDConfiguration.init(clientID: StepikApplicationsInfo.SocialInfo.AppIds.google)
+        self.signInConfig = GIDConfiguration(clientID: StepikApplicationsInfo.SocialInfo.AppIds.google)
         super.init()
     }
 

--- a/Stepic/Sources/Common/ImageDataProvider.swift
+++ b/Stepic/Sources/Common/ImageDataProvider.swift
@@ -112,5 +112,5 @@ final class NukeImageDataProvider: ImageDataProvider {
         return imageContainer.image.jpegData(compressionQuality: self.compressionQuality)
     }
 
-    var contentURL: URL? { self.imageRequest.urlRequest.url }
+    var contentURL: URL? { self.imageRequest.urlRequest?.url }
 }


### PR DESCRIPTION
Bumps:
- [SDWebImage](https://github.com/SDWebImage/SDWebImage) from 5.12.1 to 5.12.2
- [Amplitude](https://github.com/amplitude/Amplitude-iOS) from 8.5.0 to 8.7.1
- [GoogleSignIn](https://github.com/google/GoogleSignIn-iOS) from 5.0.2 to 6.1.0
- [lottie-ios](https://github.com/airbnb/lottie-ios) from 3.2.3 to 3.3.0
- [Alamofire](https://github.com/Alamofire/Alamofire) from 5.4.4 to 5.5.0
- [Nuke](https://github.com/kean/Nuke) from 9.5.0 to 10.6.1
- [Firebase](https://github.com/firebase/firebase-ios-sdk) from 8.9.1 to 8.10.0
- [SwiftLint](https://github.com/realm/SwiftLint) from 0.45.0 to 0.45.1