### PR TITLE
Fix crash in AvatarImageView.renderImage(with:)

### DIFF
--- a/Stepic/Legacy/Views/AvatarImageView.swift
+++ b/Stepic/Legacy/Views/AvatarImageView.swift
@@ -93,6 +93,10 @@ final class AvatarImageView: UIImageView {
         label.textAlignment = NSTextAlignment.center
         label.backgroundColor = UIColor(hex6: self.colors[letters.hash % self.colors.count])
 
+        if label.bounds.size == .zero {
+            return nil
+        }
+
         let scale = UIScreen.main.scale
         UIGraphicsBeginImageContextWithOptions(label.bounds.size, false, scale)
         if let context = UIGraphicsGetCurrentContext() {


### PR DESCRIPTION
Fixes crash:
```
AvatarImageView.renderImage(with:)
NSInternalInconsistencyException - UIGraphicsBeginImageContext() failed to allocate CGBitampContext: size={0, 0}, scale=3.000000, bitmapInfo=<address>.
```